### PR TITLE
add SQLite index and MCP server, bump to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Reads BPM, key, duration, tags, and format info from WAV, AIFF, MP3, FLAC,
 OGG, Opus, M4A, MIDI, and Serum presets. Zero dependencies for core metadata.
 Optional librosa analysis for BPM/key detection and ML feature extraction.
 
+Also ships a persistent SQLite index (`acidcat index`) and an MCP server
+(`acidcat-mcp`) so an LLM can query your whole sample library by bpm, key,
+tags, or full-text.
+
 ## Install
 
     git clone https://github.com/hed0rah/acidcat.git
@@ -14,6 +18,7 @@ Optional librosa analysis for BPM/key detection and ML feature extraction.
     pip install -e .[tags]          # + MP3/FLAC/OGG/M4A (mutagen)
     pip install -e .[analysis]      # + librosa BPM/key detection
     pip install -e .[ml]            # + sklearn similarity/clustering
+    pip install -e .[mcp]           # + MCP server (acidcat-mcp)
     pip install -e .[all]           # everything
 
 ## Quick Start
@@ -65,8 +70,10 @@ Optional librosa analysis for BPM/key detection and ML feature extraction.
 | `acidcat features DIR` | Extract 50+ audio features for ML |
 | `acidcat similar CSV find TARGET` | Find similar samples by features |
 | `acidcat similar CSV cluster` | Cluster samples by audio characteristics |
-| `acidcat search CSV query TEXT` | Text-based sample search |
+| `acidcat search CSV query TEXT` | Text-based sample search (legacy CSV) |
 | `acidcat dump FILE CHUNK [...]` | Hex-dump specific RIFF chunks |
+| `acidcat index DIR` | Upsert DIR into the global SQLite index |
+| `acidcat query [flags]` | Filter the global index by bpm/key/tag/text |
 
 ## Global Flags
 
@@ -86,6 +93,7 @@ Optional librosa analysis for BPM/key detection and ML feature extraction.
 | `[tags]` | mutagen | info, scan for MP3, FLAC, OGG, Opus, M4A |
 | `[analysis]` | librosa, numpy, scipy | detect, info --deep |
 | `[ml]` | + pandas, scikit-learn | features, similar, search |
+| `[mcp]` | mcp SDK | `acidcat-mcp` stdio server |
 | `[all]` | everything | all commands, all formats |
 
 ## Examples
@@ -130,6 +138,75 @@ Optional librosa analysis for BPM/key detection and ML feature extraction.
 
     # k-means clustering
     acidcat similar features.csv cluster -k 10 -o clustered.csv
+
+## Global Index
+
+`acidcat scan` writes a one-off CSV. `acidcat index` maintains a single
+persistent SQLite database at `~/.acidcat/index.db` that aggregates every
+directory you point it at. Re-running skips unchanged files and prunes
+missing ones. Query it without rescanning.
+
+    # add a library (repeat for as many folders as you want)
+    acidcat index ~/Samples/Loops
+    acidcat index ~/Samples/OneShots
+
+    # show what has been indexed
+    acidcat index --list-roots
+    acidcat index --stats
+
+    # optional: include librosa features (slower, enables similarity)
+    acidcat index ~/Samples/Loops --features
+
+    # optional: import legacy <name>_tags.json into the index
+    acidcat index ~/Samples --import-tags old_tags.json
+
+    # drop everything under a root
+    acidcat index --remove-root ~/Samples/Loops
+
+### Querying
+
+    acidcat query --bpm 120:130 --key Am
+    acidcat query --tag drums --tag punchy --duration :1
+    acidcat query --text "dusty lofi" --limit 20
+    acidcat query --format mp3 --root ~/Samples/Loops
+    acidcat query --bpm 128 --paths-only | xargs -I {} cp {} out/
+
+Override the DB on any command with `--db PATH` or the `ACIDCAT_DB`
+environment variable.
+
+## MCP Server
+
+`acidcat-mcp` is a stdio MCP server that exposes the global index as
+structured tools. An LLM can search your library by metadata, find
+compatible keys via Camelot, or (with `[analysis]` installed) find
+similar samples by librosa feature cosine.
+
+    pip install -e .[tags,mcp]        # minimum for discovery + writes
+    pip install -e .[tags,analysis,mcp]  # unlock find_similar/analyze_*
+
+Claude Desktop / Claude Code config:
+
+    {
+      "mcpServers": {
+        "acidcat": {
+          "command": "acidcat-mcp"
+        }
+      }
+    }
+
+Optional: pass `--db` or set `ACIDCAT_DB` on the server process if your
+index lives outside the default path.
+
+Tool tiers (each tool description starts with `Fast.`, `SLOW.`, or
+`VERY SLOW.` so the model self-selects):
+
+- **Fast (SQLite only)**: `search_samples`, `get_sample`, `locate_sample`,
+  `list_roots`, `list_tags`, `list_keys`, `list_formats`, `index_stats`,
+  `find_compatible`
+- **Slow analysis** (needs `[analysis]`): `find_similar`, `analyze_sample`,
+  `detect_bpm_key`
+- **Index management**: `reindex`, `reindex_features`
+- **Write**: `tag_sample`, `describe_sample` (marked destructive)
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.3.0"
+version = "0.4.0"
 description = "Audio metadata explorer and analysis tool -- like exiftool, but for audio"
 readme = "README.md"
 license = {text = "MIT"}
@@ -38,10 +38,12 @@ ml = [
 ]
 viz = ["acidcat[ml]", "matplotlib>=3.7", "seaborn>=0.12"]
 notebook = ["jupyter>=1.0", "ipykernel>=6.0"]
-all = ["acidcat[tags,ml,viz,notebook]"]
+mcp = ["mcp>=1.0"]
+all = ["acidcat[tags,ml,viz,notebook,mcp]"]
 
 [project.scripts]
 acidcat = "acidcat.cli:main"
+acidcat-mcp = "acidcat.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/acidcat/cli.py
+++ b/src/acidcat/cli.py
@@ -7,14 +7,16 @@ Usage:
     acidcat -                        # read from stdin
     cat file.wav | acidcat           # piped input (implicit stdin)
     acidcat info file.aif            # explicit info subcommand
-    acidcat scan DIR [-n N]          # batch scan
+    acidcat scan DIR [-n N]          # batch scan (writes CSV)
     acidcat chunks file.wav          # RIFF chunk walk
     acidcat survey DIR               # chunk type census
     acidcat detect file.wav          # librosa BPM/key estimation
     acidcat features DIR             # ML feature extraction
     acidcat similar CSV TARGET       # similarity search
-    acidcat search CSV QUERY         # text search
+    acidcat search CSV QUERY         # text search (legacy, CSV-based)
     acidcat dump file.wav acid       # hex dump a chunk
+    acidcat index DIR                # upsert DIR into the global SQLite index
+    acidcat query --bpm 120:130      # filter the global index
 """
 
 import argparse
@@ -22,10 +24,16 @@ import os
 import sys
 
 from acidcat import __version__
-from acidcat.commands import info, scan, chunks, survey, detect, features, similar, search, dump
+from acidcat.commands import (
+    info, scan, chunks, survey, detect, features, similar, search, dump,
+    index, query,
+)
 from acidcat.util.stdin import is_stdin_target
 
-SUBCOMMANDS = {"info", "scan", "chunks", "survey", "detect", "features", "similar", "search", "dump"}
+SUBCOMMANDS = {
+    "info", "scan", "chunks", "survey", "detect", "features", "similar",
+    "search", "dump", "index", "query",
+}
 
 
 def _build_parser():
@@ -46,6 +54,8 @@ def _build_parser():
     similar.register(subparsers)
     search.register(subparsers)
     dump.register(subparsers)
+    index.register(subparsers)
+    query.register(subparsers)
 
     return parser
 

--- a/src/acidcat/commands/index.py
+++ b/src/acidcat/commands/index.py
@@ -1,0 +1,458 @@
+"""
+acidcat index -- walk a directory and upsert samples into the global
+SQLite index at ~/.acidcat/index.db.
+"""
+
+import json
+import os
+import sys
+import time
+
+from acidcat.core import index as idx
+from acidcat.core.riff import parse_riff, get_duration, get_fmt_info
+from acidcat.core.aiff import is_aiff, parse_aiff
+from acidcat.core.midi import is_midi, parse_midi
+from acidcat.core.serum import is_serum_preset, parse_serum_preset
+from acidcat.core.tagged import is_tagged_format
+
+
+INDEXABLE_EXTENSIONS = {
+    ".wav", ".aif", ".aiff",
+    ".mp3", ".flac", ".ogg", ".oga", ".opus", ".m4a", ".mp4", ".aac",
+    ".mid", ".midi",
+    ".serumpreset",
+}
+
+# OS sidecar / metadata junk that shows up in copied libraries.
+JUNK_FILES = {".ds_store", "thumbs.db", "desktop.ini"}
+
+
+def _is_junk(name):
+    """True for files we never want in the index (AppleDouble, OS metadata)."""
+    if name.startswith("._"):
+        return True
+    return name.lower() in JUNK_FILES
+
+
+def register(subparsers):
+    p = subparsers.add_parser(
+        "index",
+        help="Build/update the global sample index at ~/.acidcat/index.db.",
+    )
+    p.add_argument("target", nargs="?", help="Directory to index.")
+    p.add_argument("--db", help="Override DB path (default: ~/.acidcat/index.db).")
+    p.add_argument("--features", action="store_true",
+                   help="Extract librosa audio features during indexing.")
+    p.add_argument("--deep", action="store_true",
+                   help="Use librosa for BPM/key when metadata is absent.")
+    p.add_argument("--import-tags", dest="import_tags",
+                   help="Import a legacy <name>_tags.json into the index.")
+    p.add_argument("--list-roots", action="store_true",
+                   help="Print known scan roots and exit.")
+    p.add_argument("--remove-root", dest="remove_root",
+                   help="Delete all samples under this root and exit.")
+    p.add_argument("--stats", action="store_true",
+                   help="Print index summary and exit.")
+    p.add_argument("-q", "--quiet", action="store_true")
+    p.set_defaults(func=run)
+
+
+def run(args):
+    db_path = idx.resolve_db_path(getattr(args, "db", None))
+    conn = idx.open_db(db_path)
+    quiet = getattr(args, "quiet", False)
+
+    try:
+        if args.list_roots:
+            _print_roots(conn, db_path)
+            return 0
+
+        if args.remove_root:
+            root = idx.normalize_path(args.remove_root)
+            removed = idx.remove_root(conn, root)
+            conn.commit()
+            if not quiet:
+                print(f"[INFO] removed {removed} sample(s) under {root}",
+                      file=sys.stderr)
+            return 0
+
+        if args.stats:
+            _print_stats(conn, db_path)
+            return 0
+
+        if not args.target:
+            print("acidcat index: missing target directory (or use "
+                  "--list-roots/--remove-root/--stats)", file=sys.stderr)
+            return 1
+
+        target = args.target
+        if not os.path.isdir(target):
+            print(f"acidcat index: {target}: Not a directory", file=sys.stderr)
+            return 1
+
+        scan_root = idx.normalize_path(target)
+        if not quiet:
+            print(f"[INFO] indexing {scan_root} -> {db_path}", file=sys.stderr)
+
+        counts = _walk_and_upsert(
+            conn, scan_root,
+            do_features=args.features,
+            do_deep=args.deep,
+            quiet=quiet,
+        )
+
+        if args.import_tags:
+            imported = _import_tags(conn, args.import_tags)
+            counts["tags_imported"] = imported
+            if not quiet:
+                print(f"[INFO] imported tags for {imported} sample(s) "
+                      f"from {args.import_tags}", file=sys.stderr)
+
+        conn.commit()
+
+        if not quiet:
+            print(
+                f"[INFO] {counts['added']} added, {counts['updated']} updated, "
+                f"{counts['skipped']} skipped, {counts['pruned']} pruned, "
+                f"{counts['failed']} failed",
+                file=sys.stderr,
+            )
+        return 0
+    finally:
+        conn.close()
+
+
+def _walk_and_upsert(conn, scan_root, do_features=False, do_deep=False, quiet=False):
+    walk_start = time.time()
+    added = updated = skipped = failed = 0
+    seen_paths = 0
+
+    for root, _, files in os.walk(scan_root):
+        for name in files:
+            if _is_junk(name):
+                continue
+            ext = os.path.splitext(name)[1].lower()
+            if ext not in INDEXABLE_EXTENSIONS:
+                continue
+
+            filepath = os.path.join(root, name)
+            norm = idx.normalize_path(filepath)
+            try:
+                st = os.stat(filepath)
+            except OSError:
+                continue
+
+            existing = idx.get_sample_stat(conn, norm)
+            if existing is not None:
+                old_mtime, old_size = existing
+                if old_mtime == st.st_mtime and old_size == st.st_size:
+                    idx.touch_last_seen(conn, norm, walk_start)
+                    skipped += 1
+                    seen_paths += 1
+                    continue
+
+            row = _extract_for_index(
+                filepath, scan_root=scan_root,
+                mtime=st.st_mtime, size=st.st_size,
+                walk_start=walk_start,
+                do_deep=do_deep,
+            )
+            if row is None:
+                failed += 1
+                if not quiet:
+                    print(f"  [skip] {name}: parse failed", file=sys.stderr)
+                continue
+
+            row_tags = row.pop("_tags", None)
+
+            if existing is None:
+                added += 1
+            else:
+                updated += 1
+            idx.upsert_sample(conn, row)
+
+            if row_tags:
+                idx.upsert_tags(conn, row["path"], row_tags, replace=True)
+
+            if do_features:
+                _extract_and_store_features(conn, filepath, row["path"], quiet=quiet)
+
+            seen_paths += 1
+            if not quiet:
+                bpm = row.get("bpm") or "-"
+                key = row.get("key") or "-"
+                print(f"  {name:40s} bpm={bpm} key={key}", file=sys.stderr)
+
+    pruned = idx.prune_missing(conn, scan_root, walk_start)
+    idx.record_scan_root(conn, scan_root, seen_paths, walk_start)
+
+    return {
+        "added": added,
+        "updated": updated,
+        "skipped": skipped,
+        "failed": failed,
+        "pruned": pruned,
+    }
+
+
+def _extract_for_index(filepath, scan_root, mtime, size, walk_start, do_deep=False):
+    """Dispatch to the right parser and return a sample row dict.
+
+    Returns None if the file could not be parsed at all.
+    Includes a synthetic '_tags' list for formats that carry their own tags
+    (e.g. Serum presets).
+    """
+    norm = idx.normalize_path(filepath)
+    ext = os.path.splitext(filepath)[1].lower()
+
+    row = {
+        "path": norm,
+        "scan_root": scan_root,
+        "mtime": mtime,
+        "size": size,
+        "indexed_at": walk_start,
+        "last_seen_at": walk_start,
+    }
+
+    try:
+        if is_midi(filepath) or ext in (".mid", ".midi"):
+            return _from_midi(filepath, row)
+        if is_aiff(filepath) or ext in (".aif", ".aiff"):
+            return _from_aiff(filepath, row)
+        if is_serum_preset(filepath) or ext == ".serumpreset":
+            return _from_serum(filepath, row)
+        if is_tagged_format(filepath) and ext != ".wav":
+            return _from_tagged(filepath, row, do_deep=do_deep)
+        # default: WAV/RIFF
+        return _from_wav(filepath, row, do_deep=do_deep)
+    except Exception:
+        return None
+
+
+def _from_wav(filepath, row, do_deep=False):
+    from acidcat.util.midi import midi_note_to_pitch_class
+    from acidcat.core.detect import parse_key_from_path, parse_bpm_from_filename
+
+    _, meta, seen = parse_riff(filepath, enumerate_all=False)
+    duration = get_duration(filepath)
+    fmt = get_fmt_info(filepath)
+
+    row["format"] = "wav"
+    row["duration"] = duration
+    row["bpm"] = meta.get("bpm")
+
+    # SMPL/ACID root_note = 0 (MIDI C-1) is the default "unset" value.
+    # Treat it as missing so we can fall back to filename parsing.
+    smpl = meta.get("smpl_root_key")
+    acid = meta.get("acid_root_note")
+    if not smpl:
+        smpl = None
+    if not acid:
+        acid = None
+
+    # key stores pitch class only (no octave); full MIDI int lives in root_note.
+    row["key"] = midi_note_to_pitch_class(smpl) or midi_note_to_pitch_class(acid)
+    row["acid_beats"] = meta.get("acid_beats")
+    row["root_note"] = smpl or acid
+    row["chunks"] = ",".join(
+        c for c in seen if c not in ("RIFF", "WAVE", "fmt ", "data")
+    ) or None
+
+    if fmt:
+        row["sample_rate"] = fmt.get("sample_rate")
+        row["channels"] = fmt.get("channels")
+        row["bits_per_sample"] = fmt.get("bits_per_sample")
+
+    if row["key"] is None:
+        row["key"] = parse_key_from_path(filepath)
+    if row["bpm"] is None:
+        fname_bpm = parse_bpm_from_filename(filepath)
+        if fname_bpm is not None:
+            row["bpm"] = float(fname_bpm)
+
+    if do_deep and row["bpm"] is None:
+        _fill_from_librosa(filepath, row)
+
+    return row
+
+
+def _from_aiff(filepath, row, do_deep=False):
+    from acidcat.core.detect import parse_key_from_path, parse_bpm_from_filename
+
+    _, meta, seen = parse_aiff(filepath, enumerate_all=False)
+    row["format"] = "aiff"
+    row["duration"] = meta.get("duration_sec")
+    row["sample_rate"] = meta.get("sample_rate")
+    row["channels"] = meta.get("channels")
+    row["bits_per_sample"] = meta.get("bits_per_sample")
+    row["title"] = meta.get("name")
+    row["artist"] = meta.get("author")
+    row["comment"] = meta.get("copyright")
+    row["chunks"] = ",".join(seen) if seen else None
+
+    # AIFF has no standard bpm/key chunks; fall back to filename/folder tokens.
+    if row.get("key") is None:
+        row["key"] = parse_key_from_path(filepath)
+    if row.get("bpm") is None:
+        fname_bpm = parse_bpm_from_filename(filepath)
+        if fname_bpm is not None:
+            row["bpm"] = float(fname_bpm)
+
+    if do_deep and row.get("bpm") is None:
+        _fill_from_librosa(filepath, row)
+    return row
+
+
+def _from_midi(filepath, row):
+    meta = parse_midi(filepath)
+    row["format"] = "midi"
+    row["duration"] = meta.get("duration_sec")
+    row["bpm"] = meta.get("tempo_bpm")
+    row["key"] = meta.get("key_sig")
+    if meta.get("track_names"):
+        row["title"] = meta["track_names"][0]
+    if meta.get("copyright"):
+        row["comment"] = meta["copyright"]
+    return row
+
+
+def _from_serum(filepath, row):
+    meta = parse_serum_preset(filepath)
+    row["format"] = "serum"
+    if meta.get("presetName"):
+        row["title"] = meta["presetName"]
+    if meta.get("presetAuthor"):
+        row["artist"] = meta["presetAuthor"]
+    if meta.get("presetDescription"):
+        row["comment"] = meta["presetDescription"]
+    tags = meta.get("tags")
+    if isinstance(tags, list):
+        row["_tags"] = tags
+    elif isinstance(tags, str) and tags:
+        row["_tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+    return row
+
+
+def _from_tagged(filepath, row, do_deep=False):
+    from acidcat.core.tagged import parse_tagged
+    from acidcat.core.detect import parse_key_from_path, parse_bpm_from_filename
+
+    meta = parse_tagged(filepath)
+    if meta is None:
+        return None
+    row["format"] = meta.get("format_type") or "tagged"
+    row["duration"] = meta.get("duration")
+    row["sample_rate"] = meta.get("sample_rate")
+    row["channels"] = meta.get("channels")
+    row["bits_per_sample"] = meta.get("bits_per_sample")
+    row["title"] = meta.get("title")
+    row["artist"] = meta.get("artist")
+    row["album"] = meta.get("album")
+    row["genre"] = meta.get("genre")
+    row["comment"] = meta.get("comment")
+    row["bpm"] = _coerce_bpm(meta.get("bpm"))
+    row["key"] = meta.get("key")
+
+    if row["key"] is None:
+        row["key"] = parse_key_from_path(filepath)
+    if row["bpm"] is None:
+        fname_bpm = parse_bpm_from_filename(filepath)
+        if fname_bpm is not None:
+            row["bpm"] = float(fname_bpm)
+
+    if do_deep and row["bpm"] is None:
+        _fill_from_librosa(filepath, row)
+    return row
+
+
+def _coerce_bpm(v):
+    if v is None:
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _fill_from_librosa(filepath, row):
+    try:
+        from acidcat.core.detect import estimate_librosa_metadata
+    except ImportError:
+        return
+    est = estimate_librosa_metadata(filepath) or {}
+    if est.get("estimated_bpm") and row.get("bpm") is None:
+        bpm = est["estimated_bpm"]
+        if isinstance(bpm, (int, float)):
+            row["bpm"] = float(bpm)
+    if est.get("estimated_key") and row.get("key") is None:
+        row["key"] = est["estimated_key"]
+    if est.get("duration_sec") and row.get("duration") is None:
+        row["duration"] = est["duration_sec"]
+
+
+def _extract_and_store_features(conn, filepath, path_key, quiet=False):
+    try:
+        from acidcat.core.features import extract_audio_features
+    except ImportError:
+        if not quiet:
+            print("  [features] librosa not installed; skipping", file=sys.stderr)
+        return
+    feats = extract_audio_features(filepath)
+    if feats is None:
+        return
+    idx.upsert_features(conn, path_key, feats, version=1)
+
+
+def _import_tags(conn, import_file):
+    """Pull a legacy <name>_tags.json into the index.
+
+    Match by filename basename since old CSV paths may differ from current.
+    """
+    with open(import_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    imported = 0
+    for old_path, entry in data.items():
+        base = os.path.basename(old_path.replace("\\", "/"))
+        if not base:
+            continue
+        like = "%/" + base
+        rows = conn.execute(
+            "SELECT path FROM samples WHERE path LIKE ?", (like,)
+        ).fetchall()
+        if not rows:
+            continue
+        desc = entry.get("description") or ""
+        tags = entry.get("tags") or []
+        for r in rows:
+            if desc:
+                idx.upsert_description(conn, r["path"], desc)
+            if tags:
+                idx.upsert_tags(conn, r["path"], tags)
+            imported += 1
+    return imported
+
+
+def _print_roots(conn, db_path):
+    roots = idx.list_roots(conn)
+    if not roots:
+        print(f"(no scan roots in {db_path})")
+        return
+    for r in roots:
+        print(f"{r['file_count']:>6}  {r['path']}")
+
+
+def _print_stats(conn, db_path):
+    stats = idx.index_stats(conn)
+    print(f"DB: {db_path}")
+    print(f"Total samples: {stats['total_samples']}")
+    print(f"With features: {stats['with_features']}")
+    print(f"With descriptions: {stats['with_descriptions']}")
+    print(f"Unique tags: {stats['unique_tags']}")
+    if stats["by_format"]:
+        print("By format:")
+        for row in stats["by_format"]:
+            print(f"  {row['format']:<10s} {row['count']}")
+    if stats["roots"]:
+        print("Scan roots:")
+        for r in stats["roots"]:
+            print(f"  {r['file_count']:>6}  {r['path']}")

--- a/src/acidcat/commands/query.py
+++ b/src/acidcat/commands/query.py
@@ -1,0 +1,163 @@
+"""
+acidcat query -- filter samples from the global SQLite index.
+"""
+
+import os
+import sys
+
+from acidcat.core import index as idx
+from acidcat.core.formats import output
+
+
+DEFAULT_FIELDS = [
+    "path", "format", "bpm", "key", "duration",
+    "title", "artist", "album", "scan_root",
+]
+
+
+def register(subparsers):
+    p = subparsers.add_parser(
+        "query",
+        help="Filter the global sample index.",
+    )
+    p.add_argument("--db", help="Override DB path (default: ~/.acidcat/index.db).")
+    p.add_argument("--bpm", help="BPM filter. Exact (128) or range (120:130).")
+    p.add_argument("--key", help="Key filter (exact match, e.g. Am, C#).")
+    p.add_argument("--duration", help="Duration filter in seconds. "
+                   "Exact (2) or range (0.5:2).")
+    p.add_argument("--tag", action="append", default=[],
+                   help="Tag filter. Repeat for AND semantics.")
+    p.add_argument("--format", dest="file_format",
+                   help="File format filter (wav, mp3, flac, midi, ...).")
+    p.add_argument("--text", help="Full-text search across title/artist/album/"
+                   "genre/comment/description/tags/path.")
+    p.add_argument("--root", help="Scope results to samples under this scan root.")
+    p.add_argument("--limit", type=int, default=50, help="Max rows (default 50).")
+    p.add_argument("-f", "--output-format", dest="output_format",
+                   default="table", choices=["table", "json", "csv"],
+                   help="Output format (default: table).")
+    p.add_argument("-o", "--output", help="Write output to file.")
+    p.add_argument("--paths-only", action="store_true",
+                   help="Print bare paths, one per line.")
+    p.set_defaults(func=run)
+
+
+def run(args):
+    db_path = idx.resolve_db_path(getattr(args, "db", None))
+    if not os.path.isfile(db_path):
+        print(f"acidcat query: no index at {db_path}. "
+              f"Run `acidcat index DIR` first.", file=sys.stderr)
+        return 1
+
+    conn = idx.open_db(db_path)
+    try:
+        rows = _run_query(conn, args)
+    finally:
+        conn.close()
+
+    if not rows:
+        if not getattr(args, "paths_only", False):
+            print("(no matches)", file=sys.stderr)
+        return 0
+
+    if args.paths_only:
+        for r in rows:
+            print(r["path"])
+        return 0
+
+    stream = sys.stdout
+    if getattr(args, "output", None):
+        stream = open(args.output, "w", encoding="utf-8", newline="")
+    try:
+        output(rows, fmt=args.output_format, stream=stream)
+    finally:
+        if stream is not sys.stdout:
+            stream.close()
+    return 0
+
+
+def _run_query(conn, args):
+    where = []
+    params = []
+    joins = []
+
+    if args.bpm:
+        lo, hi = _parse_range(args.bpm, field_name="bpm")
+        if lo is not None:
+            where.append("s.bpm >= ?")
+            params.append(lo)
+        if hi is not None:
+            where.append("s.bpm <= ?")
+            params.append(hi)
+
+    if args.duration:
+        lo, hi = _parse_range(args.duration, field_name="duration")
+        if lo is not None:
+            where.append("s.duration >= ?")
+            params.append(lo)
+        if hi is not None:
+            where.append("s.duration <= ?")
+            params.append(hi)
+
+    if args.key:
+        where.append("LOWER(s.key) = LOWER(?)")
+        params.append(args.key)
+
+    if args.file_format:
+        where.append("LOWER(s.format) = LOWER(?)")
+        params.append(args.file_format)
+
+    if args.root:
+        root = idx.normalize_path(args.root)
+        where.append("(s.scan_root = ? OR s.path LIKE ?)")
+        params.append(root)
+        params.append(root.rstrip("/") + "/%")
+
+    tags = [t for t in (args.tag or []) if t]
+    if tags:
+        placeholders = ",".join("?" for _ in tags)
+        where.append(
+            f"s.path IN ("
+            f"  SELECT path FROM tags WHERE tag IN ({placeholders}) "
+            f"  GROUP BY path HAVING COUNT(DISTINCT tag) = ?"
+            f")"
+        )
+        params.extend(tags)
+        params.append(len(tags))
+
+    if args.text:
+        joins.append("JOIN samples_fts fts ON fts.path = s.path")
+        where.append("samples_fts MATCH ?")
+        params.append(args.text)
+
+    sql = "SELECT s.* FROM samples s " + " ".join(joins)
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY s.path LIMIT ?"
+    params.append(args.limit)
+
+    rows = conn.execute(sql, params).fetchall()
+    return [_shape_row(dict(r)) for r in rows]
+
+
+def _shape_row(row):
+    """Project to the default display columns, keeping key data."""
+    out = {}
+    for k in DEFAULT_FIELDS:
+        if k in row and row[k] is not None:
+            out[k] = row[k]
+    return out
+
+
+def _parse_range(spec, field_name="value"):
+    """Accept '120', '120:130', ':130', '120:' and return (lo, hi)."""
+    if ":" not in spec:
+        try:
+            v = float(spec)
+        except ValueError:
+            raise SystemExit(f"acidcat query: bad --{field_name} value: {spec}")
+        return v, v
+    lo_s, hi_s = spec.split(":", 1)
+    lo = float(lo_s) if lo_s else None
+    hi = float(hi_s) if hi_s else None
+    return lo, hi

--- a/src/acidcat/core/camelot.py
+++ b/src/acidcat/core/camelot.py
@@ -1,0 +1,205 @@
+"""Camelot wheel key utilities for harmonic mixing.
+
+Given a key string like 'Am', 'C#', 'F minor', or '5A', returns the
+Camelot code (1A-12B) and its harmonically compatible neighbors:
+same code (exact match), relative major/minor, perfect 4th, perfect 5th.
+"""
+
+import re
+
+
+_PITCH_CLASS = {
+    "c": 0, "b#": 0,
+    "c#": 1, "db": 1,
+    "d": 2,
+    "d#": 3, "eb": 3,
+    "e": 4, "fb": 4,
+    "f": 5, "e#": 5,
+    "f#": 6, "gb": 6,
+    "g": 7,
+    "g#": 8, "ab": 8,
+    "a": 9,
+    "a#": 10, "bb": 10,
+    "b": 11, "cb": 11,
+}
+
+# Camelot: (pitch_class, mode) -> code
+# mode: 0 = major (B), 1 = minor (A)
+# Standard Camelot wheel mapping.
+_CAMELOT_MAP = {
+    # major (B)
+    (11, 0): "1B",   # B
+    (6,  0): "2B",   # F#
+    (1,  0): "3B",   # Db
+    (8,  0): "4B",   # Ab
+    (3,  0): "5B",   # Eb
+    (10, 0): "6B",   # Bb
+    (5,  0): "7B",   # F
+    (0,  0): "8B",   # C
+    (7,  0): "9B",   # G
+    (2,  0): "10B",  # D
+    (9,  0): "11B",  # A
+    (4,  0): "12B",  # E
+    # minor (A)
+    (8,  1): "1A",   # G#m / Abm
+    (3,  1): "2A",   # Ebm / D#m
+    (10, 1): "3A",   # Bbm
+    (5,  1): "4A",   # Fm
+    (0,  1): "5A",   # Cm
+    (7,  1): "6A",   # Gm
+    (2,  1): "7A",   # Dm
+    (9,  1): "8A",   # Am
+    (4,  1): "9A",   # Em
+    (11, 1): "10A",  # Bm
+    (6,  1): "11A",  # F#m
+    (1,  1): "12A",  # C#m
+}
+
+
+def parse_key(key_str):
+    """Parse a key string to (pitch_class, mode) where mode is 0=major, 1=minor.
+
+    Handles: 'C', 'Cm', 'C#m', 'Db', 'A minor', 'F#min', 'Bb maj',
+    MIDI-note-ish values like 'C4' (treated as C), Camelot codes like '5A'.
+    Returns None if parsing fails.
+    """
+    if not key_str:
+        return None
+    s = str(key_str).strip()
+    if not s:
+        return None
+
+    # Camelot code (e.g. 8A)
+    m = re.match(r"^\s*(\d{1,2})\s*([ABab])\s*$", s)
+    if m:
+        num = int(m.group(1))
+        letter = m.group(2).upper()
+        if 1 <= num <= 12:
+            # inverse lookup
+            for (pc, mode), code in _CAMELOT_MAP.items():
+                if code == f"{num}{letter}":
+                    return pc, mode
+        return None
+
+    # note + optional 'm'/'minor'/'maj' (ignore octave numbers like C4)
+    m = re.match(
+        r"^\s*([A-Ga-g])([#b]?)\s*(m|min|minor|maj|major|M)?\s*(\d+)?\s*$",
+        s,
+    )
+    if not m:
+        return None
+    root = (m.group(1) + (m.group(2) or "")).lower()
+    suffix = (m.group(3) or "").lower()
+    pc = _PITCH_CLASS.get(root)
+    if pc is None:
+        return None
+    if suffix in ("m", "min", "minor"):
+        mode = 1
+    elif suffix in ("maj", "major", "M".lower()):
+        mode = 0
+    elif suffix == "":
+        mode = 0
+    else:
+        mode = 0
+    return pc, mode
+
+
+def key_to_camelot(key_str):
+    """Return 'NNL' Camelot code (e.g. '8A') or None if unparseable."""
+    parsed = parse_key(key_str)
+    if parsed is None:
+        return None
+    return _CAMELOT_MAP.get(parsed)
+
+
+def _split_camelot(code):
+    m = re.match(r"^(\d{1,2})([AB])$", code)
+    if not m:
+        return None
+    return int(m.group(1)), m.group(2)
+
+
+def camelot_neighbors(code):
+    """Return harmonic neighbors for a Camelot code.
+
+    Returns a list of codes: [same, relative, perfect_fourth, perfect_fifth].
+    Empty list if code is invalid.
+    """
+    split = _split_camelot(code)
+    if split is None:
+        return []
+    num, letter = split
+    other = "B" if letter == "A" else "A"
+    down = 12 if num == 1 else num - 1
+    up = 1 if num == 12 else num + 1
+    return [
+        f"{num}{letter}",
+        f"{num}{other}",
+        f"{down}{letter}",
+        f"{up}{letter}",
+    ]
+
+
+def compatible_keys(key_str):
+    """Return the set of key strings (normalized) harmonically compatible
+    with key_str. The set includes key_str's own normalized form.
+
+    Each element is a canonical pretty name like 'Am' or 'C'.
+    """
+    code = key_to_camelot(key_str)
+    if code is None:
+        return set()
+    codes = camelot_neighbors(code)
+    # reverse lookup -> (pc, mode) -> pretty name
+    pretty = set()
+    for c in codes:
+        for (pc, mode), kc in _CAMELOT_MAP.items():
+            if kc == c:
+                pretty.add(pitch_class_to_name(pc, mode))
+                break
+    return pretty
+
+
+_NOTE_NAMES_SHARP = ["C", "C#", "D", "D#", "E", "F",
+                     "F#", "G", "G#", "A", "A#", "B"]
+
+
+def pitch_class_to_name(pc, mode):
+    """Return 'C', 'C#', 'Am', etc. for (pitch_class, mode)."""
+    name = _NOTE_NAMES_SHARP[pc % 12]
+    return name + ("m" if mode == 1 else "")
+
+
+# enharmonic equivalents for each canonical sharp spelling
+_ENHARMONICS = {
+    "C":  {"C", "B#"},
+    "C#": {"C#", "Db"},
+    "D":  {"D"},
+    "D#": {"D#", "Eb"},
+    "E":  {"E", "Fb"},
+    "F":  {"F", "E#"},
+    "F#": {"F#", "Gb"},
+    "G":  {"G"},
+    "G#": {"G#", "Ab"},
+    "A":  {"A"},
+    "A#": {"A#", "Bb"},
+    "B":  {"B", "Cb"},
+}
+
+
+def enharmonic_spellings(key_str):
+    """Return every string form that is enharmonically equivalent to key_str.
+
+    Used as a safety net when filtering a DB that may hold either
+    flat or sharp spellings. Returns a set including key_str itself;
+    empty set if key_str can't be parsed.
+    """
+    parsed = parse_key(key_str)
+    if parsed is None:
+        return set()
+    pc, mode = parsed
+    canonical = _NOTE_NAMES_SHARP[pc]
+    suffix = "m" if mode == 1 else ""
+    out = {name + suffix for name in _ENHARMONICS.get(canonical, {canonical})}
+    out.add(str(key_str).strip())
+    return out

--- a/src/acidcat/core/detect.py
+++ b/src/acidcat/core/detect.py
@@ -15,19 +15,18 @@ def parse_bpm_from_filename(filepath):
     filename = os.path.basename(filepath)
     bpm_patterns = [
         r'(\d{2,3})\s*bpm',
-        r'(\d{2,3})\s*BPM',
         r'bpm\s*(\d{2,3})',
-        r'BPM\s*(\d{2,3})',
         r'(\d{2,3})bpm',
-        r'(\d{2,3})BPM',
-        r'_(\d{2,3})_',
-        r'-(\d{2,3})-',
-        r'\s(\d{2,3})\s',
+        # bare 2-3 digit run, not adjacent to other digits or a decimal point;
+        # zero-width lookarounds so consecutive numbers (e.g. '_03_126_') both
+        # surface instead of the first consuming the shared underscore.
+        r'(?<![\d.])(\d{2,3})(?![\d.])',
     ]
+    # iterate ALL matches of each pattern; a filename like "Pack_03_126_A#"
+    # matches "_03_" before "_126_" so we need to consider every occurrence.
     for pattern in bpm_patterns:
-        match = re.search(pattern, filename, re.IGNORECASE)
-        if match:
-            bpm = int(match.group(1))
+        for match in re.findall(pattern, filename, re.IGNORECASE):
+            bpm = int(match)
             if 60 <= bpm <= 200:
                 return bpm
     return None
@@ -54,10 +53,83 @@ def parse_key_from_filename(filepath):
         if match:
             note = match.group(1).upper()
             key_text = match.group(0).lower()
-            if any(x in key_text for x in ['min', 'm']):
+            # classify minor vs major: 'min' or 'minor' anywhere; or trailing
+            # 'm' that isn't part of 'major'/'maj'.
+            if "min" in key_text:
                 return f"{note}m"
-            else:
+            if "maj" in key_text:
                 return note
+            # bare trailing m (e.g. 'Am', 'C#m')
+            if re.search(r"m\s*$", key_text):
+                return f"{note}m"
+            return note
+    return None
+
+
+# whole-token key regex: A, A#, Ab, Am, A#m, Gbm, etc.
+# Lowercase m for minor; capital M rejected to avoid false positives (file "SCREAM").
+_BARE_KEY_TOKEN = re.compile(r"^([A-G])([#b]?)(m)?$")
+
+
+def parse_bare_key_token(token):
+    """If `token` is a whole-token musical key (e.g. 'A#', 'Em', 'Bbm'), return
+    the normalized 'C#m' / 'Eb' form. Otherwise None.
+    """
+    m = _BARE_KEY_TOKEN.match(token)
+    if not m:
+        return None
+    note = m.group(1).upper()
+    accidental = m.group(2) or ""
+    minor = "m" if m.group(3) else ""
+    # normalize flat to sharp for consistency with MIDI note naming.
+    # Cb/Fb aren't pitch-raising flats; they're enharmonic with B/E.
+    if accidental == "b":
+        flat_to_sharp = {"Db": "C#", "Eb": "D#", "Gb": "F#",
+                         "Ab": "G#", "Bb": "A#",
+                         "Cb": "B", "Fb": "E"}
+        root = flat_to_sharp.get(note + "b", note + "b")
+    else:
+        root = note + accidental
+    return root + minor
+
+
+def parse_key_from_path(filepath, max_parent_depth=3):
+    """Robust key extraction across filename + parent folders.
+
+    Tries parse_key_from_filename first (matches 'Am', 'C minor', etc.),
+    then falls back to whole-token bare-key matches in the filename and
+    up to `max_parent_depth` parent folders. Returns the first hit or None.
+
+    Whole-token matching avoids false positives like "Analog" matching 'A'.
+    """
+    existing = parse_key_from_filename(filepath)
+    if existing is not None:
+        return existing
+
+    # walk filename basename + parent dirs outward
+    segments = []
+    stem = os.path.splitext(os.path.basename(filepath))[0]
+    segments.append(stem)
+    cur = os.path.dirname(filepath)
+    for _ in range(max_parent_depth):
+        if not cur or cur in ("/", "\\"):
+            break
+        parent = os.path.basename(cur)
+        if parent:
+            segments.append(parent)
+        new_cur = os.path.dirname(cur)
+        if new_cur == cur:
+            break
+        cur = new_cur
+
+    token_re = re.compile(r"[_\-\.\s]+")
+    for seg in segments:
+        for token in token_re.split(seg):
+            if not token:
+                continue
+            key = parse_bare_key_token(token)
+            if key is not None:
+                return key
     return None
 
 

--- a/src/acidcat/core/index.py
+++ b/src/acidcat/core/index.py
@@ -1,0 +1,381 @@
+"""SQLite-backed sample index.
+
+Single global DB at ~/.acidcat/index.db holds metadata for every sample
+the user has pointed `acidcat index` at. Schema groups immutable audio
+facts (samples), per-root bookkeeping (scan_roots), user annotations
+(tags, descriptions), an FTS5 mirror (samples_fts), and optional librosa
+features (features).
+
+Everything here is stdlib-only. Connections are opened with foreign_keys
+on and WAL journaling for concurrent readers.
+"""
+
+import json
+import os
+import sqlite3
+import time
+
+
+SCHEMA_VERSION = 1
+
+
+SAMPLE_COLUMNS = (
+    "path", "scan_root", "mtime", "size",
+    "format", "duration", "bpm", "key",
+    "title", "artist", "album", "genre", "comment",
+    "acid_beats", "root_note",
+    "sample_rate", "channels", "bits_per_sample",
+    "chunks",
+    "indexed_at", "last_seen_at",
+)
+
+
+def default_db_path():
+    """Return ~/.acidcat/index.db (works on Windows/macOS/Linux)."""
+    return os.path.join(os.path.expanduser("~"), ".acidcat", "index.db")
+
+
+def resolve_db_path(cli_value=None):
+    """Resolve DB path from --db, ACIDCAT_DB env, or default."""
+    if cli_value:
+        return cli_value
+    env = os.environ.get("ACIDCAT_DB")
+    if env:
+        return env
+    return default_db_path()
+
+
+def open_db(path):
+    """Open (or create) a DB at path. Applies schema if new."""
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent, exist_ok=True)
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+    except sqlite3.DatabaseError:
+        pass
+
+    _apply_schema(conn)
+    return conn
+
+
+def _apply_schema(conn):
+    cur = conn.cursor()
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS meta (
+            k TEXT PRIMARY KEY,
+            v TEXT
+        )
+    """)
+
+    row = cur.execute("SELECT v FROM meta WHERE k = 'schema_version'").fetchone()
+    if row is None:
+        _create_tables(cur)
+        cur.execute(
+            "INSERT INTO meta (k, v) VALUES ('schema_version', ?)",
+            (str(SCHEMA_VERSION),),
+        )
+        conn.commit()
+        return
+
+    # future: handle migrations when SCHEMA_VERSION bumps.
+
+
+def _create_tables(cur):
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS samples (
+            path TEXT PRIMARY KEY,
+            scan_root TEXT,
+            mtime REAL,
+            size INTEGER,
+            format TEXT,
+            duration REAL,
+            bpm REAL,
+            key TEXT,
+            title TEXT,
+            artist TEXT,
+            album TEXT,
+            genre TEXT,
+            comment TEXT,
+            acid_beats INTEGER,
+            root_note INTEGER,
+            sample_rate INTEGER,
+            channels INTEGER,
+            bits_per_sample INTEGER,
+            chunks TEXT,
+            indexed_at REAL,
+            last_seen_at REAL
+        )
+    """)
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_samples_bpm ON samples(bpm)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_samples_key ON samples(key)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_samples_duration ON samples(duration)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_samples_format ON samples(format)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_samples_scan_root ON samples(scan_root)")
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS scan_roots (
+            path TEXT PRIMARY KEY,
+            added_at REAL,
+            last_indexed_at REAL,
+            file_count INTEGER
+        )
+    """)
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS tags (
+            path TEXT,
+            tag TEXT,
+            PRIMARY KEY (path, tag)
+        )
+    """)
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag)")
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS descriptions (
+            path TEXT PRIMARY KEY,
+            description TEXT
+        )
+    """)
+
+    cur.execute("""
+        CREATE VIRTUAL TABLE IF NOT EXISTS samples_fts USING fts5(
+            path, title, artist, album, genre, comment, description, tags,
+            tokenize='porter'
+        )
+    """)
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS features (
+            path TEXT PRIMARY KEY,
+            features_json TEXT,
+            features_version INTEGER,
+            extracted_at REAL
+        )
+    """)
+
+
+def normalize_path(p):
+    """Canonical path form for DB keys."""
+    return os.path.abspath(p).replace("\\", "/")
+
+
+def get_sample_stat(conn, path):
+    """Return (mtime, size) stored for path, or None if not indexed."""
+    row = conn.execute(
+        "SELECT mtime, size FROM samples WHERE path = ?", (path,)
+    ).fetchone()
+    if row is None:
+        return None
+    return (row["mtime"], row["size"])
+
+
+def upsert_sample(conn, row):
+    """Insert or update a sample. `row` is a dict keyed by SAMPLE_COLUMNS.
+
+    Missing keys default to None. `path` is required.
+    """
+    values = [row.get(col) for col in SAMPLE_COLUMNS]
+    placeholders = ",".join("?" for _ in SAMPLE_COLUMNS)
+    cols = ",".join(SAMPLE_COLUMNS)
+    updates = ",".join(f"{c}=excluded.{c}" for c in SAMPLE_COLUMNS if c != "path")
+    conn.execute(
+        f"INSERT INTO samples ({cols}) VALUES ({placeholders}) "
+        f"ON CONFLICT(path) DO UPDATE SET {updates}",
+        values,
+    )
+    rebuild_fts_for_path(conn, row["path"])
+
+
+def touch_last_seen(conn, path, ts):
+    """Stamp last_seen_at without re-parsing the file."""
+    conn.execute(
+        "UPDATE samples SET last_seen_at = ? WHERE path = ?",
+        (ts, path),
+    )
+
+
+def upsert_tags(conn, path, tags, replace=False):
+    """Add tags to a sample. If replace=True, wipes existing tags first."""
+    if replace:
+        conn.execute("DELETE FROM tags WHERE path = ?", (path,))
+    for t in tags:
+        t = t.strip()
+        if not t:
+            continue
+        conn.execute(
+            "INSERT OR IGNORE INTO tags (path, tag) VALUES (?, ?)",
+            (path, t),
+        )
+    rebuild_fts_for_path(conn, path)
+
+
+def remove_tags(conn, path, tags):
+    for t in tags:
+        conn.execute("DELETE FROM tags WHERE path = ? AND tag = ?", (path, t))
+    rebuild_fts_for_path(conn, path)
+
+
+def upsert_description(conn, path, description):
+    if description is None or description == "":
+        conn.execute("DELETE FROM descriptions WHERE path = ?", (path,))
+    else:
+        conn.execute(
+            "INSERT INTO descriptions (path, description) VALUES (?, ?) "
+            "ON CONFLICT(path) DO UPDATE SET description=excluded.description",
+            (path, description),
+        )
+    rebuild_fts_for_path(conn, path)
+
+
+def upsert_features(conn, path, features, version=1):
+    """Store librosa features as JSON blob."""
+    payload = json.dumps(features, default=str)
+    conn.execute(
+        "INSERT INTO features (path, features_json, features_version, extracted_at) "
+        "VALUES (?, ?, ?, ?) "
+        "ON CONFLICT(path) DO UPDATE SET features_json=excluded.features_json, "
+        "features_version=excluded.features_version, extracted_at=excluded.extracted_at",
+        (path, payload, version, time.time()),
+    )
+
+
+def get_features(conn, path):
+    row = conn.execute(
+        "SELECT features_json FROM features WHERE path = ?", (path,)
+    ).fetchone()
+    if row is None:
+        return None
+    return json.loads(row["features_json"])
+
+
+def rebuild_fts_for_path(conn, path):
+    """Refresh the FTS row for a single path."""
+    conn.execute("DELETE FROM samples_fts WHERE path = ?", (path,))
+    sample = conn.execute(
+        "SELECT title, artist, album, genre, comment FROM samples WHERE path = ?",
+        (path,),
+    ).fetchone()
+    if sample is None:
+        return
+    desc_row = conn.execute(
+        "SELECT description FROM descriptions WHERE path = ?", (path,)
+    ).fetchone()
+    description = desc_row["description"] if desc_row else None
+    tag_rows = conn.execute(
+        "SELECT tag FROM tags WHERE path = ?", (path,)
+    ).fetchall()
+    tags_text = " ".join(r["tag"] for r in tag_rows)
+    conn.execute(
+        "INSERT INTO samples_fts "
+        "(path, title, artist, album, genre, comment, description, tags) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            path,
+            sample["title"] or "",
+            sample["artist"] or "",
+            sample["album"] or "",
+            sample["genre"] or "",
+            sample["comment"] or "",
+            description or "",
+            tags_text,
+        ),
+    )
+
+
+def record_scan_root(conn, path, file_count, indexed_at):
+    """Insert or update a scan_roots entry."""
+    existing = conn.execute(
+        "SELECT path FROM scan_roots WHERE path = ?", (path,)
+    ).fetchone()
+    if existing:
+        conn.execute(
+            "UPDATE scan_roots SET last_indexed_at = ?, file_count = ? WHERE path = ?",
+            (indexed_at, file_count, path),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO scan_roots (path, added_at, last_indexed_at, file_count) "
+            "VALUES (?, ?, ?, ?)",
+            (path, indexed_at, indexed_at, file_count),
+        )
+
+
+def list_roots(conn):
+    rows = conn.execute(
+        "SELECT path, added_at, last_indexed_at, file_count FROM scan_roots "
+        "ORDER BY path"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def remove_root(conn, root):
+    """Delete all samples under root and drop the scan_roots entry."""
+    like = root.rstrip("/") + "/%"
+    paths = [
+        r["path"] for r in conn.execute(
+            "SELECT path FROM samples WHERE scan_root = ? OR path LIKE ?",
+            (root, like),
+        ).fetchall()
+    ]
+    for p in paths:
+        conn.execute("DELETE FROM samples WHERE path = ?", (p,))
+        conn.execute("DELETE FROM tags WHERE path = ?", (p,))
+        conn.execute("DELETE FROM descriptions WHERE path = ?", (p,))
+        conn.execute("DELETE FROM features WHERE path = ?", (p,))
+        conn.execute("DELETE FROM samples_fts WHERE path = ?", (p,))
+    conn.execute("DELETE FROM scan_roots WHERE path = ?", (root,))
+    return len(paths)
+
+
+def prune_missing(conn, scan_root, before_ts):
+    """Remove rows under scan_root whose last_seen_at is older than before_ts."""
+    paths = [
+        r["path"] for r in conn.execute(
+            "SELECT path FROM samples WHERE scan_root = ? AND "
+            "(last_seen_at IS NULL OR last_seen_at < ?)",
+            (scan_root, before_ts),
+        ).fetchall()
+    ]
+    for p in paths:
+        conn.execute("DELETE FROM samples WHERE path = ?", (p,))
+        conn.execute("DELETE FROM tags WHERE path = ?", (p,))
+        conn.execute("DELETE FROM descriptions WHERE path = ?", (p,))
+        conn.execute("DELETE FROM features WHERE path = ?", (p,))
+        conn.execute("DELETE FROM samples_fts WHERE path = ?", (p,))
+    return len(paths)
+
+
+def index_stats(conn):
+    """Summary counts for `acidcat index --stats` / MCP index_stats."""
+    total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
+    by_format = [
+        dict(r) for r in conn.execute(
+            "SELECT format, COUNT(*) AS count FROM samples "
+            "GROUP BY format ORDER BY count DESC"
+        ).fetchall()
+    ]
+    feat_count = conn.execute("SELECT COUNT(*) AS c FROM features").fetchone()["c"]
+    tag_count = conn.execute(
+        "SELECT COUNT(DISTINCT tag) AS c FROM tags"
+    ).fetchone()["c"]
+    desc_count = conn.execute(
+        "SELECT COUNT(*) AS c FROM descriptions"
+    ).fetchone()["c"]
+    last_root = conn.execute(
+        "SELECT MAX(last_indexed_at) AS t FROM scan_roots"
+    ).fetchone()["t"]
+    return {
+        "total_samples": total,
+        "with_features": feat_count,
+        "unique_tags": tag_count,
+        "with_descriptions": desc_count,
+        "last_indexed_at": last_root,
+        "by_format": by_format,
+        "roots": list_roots(conn),
+    }

--- a/src/acidcat/mcp_server.py
+++ b/src/acidcat/mcp_server.py
@@ -1,0 +1,917 @@
+"""
+acidcat-mcp -- stdio MCP server over the global SQLite sample index.
+
+Register all tools up front even when optional deps (librosa) are missing;
+the slow ones return a structured error describing the install step. This
+way the LLM discovers what's possible and can surface the fix to the user.
+"""
+
+import argparse
+import importlib.util
+import json
+import math
+import os
+import sys
+import time
+
+from acidcat import __version__
+from acidcat.core import index as idx
+from acidcat.core import camelot
+
+
+# ── server config ─────────────────────────────────────────────────
+
+_DB_PATH = None
+
+
+def _get_conn():
+    """Open a fresh connection per tool call -- cheap for SQLite."""
+    return idx.open_db(_DB_PATH)
+
+
+# ── tool registry ─────────────────────────────────────────────────
+
+
+class ToolError(Exception):
+    """Signalled back to the LLM as an error content block."""
+
+
+TOOLS = []
+
+
+def _tool(name, description, input_schema, handler, annotations):
+    TOOLS.append({
+        "name": name,
+        "description": description,
+        "input_schema": input_schema,
+        "handler": handler,
+        "annotations": annotations,
+    })
+
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _require_path(args, field="path"):
+    v = args.get(field)
+    if not v:
+        raise ToolError(f"{field} is required")
+    return v
+
+
+def _resolve_stored_path(conn, user_path):
+    """Find the canonical stored path for a user-provided path.
+
+    Tries the normalized form first, then the raw form. Returns the stored
+    path, or None if the sample is not indexed.
+    """
+    norm = idx.normalize_path(user_path)
+    for candidate in (norm, user_path):
+        row = conn.execute(
+            "SELECT path FROM samples WHERE path = ?", (candidate,)
+        ).fetchone()
+        if row is not None:
+            return row["path"]
+    return None
+
+
+def _librosa_available():
+    """Cheap check: does Python see librosa + numpy on the import path?
+
+    Uses find_spec so this never actually imports librosa (which would
+    cold-start the numba JIT chain and add tens of seconds to the first
+    call of any tool that probes availability).
+    """
+    return (importlib.util.find_spec("librosa") is not None
+            and importlib.util.find_spec("numpy") is not None)
+
+
+def _analysis_unavailable():
+    return {
+        "error": "analysis dependencies not installed",
+        "fix": "pip install acidcat[analysis]",
+    }
+
+
+# ── fast tools ────────────────────────────────────────────────────
+
+
+def search_samples(args):
+    conn = _get_conn()
+    try:
+        where, params, joins = [], [], []
+
+        if args.get("bpm_min") is not None:
+            where.append("s.bpm >= ?")
+            params.append(float(args["bpm_min"]))
+        if args.get("bpm_max") is not None:
+            where.append("s.bpm <= ?")
+            params.append(float(args["bpm_max"]))
+        if args.get("duration_min") is not None:
+            where.append("s.duration >= ?")
+            params.append(float(args["duration_min"]))
+        if args.get("duration_max") is not None:
+            where.append("s.duration <= ?")
+            params.append(float(args["duration_max"]))
+        if args.get("key"):
+            where.append("LOWER(s.key) = LOWER(?)")
+            params.append(args["key"])
+        if args.get("format"):
+            where.append("LOWER(s.format) = LOWER(?)")
+            params.append(args["format"])
+        if args.get("root"):
+            root = idx.normalize_path(args["root"])
+            where.append("(s.scan_root = ? OR s.path LIKE ?)")
+            params.append(root)
+            params.append(root.rstrip("/") + "/%")
+
+        tags = args.get("tags") or []
+        if tags:
+            placeholders = ",".join("?" for _ in tags)
+            where.append(
+                f"s.path IN (SELECT path FROM tags WHERE tag IN ({placeholders}) "
+                f"GROUP BY path HAVING COUNT(DISTINCT tag) = ?)"
+            )
+            params.extend(tags)
+            params.append(len(tags))
+
+        if args.get("text"):
+            joins.append("JOIN samples_fts fts ON fts.path = s.path")
+            where.append("samples_fts MATCH ?")
+            params.append(args["text"])
+
+        limit = int(args.get("limit") or 50)
+        sql = "SELECT s.* FROM samples s " + " ".join(joins)
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY s.path LIMIT ?"
+        params.append(limit)
+
+        rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
+        return {"count": len(rows), "samples": rows}
+    finally:
+        conn.close()
+
+
+def get_sample(args):
+    path = _require_path(args)
+    conn = _get_conn()
+    try:
+        resolved = _resolve_stored_path(conn, path)
+        if resolved is None:
+            raise ToolError(f"sample not indexed: {path}")
+        row = conn.execute(
+            "SELECT * FROM samples WHERE path = ?", (resolved,)
+        ).fetchone()
+        out = dict(row)
+        out["tags"] = [
+            r["tag"] for r in conn.execute(
+                "SELECT tag FROM tags WHERE path = ? ORDER BY tag", (resolved,)
+            ).fetchall()
+        ]
+        desc = conn.execute(
+            "SELECT description FROM descriptions WHERE path = ?", (resolved,)
+        ).fetchone()
+        out["description"] = desc["description"] if desc else None
+        out["has_features"] = bool(
+            conn.execute(
+                "SELECT 1 FROM features WHERE path = ?", (resolved,)
+            ).fetchone()
+        )
+        return out
+    finally:
+        conn.close()
+
+
+def locate_sample(args):
+    name = args.get("name")
+    if not name:
+        raise ToolError("name is required")
+    limit = int(args.get("limit") or 10)
+    conn = _get_conn()
+    try:
+        like = "%/" + name + "%"
+        rows = conn.execute(
+            "SELECT path, scan_root, format, bpm, key, duration "
+            "FROM samples WHERE path LIKE ? ORDER BY path LIMIT ?",
+            (like, limit),
+        ).fetchall()
+        return {"count": len(rows), "samples": [dict(r) for r in rows]}
+    finally:
+        conn.close()
+
+
+def list_roots(_args):
+    conn = _get_conn()
+    try:
+        return {"roots": idx.list_roots(conn)}
+    finally:
+        conn.close()
+
+
+def list_tags(args):
+    conn = _get_conn()
+    try:
+        prefix = args.get("prefix") or ""
+        if prefix:
+            rows = conn.execute(
+                "SELECT tag, COUNT(*) AS count FROM tags "
+                "WHERE tag LIKE ? GROUP BY tag ORDER BY count DESC, tag",
+                (prefix + "%",),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT tag, COUNT(*) AS count FROM tags "
+                "GROUP BY tag ORDER BY count DESC, tag"
+            ).fetchall()
+        return {"tags": [dict(r) for r in rows]}
+    finally:
+        conn.close()
+
+
+def list_keys(_args):
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT key, COUNT(*) AS count FROM samples "
+            "WHERE key IS NOT NULL GROUP BY key ORDER BY count DESC, key"
+        ).fetchall()
+        return {"keys": [dict(r) for r in rows]}
+    finally:
+        conn.close()
+
+
+def list_formats(_args):
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT format, COUNT(*) AS count FROM samples "
+            "WHERE format IS NOT NULL GROUP BY format ORDER BY count DESC"
+        ).fetchall()
+        return {"formats": [dict(r) for r in rows]}
+    finally:
+        conn.close()
+
+
+def index_stats(_args):
+    conn = _get_conn()
+    try:
+        stats = idx.index_stats(conn)
+        stats["analysis_available"] = _librosa_available()
+        stats["db_path"] = _DB_PATH
+        return stats
+    finally:
+        conn.close()
+
+
+def infer_kind(duration, acid_beats):
+    """Classify a sample as 'loop' / 'one_shot' / 'any' from length + beats.
+
+    acid_beats > 0 OR duration >= 2.0 -> loop
+    duration < 1.0 AND (acid_beats is None or 0) -> one_shot
+    otherwise (1.0 <= duration < 2.0 without beats) -> any
+    """
+    d = duration or 0.0
+    b = acid_beats or 0
+    if b > 0 or d >= 2.0:
+        return "loop"
+    if d < 1.0 and b <= 0:
+        return "one_shot"
+    return "any"
+
+
+def find_compatible(args):
+    path = _require_path(args)
+    tol = float(args.get("bpm_tolerance_pct") or 6) / 100.0
+    limit = int(args.get("limit") or 20)
+    include_relative = args.get("include_relative", True)
+    kind_arg = (args.get("kind") or "").lower() or None
+    min_duration = args.get("min_duration")
+
+    conn = _get_conn()
+    try:
+        resolved = _resolve_stored_path(conn, path)
+        if resolved is None:
+            raise ToolError(f"sample not indexed: {path}")
+        target = conn.execute(
+            "SELECT * FROM samples WHERE path = ?", (resolved,)
+        ).fetchone()
+
+        target_bpm = target["bpm"]
+        target_key = target["key"]
+        target_kind = infer_kind(target["duration"], target["acid_beats"])
+
+        # default kind: match the target's own classification (so loops return
+        # loops, one-shots return one-shots). 'any' skips kind filtering.
+        effective_kind = kind_arg or target_kind
+        if effective_kind not in ("loop", "one_shot", "any"):
+            raise ToolError(
+                f"kind must be loop, one_shot, or any (got {effective_kind!r})"
+            )
+
+        compat_keys = camelot.compatible_keys(target_key) if target_key else set()
+        if not include_relative and target_key:
+            base = camelot.key_to_camelot(target_key)
+            if base:
+                keep = {c for c in camelot.camelot_neighbors(base)
+                        if not c.endswith(("A",) if base.endswith("B") else ("B",))}
+                compat_keys = {
+                    k for k in compat_keys
+                    if camelot.key_to_camelot(k) in keep
+                }
+
+        # expand each compatible key to all enharmonic spellings so a DB row
+        # stored as "Cb" still matches when target implies "B", etc.
+        sql_keys = set()
+        for k in compat_keys:
+            sql_keys.update(camelot.enharmonic_spellings(k))
+
+        where = ["s.path != ?"]
+        params = [resolved]
+
+        if target_bpm is not None:
+            lo = target_bpm * (1 - tol)
+            hi = target_bpm * (1 + tol)
+            where.append("s.bpm BETWEEN ? AND ?")
+            params.extend([lo, hi])
+
+        if sql_keys:
+            placeholders = ",".join("?" for _ in sql_keys)
+            where.append(f"LOWER(s.key) IN ({placeholders})")
+            params.extend(k.lower() for k in sql_keys)
+
+        if effective_kind == "loop":
+            where.append("(s.acid_beats > 0 OR s.duration >= 2.0)")
+        elif effective_kind == "one_shot":
+            where.append(
+                "((s.acid_beats IS NULL OR s.acid_beats = 0) AND "
+                "(s.duration IS NULL OR s.duration < 1.0))"
+            )
+
+        if min_duration is not None:
+            where.append("s.duration >= ?")
+            params.append(float(min_duration))
+
+        sql = (
+            "SELECT s.* FROM samples s WHERE "
+            + " AND ".join(where)
+            + " ORDER BY s.bpm IS NULL, ABS(s.bpm - ?) LIMIT ?"
+        )
+        params.append(target_bpm or 0)
+        params.append(limit)
+
+        rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
+        return {
+            "target": {
+                "path": resolved,
+                "bpm": target_bpm,
+                "key": target_key,
+                "camelot": camelot.key_to_camelot(target_key) if target_key else None,
+                "kind": target_kind,
+            },
+            "compatible_keys": sorted(compat_keys),
+            "filter_kind": effective_kind,
+            "count": len(rows),
+            "samples": rows,
+        }
+    finally:
+        conn.close()
+
+
+# ── analysis tools (slow) ─────────────────────────────────────────
+
+
+def find_similar(args):
+    path = _require_path(args)
+    n = int(args.get("n") or 5)
+
+    conn = _get_conn()
+    try:
+        norm = idx.normalize_path(path)
+        target_feats = idx.get_features(conn, norm) or idx.get_features(conn, path)
+
+        if target_feats is None:
+            if not _librosa_available():
+                return _analysis_unavailable()
+            from acidcat.core.features import extract_audio_features
+            target_feats = extract_audio_features(path)
+            if target_feats is None:
+                raise ToolError(f"could not extract features from {path}")
+
+        feature_keys = sorted(
+            k for k, v in target_feats.items()
+            if isinstance(v, (int, float)) and not isinstance(v, bool)
+        )
+        if not feature_keys:
+            raise ToolError("no numeric features available")
+
+        tv = [float(target_feats[k]) for k in feature_keys]
+
+        rows = conn.execute(
+            "SELECT f.path, f.features_json, s.bpm, s.key, s.duration, s.format "
+            "FROM features f JOIN samples s ON s.path = f.path"
+        ).fetchall()
+
+        scored = []
+        for r in rows:
+            try:
+                feats = json.loads(r["features_json"])
+                v = [float(feats.get(k, 0.0) or 0.0) for k in feature_keys]
+            except Exception:
+                continue
+            sim = _cosine(tv, v)
+            scored.append({
+                "path": r["path"],
+                "bpm": r["bpm"],
+                "key": r["key"],
+                "duration": r["duration"],
+                "format": r["format"],
+                "similarity": round(sim, 6),
+            })
+        scored.sort(key=lambda x: x["similarity"], reverse=True)
+        # filter out the target itself
+        target_path = idx.normalize_path(path)
+        scored = [s for s in scored if s["path"] != target_path][:n]
+        return {
+            "target": path,
+            "population": len(rows),
+            "results": scored,
+        }
+    finally:
+        conn.close()
+
+
+def _cosine(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def analyze_sample(args):
+    path = _require_path(args)
+    if not _librosa_available():
+        return _analysis_unavailable()
+    from acidcat.core.features import extract_audio_features
+    feats = extract_audio_features(path)
+    if feats is None:
+        raise ToolError(f"could not extract features from {path}")
+    return {"path": path, "features": feats}
+
+
+def detect_bpm_key(args):
+    path = _require_path(args)
+    if not _librosa_available():
+        return _analysis_unavailable()
+    from acidcat.core.detect import estimate_librosa_metadata
+    est = estimate_librosa_metadata(path) or {}
+    return {
+        "path": path,
+        "bpm": est.get("estimated_bpm"),
+        "key": est.get("estimated_key"),
+        "bpm_source": est.get("bpm_source"),
+        "key_source": est.get("key_source"),
+        "duration": est.get("duration_sec"),
+    }
+
+
+# ── index management ──────────────────────────────────────────────
+
+
+def reindex(args):
+    path = _require_path(args)
+    with_features = bool(args.get("with_features", False))
+    if not os.path.isdir(path):
+        raise ToolError(f"not a directory: {path}")
+
+    from acidcat.commands.index import _walk_and_upsert
+
+    conn = _get_conn()
+    try:
+        scan_root = idx.normalize_path(path)
+        counts = _walk_and_upsert(
+            conn, scan_root,
+            do_features=with_features,
+            do_deep=False,
+            quiet=True,
+        )
+        conn.commit()
+        return {"root": scan_root, "counts": counts}
+    finally:
+        conn.close()
+
+
+def reindex_features(args):
+    limit = args.get("limit")
+    if not _librosa_available():
+        return _analysis_unavailable()
+    from acidcat.core.features import extract_audio_features
+
+    conn = _get_conn()
+    try:
+        sql = (
+            "SELECT s.path FROM samples s "
+            "LEFT JOIN features f ON f.path = s.path "
+            "WHERE f.path IS NULL"
+        )
+        if limit:
+            sql += " LIMIT ?"
+            rows = conn.execute(sql, (int(limit),)).fetchall()
+        else:
+            rows = conn.execute(sql).fetchall()
+
+        processed = failed = 0
+        for r in rows:
+            path = r["path"]
+            if not os.path.isfile(path):
+                failed += 1
+                continue
+            feats = extract_audio_features(path)
+            if feats is None:
+                failed += 1
+                continue
+            idx.upsert_features(conn, path, feats, version=1)
+            processed += 1
+        conn.commit()
+        return {"processed": processed, "failed": failed,
+                "remaining_unprocessed": len(rows) - processed - failed}
+    finally:
+        conn.close()
+
+
+# ── write tools ───────────────────────────────────────────────────
+
+
+def tag_sample(args):
+    path = _require_path(args)
+    add = args.get("add_tags") or []
+    remove = args.get("remove_tags") or []
+    if not add and not remove:
+        raise ToolError("provide add_tags and/or remove_tags")
+
+    conn = _get_conn()
+    try:
+        resolved = _resolve_stored_path(conn, path)
+        if resolved is None:
+            raise ToolError(f"sample not indexed: {path}")
+        if add:
+            idx.upsert_tags(conn, resolved, add)
+        if remove:
+            idx.remove_tags(conn, resolved, remove)
+        conn.commit()
+        tags = [
+            r["tag"] for r in conn.execute(
+                "SELECT tag FROM tags WHERE path = ? ORDER BY tag", (resolved,)
+            ).fetchall()
+        ]
+        return {"path": resolved, "tags": tags}
+    finally:
+        conn.close()
+
+
+def describe_sample(args):
+    path = _require_path(args)
+    description = args.get("description")
+    conn = _get_conn()
+    try:
+        resolved = _resolve_stored_path(conn, path)
+        if resolved is None:
+            raise ToolError(f"sample not indexed: {path}")
+        idx.upsert_description(conn, resolved, description or "")
+        conn.commit()
+        return {"path": resolved, "description": description or ""}
+    finally:
+        conn.close()
+
+
+# ── tool registration ─────────────────────────────────────────────
+
+
+def _register_all():
+    # fast
+    _tool(
+        "search_samples",
+        "Fast. Filter the sample index by bpm/key/duration/tags/text/format/root. "
+        "Prefer this over analysis tools for any discovery query.",
+        {
+            "type": "object",
+            "properties": {
+                "bpm_min": {"type": "number"},
+                "bpm_max": {"type": "number"},
+                "key": {"type": "string",
+                        "description": "Exact key (e.g. 'Am', 'C#')."},
+                "duration_min": {"type": "number"},
+                "duration_max": {"type": "number"},
+                "tags": {"type": "array", "items": {"type": "string"},
+                         "description": "AND semantics across tags."},
+                "text": {"type": "string",
+                         "description": "FTS across title/artist/album/"
+                         "genre/comment/description/tags/path."},
+                "format": {"type": "string",
+                           "description": "wav, mp3, flac, midi, serum, ..."},
+                "root": {"type": "string",
+                         "description": "Scope to samples under this scan root."},
+                "limit": {"type": "integer", "default": 50},
+            },
+        },
+        search_samples,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "get_sample",
+        "Fast. Full metadata for one sample path, including tags and description.",
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        get_sample,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "locate_sample",
+        "Fast. Find a sample by filename substring across all indexed roots. "
+        "Use this to answer 'where is X?' questions.",
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "limit": {"type": "integer", "default": 10},
+            },
+            "required": ["name"],
+        },
+        locate_sample,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "list_roots",
+        "Fast. Indexed scan roots with file counts and last-indexed times.",
+        {"type": "object", "properties": {}},
+        list_roots,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "list_tags",
+        "Fast. Distinct tags with counts. Use 'prefix' to narrow.",
+        {
+            "type": "object",
+            "properties": {"prefix": {"type": "string"}},
+        },
+        list_tags,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "list_keys",
+        "Fast. Distinct musical keys with counts.",
+        {"type": "object", "properties": {}},
+        list_keys,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "list_formats",
+        "Fast. Distinct file formats with counts.",
+        {"type": "object", "properties": {}},
+        list_formats,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "index_stats",
+        "Fast. Totals, per-format counts, analysis availability, DB path.",
+        {"type": "object", "properties": {}},
+        index_stats,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "find_compatible",
+        "Fast. Harmonically and rhythmically compatible samples via Camelot + "
+        "BPM tolerance. By default filters to the target's own kind (loops "
+        "match loops, one-shots match one-shots) so a kalimba loop query "
+        "does not return kalimba one-shots. No audio analysis; metadata-only.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "bpm_tolerance_pct": {"type": "number", "default": 6},
+                "include_relative": {"type": "boolean", "default": True},
+                "kind": {
+                    "type": "string",
+                    "enum": ["loop", "one_shot", "any"],
+                    "description":
+                        "Filter by sample kind. Default: auto-infer from "
+                        "target (loop vs one-shot based on acid_beats+duration).",
+                },
+                "min_duration": {
+                    "type": "number",
+                    "description":
+                        "Optional seconds floor. Overrides/augments kind "
+                        "filter when you want a specific minimum length.",
+                },
+                "limit": {"type": "integer", "default": 20},
+            },
+            "required": ["path"],
+        },
+        find_compatible,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+
+    # analysis (slow)
+    _tool(
+        "find_similar",
+        "SLOW if features are not indexed, fast if they are. Requires "
+        "acidcat[analysis]. Nearest neighbors by librosa feature cosine. "
+        "Only use when metadata-based tools (search_samples, find_compatible) "
+        "cannot answer.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "n": {"type": "integer", "default": 5},
+            },
+            "required": ["path"],
+        },
+        find_similar,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "analyze_sample",
+        "SLOW (~1-10s). Requires acidcat[analysis]. On-the-fly librosa feature "
+        "extraction for an unindexed file. Prefer get_sample for indexed files.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "deep": {"type": "boolean", "default": False},
+            },
+            "required": ["path"],
+        },
+        analyze_sample,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "detect_bpm_key",
+        "SLOW (~0.5-2s). Requires acidcat[analysis]. BPM + key estimation only. "
+        "Cheaper than analyze_sample. Prefer get_sample when possible.",
+        {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        detect_bpm_key,
+        {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+    )
+
+    # reindex (operational, slow)
+    _tool(
+        "reindex",
+        "SLOW. Only call when the user explicitly asks to refresh the index. "
+        "Walks a directory and upserts samples incrementally.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "with_features": {"type": "boolean", "default": False},
+            },
+            "required": ["path"],
+        },
+        reindex,
+        {"readOnlyHint": False, "destructiveHint": False,
+         "idempotentHint": True, "openWorldHint": False},
+    )
+    _tool(
+        "reindex_features",
+        "VERY SLOW. Requires acidcat[analysis]. Extracts librosa features for "
+        "any indexed samples that do not have them yet. Only call when the "
+        "user explicitly asks.",
+        {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer",
+                          "description": "Max files to process this call."},
+            },
+        },
+        reindex_features,
+        {"readOnlyHint": False, "destructiveHint": False,
+         "idempotentHint": True, "openWorldHint": False},
+    )
+
+    # write tools
+    _tool(
+        "tag_sample",
+        "Modify the index. Add/remove tags on a sample. Confirm with the user "
+        "before calling.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "add_tags": {"type": "array", "items": {"type": "string"}},
+                "remove_tags": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["path"],
+        },
+        tag_sample,
+        {"readOnlyHint": False, "destructiveHint": True,
+         "idempotentHint": False, "openWorldHint": False},
+    )
+    _tool(
+        "describe_sample",
+        "Modify the index. Set or clear the free-text description for a sample. "
+        "Confirm with the user before calling.",
+        {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "description": {"type": "string"},
+            },
+            "required": ["path"],
+        },
+        describe_sample,
+        {"readOnlyHint": False, "destructiveHint": True,
+         "idempotentHint": True, "openWorldHint": False},
+    )
+
+
+_register_all()
+
+
+def dispatch(name, arguments):
+    """Call a tool by name with a dict of arguments. Raises ToolError or returns dict."""
+    for t in TOOLS:
+        if t["name"] == name:
+            return t["handler"](arguments or {})
+    raise ToolError(f"unknown tool: {name}")
+
+
+# ── stdio entrypoint ──────────────────────────────────────────────
+
+
+async def _run_stdio():
+    try:
+        from mcp.server import Server
+        from mcp.server.stdio import stdio_server
+        import mcp.types as mcp_types
+    except ImportError:
+        print("acidcat-mcp: the mcp package is not installed. "
+              "Install with: pip install acidcat[mcp]", file=sys.stderr)
+        sys.exit(1)
+
+    app = Server("acidcat")
+
+    @app.list_tools()
+    async def _list_tools():
+        out = []
+        for t in TOOLS:
+            ann_kwargs = {}
+            for k, v in t["annotations"].items():
+                ann_kwargs[k] = v
+            try:
+                annotations = mcp_types.ToolAnnotations(**ann_kwargs)
+            except TypeError:
+                annotations = None
+            tool_kwargs = {
+                "name": t["name"],
+                "description": t["description"],
+                "inputSchema": t["input_schema"],
+            }
+            if annotations is not None:
+                tool_kwargs["annotations"] = annotations
+            out.append(mcp_types.Tool(**tool_kwargs))
+        return out
+
+    @app.call_tool()
+    async def _call_tool(name, arguments):
+        try:
+            result = dispatch(name, arguments or {})
+            text = json.dumps(result, default=str, indent=2)
+            return [mcp_types.TextContent(type="text", text=text)]
+        except ToolError as e:
+            payload = {"error": str(e)}
+            return [mcp_types.TextContent(type="text", text=json.dumps(payload))]
+        except Exception as e:
+            payload = {"error": f"internal: {e.__class__.__name__}: {e}"}
+            return [mcp_types.TextContent(type="text", text=json.dumps(payload))]
+
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+def main(argv=None):
+    global _DB_PATH
+    parser = argparse.ArgumentParser(
+        prog="acidcat-mcp",
+        description="MCP server exposing the acidcat sample index over stdio.",
+    )
+    parser.add_argument("--db", help="Override DB path (default: "
+                                     "$ACIDCAT_DB or ~/.acidcat/index.db).")
+    parser.add_argument("--version", action="version",
+                        version=f"acidcat-mcp {__version__}")
+    args = parser.parse_args(argv)
+    _DB_PATH = idx.resolve_db_path(args.db)
+
+    import asyncio
+    asyncio.run(_run_stdio())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/acidcat/util/midi.py
+++ b/src/acidcat/util/midi.py
@@ -10,3 +10,15 @@ def midi_note_to_name(note_number):
     octave = (note_number // 12) - 1
     note = NOTES[note_number % 12]
     return f"{note}{octave}"
+
+
+def midi_note_to_pitch_class(note_number):
+    """Convert MIDI note number to pitch class only (no octave), e.g. 'C'.
+
+    Use this when storing a musical key where the octave is noise
+    (harmonic matching cares about pitch class). The octave info is
+    preserved elsewhere (e.g. a `root_note` int column).
+    """
+    if note_number is None:
+        return None
+    return NOTES[note_number % 12]

--- a/tests/test_camelot.py
+++ b/tests/test_camelot.py
@@ -1,0 +1,87 @@
+"""Tests for the Camelot key helper."""
+
+from acidcat.core import camelot
+
+
+def test_parse_simple_major():
+    assert camelot.parse_key("C") == (0, 0)
+    assert camelot.parse_key("c") == (0, 0)
+    assert camelot.parse_key("C major") == (0, 0)
+    assert camelot.parse_key("C maj") == (0, 0)
+
+
+def test_parse_simple_minor():
+    assert camelot.parse_key("Am") == (9, 1)
+    assert camelot.parse_key("A minor") == (9, 1)
+    assert camelot.parse_key("a min") == (9, 1)
+    assert camelot.parse_key("F#m") == (6, 1)
+
+
+def test_parse_enharmonic():
+    assert camelot.parse_key("C#") == camelot.parse_key("Db")
+    assert camelot.parse_key("Eb") == camelot.parse_key("D#")
+
+
+def test_parse_camelot_code():
+    assert camelot.parse_key("8A") == (9, 1)  # Am
+    assert camelot.parse_key("8B") == (0, 0)  # C
+
+
+def test_parse_midi_note_like():
+    # C4 style strings (stripped octave)
+    assert camelot.parse_key("C4") == (0, 0)
+    assert camelot.parse_key("F#3") == (6, 0)
+
+
+def test_parse_invalid():
+    assert camelot.parse_key("") is None
+    assert camelot.parse_key(None) is None
+    assert camelot.parse_key("ZZZ") is None
+
+
+def test_key_to_camelot():
+    assert camelot.key_to_camelot("Am") == "8A"
+    assert camelot.key_to_camelot("C") == "8B"
+    assert camelot.key_to_camelot("Fm") == "4A"
+    assert camelot.key_to_camelot("Eb") == "5B"
+
+
+def test_neighbors_cover_all_four():
+    n = camelot.camelot_neighbors("8A")
+    # same, relative, perfect fourth, perfect fifth
+    assert n == ["8A", "8B", "7A", "9A"]
+
+
+def test_neighbors_wrap():
+    assert camelot.camelot_neighbors("1A") == ["1A", "1B", "12A", "2A"]
+    assert camelot.camelot_neighbors("12B") == ["12B", "12A", "11B", "1B"]
+
+
+def test_compatible_keys_am():
+    compat = camelot.compatible_keys("Am")
+    # Am(8A) -> 8A, 8B, 7A, 9A = Am, C, Dm, Em
+    assert compat == {"Am", "C", "Dm", "Em"}
+
+
+def test_compatible_keys_unparseable():
+    assert camelot.compatible_keys("xyz") == set()
+    assert camelot.compatible_keys(None) == set()
+
+
+def test_enharmonic_spellings_roundtrip():
+    # B and Cb are enharmonically the same pitch
+    assert "Cb" in camelot.enharmonic_spellings("B")
+    assert "B" in camelot.enharmonic_spellings("Cb")
+
+    # C# and Db are enharmonic
+    assert "Db" in camelot.enharmonic_spellings("C#")
+    assert "C#" in camelot.enharmonic_spellings("Db")
+
+    # Minor keys preserve suffix
+    assert "Cbm" in camelot.enharmonic_spellings("Bm")
+    assert "Bm" in camelot.enharmonic_spellings("Cbm")
+
+
+def test_enharmonic_spellings_unparseable():
+    assert camelot.enharmonic_spellings("xyz") == set()
+    assert camelot.enharmonic_spellings(None) == set()

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,71 @@
+"""Tests for filename/path-based key and BPM parsing."""
+
+from acidcat.core.detect import (
+    parse_bare_key_token,
+    parse_key_from_path,
+    parse_key_from_filename,
+    parse_bpm_from_filename,
+)
+
+
+def test_bare_token_major():
+    assert parse_bare_key_token("A") == "A"
+    assert parse_bare_key_token("C#") == "C#"
+    assert parse_bare_key_token("Db") == "C#"  # flat -> sharp normalization
+    assert parse_bare_key_token("Bb") == "A#"
+
+
+def test_bare_token_cb_fb_enharmonic():
+    assert parse_bare_key_token("Cb") == "B"
+    assert parse_bare_key_token("Fb") == "E"
+    assert parse_bare_key_token("Cbm") == "Bm"
+    assert parse_bare_key_token("Fbm") == "Em"
+
+
+def test_bare_token_minor():
+    assert parse_bare_key_token("Am") == "Am"
+    assert parse_bare_key_token("F#m") == "F#m"
+    assert parse_bare_key_token("Ebm") == "D#m"
+
+
+def test_bare_token_rejects_non_keys():
+    assert parse_bare_key_token("Analog") is None
+    assert parse_bare_key_token("Hypnotize") is None
+    assert parse_bare_key_token("Break") is None
+    assert parse_bare_key_token("") is None
+    assert parse_bare_key_token("127") is None
+    assert parse_bare_key_token("A#m7") is None  # not a whole key token
+
+
+def test_path_filename_bare_key():
+    assert parse_key_from_path("/loops/PL_Hypnotize_03_126_A#.wav") == "A#"
+    assert parse_key_from_path("/loops/kick_120_Am.wav") == "Am"
+
+
+def test_path_parent_folder_bare_key():
+    # key in parent folder, not filename
+    path = "/samples/PL_Hypnotize_03_126_A#/Drums/kick.wav"
+    assert parse_key_from_path(path) == "A#"
+
+
+def test_path_grandparent_folder():
+    # key two levels up; max_parent_depth=2 by default
+    path = "/packs/PL_Hypnotize_03_126_A#/Drums/Raw/kick.wav"
+    assert parse_key_from_path(path) == "A#"
+
+
+def test_path_suffix_style_matches_existing():
+    # existing parse_key_from_filename handles 'Am' with suffix styles too
+    assert parse_key_from_path("/loops/pad_in_A minor.wav") == "Am"
+    assert parse_key_from_path("/loops/pad_in_C_major.wav") == "C"
+
+
+def test_path_no_key_returns_none():
+    assert parse_key_from_path("/loops/Analog_Break_fx.wav") is None
+    assert parse_key_from_path("/loops/kick.wav") is None
+
+
+def test_parse_bpm_existing():
+    # sanity: existing bpm parser still works
+    assert parse_bpm_from_filename("/loops/PL_Hypnotize_03_126_A#.wav") == 126
+    assert parse_bpm_from_filename("/loops/kick.wav") is None

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,325 @@
+"""Tests for the SQLite index and `acidcat index` command."""
+
+import json
+import os
+import struct
+import time
+
+import pytest
+
+from acidcat.commands import index as index_cmd
+from acidcat.core import index as idx
+
+
+def _make_riff_wav(sample_rate=44100, channels=1, bits=16, num_samples=4,
+                   smpl_root_key=None):
+    """Build a minimal valid PCM WAV. If smpl_root_key is given, add a SMPL
+    chunk with that MIDI note as the unity note (no loops).
+    """
+    block_align = channels * bits // 8
+    byte_rate = sample_rate * block_align
+    audio_data = b"\x00" * (num_samples * block_align)
+    fmt = struct.pack(
+        "<HHIIHH", 1, channels, sample_rate, byte_rate, block_align, bits,
+    )
+    fmt_chunk = b"fmt " + struct.pack("<I", 16) + fmt
+    data_chunk = b"data" + struct.pack("<I", len(audio_data)) + audio_data
+
+    smpl_chunk = b""
+    if smpl_root_key is not None:
+        # 36-byte smpl body: manufacturer, product, sample_period,
+        # midi_unity_note, midi_pitch_fraction, smpte_format, smpte_offset,
+        # sample_loops, sampler_data
+        smpl_body = struct.pack(
+            "<IIIIIIiiI",
+            0, 0, 0, smpl_root_key, 0, 0, 0, 0, 0,
+        )
+        smpl_chunk = b"smpl" + struct.pack("<I", len(smpl_body)) + smpl_body
+
+    riff_body = b"WAVE" + fmt_chunk + data_chunk + smpl_chunk
+    return b"RIFF" + struct.pack("<I", len(riff_body)) + riff_body
+
+
+class _Args:
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+        for name in ("target", "db", "features", "deep", "import_tags",
+                     "list_roots", "remove_root", "stats", "quiet"):
+            if not hasattr(self, name):
+                setattr(self, name, None)
+        if self.quiet is None:
+            self.quiet = True
+        if self.features is None:
+            self.features = False
+        if self.deep is None:
+            self.deep = False
+        if self.list_roots is None:
+            self.list_roots = False
+        if self.stats is None:
+            self.stats = False
+
+
+def _library(tmp_path, minimal_wav_bytes):
+    """Build a small library of WAVs in tmp_path/lib."""
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "kick.wav").write_bytes(minimal_wav_bytes)
+    (lib / "snare.wav").write_bytes(minimal_wav_bytes)
+    sub = lib / "sub"
+    sub.mkdir()
+    (sub / "hat.wav").write_bytes(minimal_wav_bytes)
+    return lib
+
+
+@pytest.fixture
+def wav_bytes():
+    return _make_riff_wav()
+
+
+def test_open_db_creates_schema(tmp_path):
+    db = tmp_path / "test.db"
+    conn = idx.open_db(str(db))
+    try:
+        row = conn.execute(
+            "SELECT v FROM meta WHERE k = 'schema_version'"
+        ).fetchone()
+        assert row["v"] == str(idx.SCHEMA_VERSION)
+        tables = {
+            r["name"] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')"
+            ).fetchall()
+        }
+        for required in ("samples", "scan_roots", "tags", "descriptions",
+                         "features", "samples_fts"):
+            assert required in tables
+    finally:
+        conn.close()
+
+
+def test_index_populates_rows(tmp_path, wav_bytes):
+    lib = _library(tmp_path, wav_bytes)
+    db = tmp_path / "idx.db"
+    args = _Args(target=str(lib), db=str(db))
+    rc = index_cmd.run(args)
+    assert rc == 0
+
+    conn = idx.open_db(str(db))
+    try:
+        total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
+        assert total == 3
+        fmt_row = conn.execute(
+            "SELECT DISTINCT format FROM samples"
+        ).fetchone()
+        assert fmt_row["format"] == "wav"
+        roots = idx.list_roots(conn)
+        assert len(roots) == 1
+        assert roots[0]["file_count"] == 3
+    finally:
+        conn.close()
+
+
+def test_reindex_skips_unchanged(tmp_path, wav_bytes):
+    lib = _library(tmp_path, wav_bytes)
+    db = tmp_path / "idx.db"
+    args = _Args(target=str(lib), db=str(db))
+    index_cmd.run(args)
+
+    conn = idx.open_db(str(db))
+    try:
+        rows = conn.execute(
+            "SELECT path, indexed_at FROM samples"
+        ).fetchall()
+        first_indexed = {r["path"]: r["indexed_at"] for r in rows}
+    finally:
+        conn.close()
+
+    time.sleep(0.05)
+    index_cmd.run(args)
+
+    conn = idx.open_db(str(db))
+    try:
+        rows = conn.execute(
+            "SELECT path, indexed_at, last_seen_at FROM samples"
+        ).fetchall()
+        for r in rows:
+            assert r["indexed_at"] == first_indexed[r["path"]]
+            assert r["last_seen_at"] >= r["indexed_at"]
+    finally:
+        conn.close()
+
+
+def test_prune_missing_files(tmp_path, wav_bytes):
+    lib = _library(tmp_path, wav_bytes)
+    db = tmp_path / "idx.db"
+    args = _Args(target=str(lib), db=str(db))
+    index_cmd.run(args)
+
+    os.remove(lib / "kick.wav")
+
+    index_cmd.run(args)
+
+    conn = idx.open_db(str(db))
+    try:
+        paths = [
+            r["path"] for r in conn.execute(
+                "SELECT path FROM samples"
+            ).fetchall()
+        ]
+        assert not any(p.endswith("kick.wav") for p in paths)
+        assert len(paths) == 2
+    finally:
+        conn.close()
+
+
+def test_changed_file_updates_row(tmp_path, wav_bytes):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    target = lib / "x.wav"
+    target.write_bytes(wav_bytes)
+    db = tmp_path / "idx.db"
+    args = _Args(target=str(lib), db=str(db))
+    index_cmd.run(args)
+
+    conn = idx.open_db(str(db))
+    orig_size = conn.execute("SELECT size FROM samples").fetchone()["size"]
+    conn.close()
+
+    # mutate the file: rewrite with longer audio
+    target.write_bytes(_make_riff_wav(num_samples=1024))
+    os.utime(target, (time.time() + 1, time.time() + 1))
+
+    index_cmd.run(args)
+
+    conn = idx.open_db(str(db))
+    new_size = conn.execute("SELECT size FROM samples").fetchone()["size"]
+    conn.close()
+    assert new_size != orig_size
+
+
+def test_multiple_roots_share_db(tmp_path, wav_bytes):
+    db = tmp_path / "idx.db"
+
+    lib_a = tmp_path / "a"
+    lib_a.mkdir()
+    (lib_a / "one.wav").write_bytes(wav_bytes)
+
+    lib_b = tmp_path / "b"
+    lib_b.mkdir()
+    (lib_b / "two.wav").write_bytes(wav_bytes)
+
+    index_cmd.run(_Args(target=str(lib_a), db=str(db)))
+    index_cmd.run(_Args(target=str(lib_b), db=str(db)))
+
+    conn = idx.open_db(str(db))
+    try:
+        total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
+        assert total == 2
+        roots = idx.list_roots(conn)
+        assert len(roots) == 2
+    finally:
+        conn.close()
+
+
+def test_remove_root(tmp_path, wav_bytes):
+    lib = _library(tmp_path, wav_bytes)
+    db = tmp_path / "idx.db"
+    index_cmd.run(_Args(target=str(lib), db=str(db)))
+
+    scan_root = idx.normalize_path(str(lib))
+    args = _Args(remove_root=scan_root, db=str(db))
+    rc = index_cmd.run(args)
+    assert rc == 0
+
+    conn = idx.open_db(str(db))
+    try:
+        total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
+        assert total == 0
+        assert idx.list_roots(conn) == []
+    finally:
+        conn.close()
+
+
+def test_junk_files_skipped(tmp_path, wav_bytes):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "real.wav").write_bytes(wav_bytes)
+    # AppleDouble sidecars, plus other OS junk
+    (lib / "._real.wav").write_bytes(b"\x00" * 32)
+    (lib / ".DS_Store").write_bytes(b"\x00" * 32)
+    (lib / "Thumbs.db").write_bytes(b"\x00" * 32)
+    (lib / "desktop.ini").write_bytes(b"\x00" * 32)
+
+    db = tmp_path / "idx.db"
+    index_cmd.run(_Args(target=str(lib), db=str(db)))
+
+    conn = idx.open_db(str(db))
+    try:
+        paths = [
+            r["path"] for r in conn.execute("SELECT path FROM samples").fetchall()
+        ]
+        assert len(paths) == 1
+        assert paths[0].endswith("/real.wav")
+    finally:
+        conn.close()
+
+
+def test_smpl_root_key_stores_pitch_class_only(tmp_path):
+    # MIDI 60 = C4; key column should hold "C" (pitch class), not "C4".
+    bytes_c4 = _make_riff_wav(smpl_root_key=60)
+    bytes_fs3 = _make_riff_wav(smpl_root_key=54)  # F#3
+
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "c_sample.wav").write_bytes(bytes_c4)
+    (lib / "fsharp_sample.wav").write_bytes(bytes_fs3)
+
+    db = tmp_path / "idx.db"
+    index_cmd.run(_Args(target=str(lib), db=str(db)))
+
+    conn = idx.open_db(str(db))
+    try:
+        rows = {
+            os.path.basename(r["path"]): dict(r)
+            for r in conn.execute(
+                "SELECT path, key, root_note FROM samples"
+            ).fetchall()
+        }
+        assert rows["c_sample.wav"]["key"] == "C"
+        assert rows["c_sample.wav"]["root_note"] == 60
+        assert rows["fsharp_sample.wav"]["key"] == "F#"
+        assert rows["fsharp_sample.wav"]["root_note"] == 54
+    finally:
+        conn.close()
+
+
+def test_import_tags(tmp_path, wav_bytes):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    (lib / "Drum_Loop.wav").write_bytes(wav_bytes)
+    db = tmp_path / "idx.db"
+
+    tags_file = tmp_path / "legacy_tags.json"
+    tags_file.write_text(json.dumps({
+        "data/samples\\Drum_Loop.wav": {
+            "description": "Energetic drum loop",
+            "tags": ["drums", "loop"],
+        }
+    }))
+
+    args = _Args(target=str(lib), db=str(db), import_tags=str(tags_file))
+    rc = index_cmd.run(args)
+    assert rc == 0
+
+    conn = idx.open_db(str(db))
+    try:
+        tag_rows = conn.execute(
+            "SELECT tag FROM tags ORDER BY tag"
+        ).fetchall()
+        assert [r["tag"] for r in tag_rows] == ["drums", "loop"]
+        desc = conn.execute(
+            "SELECT description FROM descriptions"
+        ).fetchone()
+        assert desc["description"] == "Energetic drum loop"
+    finally:
+        conn.close()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,295 @@
+"""Tests for the MCP tool surface (direct handler calls, bypass stdio)."""
+
+import json
+import time
+
+import pytest
+
+from acidcat import mcp_server
+from acidcat.core import index as idx
+
+
+ROOT_A = idx.normalize_path("/tmp/mcp/a")
+ROOT_B = idx.normalize_path("/tmp/mcp/b")
+P_KICK = ROOT_A + "/kick_120.wav"
+P_HAT = ROOT_A + "/hat_128.wav"
+P_SYNTH = ROOT_B + "/synth_124.flac"
+
+
+def _seed(db_path):
+    conn = idx.open_db(db_path)
+    now = time.time()
+    rows = [
+        {"path": P_KICK, "scan_root": ROOT_A, "format": "wav",
+         "duration": 1.2, "bpm": 120.0, "key": "C",
+         "title": "kick one", "comment": "booming sub",
+         "mtime": now, "size": 100, "indexed_at": now, "last_seen_at": now,
+         "chunks": "acid,smpl", "acid_beats": 4, "root_note": 60,
+         "sample_rate": 44100, "channels": 1, "bits_per_sample": 16,
+         "artist": None, "album": None, "genre": None},
+        {"path": P_HAT, "scan_root": ROOT_A, "format": "wav",
+         "duration": 0.5, "bpm": 128.0, "key": "Am",
+         "title": "closed hat", "mtime": now, "size": 100,
+         "indexed_at": now, "last_seen_at": now,
+         "artist": None, "album": None, "genre": None, "comment": None,
+         "chunks": None, "acid_beats": None, "root_note": None,
+         "sample_rate": None, "channels": None, "bits_per_sample": None},
+        {"path": P_SYNTH, "scan_root": ROOT_B, "format": "flac",
+         "duration": 8.0, "bpm": 124.0, "key": "Em",
+         "title": "dusty synth", "artist": "someone",
+         "album": "dust pack", "genre": "electronic",
+         "comment": "warm and lofi",
+         "mtime": now, "size": 200, "indexed_at": now, "last_seen_at": now,
+         "chunks": None, "acid_beats": None, "root_note": None,
+         "sample_rate": 44100, "channels": 2, "bits_per_sample": 16},
+    ]
+    for r in rows:
+        idx.upsert_sample(conn, r)
+    idx.upsert_tags(conn, P_KICK, ["drums", "kick", "punchy"])
+    idx.upsert_tags(conn, P_HAT, ["drums", "hat"])
+    idx.upsert_tags(conn, P_SYNTH, ["synth", "pad"])
+    idx.upsert_description(conn, P_SYNTH, "moody analog pad")
+    idx.record_scan_root(conn, ROOT_A, 2, now)
+    idx.record_scan_root(conn, ROOT_B, 1, now)
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def seeded_db(tmp_path, monkeypatch):
+    db = tmp_path / "mcp.db"
+    _seed(str(db))
+    monkeypatch.setattr(mcp_server, "_DB_PATH", str(db))
+    return str(db)
+
+
+def test_tools_registered():
+    names = {t["name"] for t in mcp_server.TOOLS}
+    expected = {
+        "search_samples", "get_sample", "locate_sample", "list_roots",
+        "list_tags", "list_keys", "list_formats", "index_stats",
+        "find_compatible",
+        "find_similar", "analyze_sample", "detect_bpm_key",
+        "reindex", "reindex_features",
+        "tag_sample", "describe_sample",
+    }
+    assert expected.issubset(names)
+
+
+def test_fast_tools_have_fast_prefix():
+    fast_names = {"search_samples", "get_sample", "locate_sample",
+                  "list_roots", "list_tags", "list_keys", "list_formats",
+                  "index_stats", "find_compatible"}
+    for t in mcp_server.TOOLS:
+        if t["name"] in fast_names:
+            assert t["description"].startswith("Fast."), t["name"]
+
+
+def test_slow_tools_have_slow_prefix():
+    slow_names = {"find_similar", "analyze_sample", "detect_bpm_key",
+                  "reindex", "reindex_features"}
+    for t in mcp_server.TOOLS:
+        if t["name"] in slow_names:
+            assert t["description"].startswith(("SLOW", "VERY SLOW")), t["name"]
+
+
+def test_write_tools_marked_destructive():
+    for t in mcp_server.TOOLS:
+        if t["name"] in ("tag_sample", "describe_sample"):
+            assert t["annotations"]["destructiveHint"] is True
+            assert t["annotations"]["readOnlyHint"] is False
+
+
+def test_fast_tools_read_only():
+    fast = {"search_samples", "get_sample", "locate_sample", "list_roots",
+            "list_tags", "list_keys", "list_formats", "index_stats",
+            "find_compatible"}
+    for t in mcp_server.TOOLS:
+        if t["name"] in fast:
+            assert t["annotations"]["readOnlyHint"] is True
+            assert t["annotations"]["destructiveHint"] is False
+
+
+def test_search_samples(seeded_db):
+    r = mcp_server.dispatch("search_samples", {"bpm_min": 120, "bpm_max": 125})
+    paths = {s["path"] for s in r["samples"]}
+    assert paths == {P_KICK, P_SYNTH}
+
+
+def test_search_samples_text(seeded_db):
+    r = mcp_server.dispatch("search_samples", {"text": "dusty"})
+    assert r["count"] == 1
+    assert r["samples"][0]["path"] == P_SYNTH
+
+
+def test_search_samples_tags_and(seeded_db):
+    r = mcp_server.dispatch("search_samples", {"tags": ["drums", "kick"]})
+    assert r["count"] == 1
+    assert r["samples"][0]["path"] == P_KICK
+
+
+def test_get_sample(seeded_db):
+    r = mcp_server.dispatch("get_sample", {"path": P_SYNTH})
+    assert r["path"] == P_SYNTH
+    assert r["tags"] == ["pad", "synth"]
+    assert r["description"] == "moody analog pad"
+    assert r["has_features"] is False
+
+
+def test_get_sample_not_indexed(seeded_db):
+    with pytest.raises(mcp_server.ToolError):
+        mcp_server.dispatch("get_sample", {"path": "/nope.wav"})
+
+
+def test_locate_sample(seeded_db):
+    r = mcp_server.dispatch("locate_sample", {"name": "synth"})
+    assert r["count"] == 1
+    assert r["samples"][0]["path"] == P_SYNTH
+
+
+def test_list_roots(seeded_db):
+    r = mcp_server.dispatch("list_roots", {})
+    paths = {root["path"] for root in r["roots"]}
+    assert paths == {ROOT_A, ROOT_B}
+
+
+def test_list_tags(seeded_db):
+    r = mcp_server.dispatch("list_tags", {})
+    tag_names = [t["tag"] for t in r["tags"]]
+    assert "drums" in tag_names
+    # drums count is 2 (kick + hat)
+    tag_map = {t["tag"]: t["count"] for t in r["tags"]}
+    assert tag_map["drums"] == 2
+
+
+def test_list_tags_prefix(seeded_db):
+    r = mcp_server.dispatch("list_tags", {"prefix": "dr"})
+    tag_names = [t["tag"] for t in r["tags"]]
+    assert tag_names == ["drums"]
+
+
+def test_list_keys(seeded_db):
+    r = mcp_server.dispatch("list_keys", {})
+    keys = {k["key"] for k in r["keys"]}
+    assert keys == {"C", "Am", "Em"}
+
+
+def test_list_formats(seeded_db):
+    r = mcp_server.dispatch("list_formats", {})
+    formats = {f["format"] for f in r["formats"]}
+    assert formats == {"wav", "flac"}
+
+
+def test_index_stats(seeded_db):
+    r = mcp_server.dispatch("index_stats", {})
+    assert r["total_samples"] == 3
+    assert "analysis_available" in r
+    assert r["db_path"] == seeded_db
+
+
+def test_find_compatible_loops_match_loops(seeded_db):
+    # P_KICK: duration 1.2, acid_beats 4 -> loop (acid_beats > 0)
+    # P_SYNTH: duration 8.0, no acid_beats -> loop (duration >= 2.0)
+    # P_HAT:   duration 0.5, no acid_beats -> one_shot
+    # P_KICK is key C (8B); compatible with Am, Em, F, G. None of seeds match.
+    # Run with wider tolerance and check synth (Em) loop shows up.
+    r = mcp_server.dispatch("find_compatible", {
+        "path": P_SYNTH, "bpm_tolerance_pct": 20,
+    })
+    assert r["target"]["kind"] == "loop"
+    assert r["filter_kind"] == "loop"
+    # P_KICK and P_HAT are both compatible by key (Em -> compatible with C and G);
+    # only the loop (P_KICK) should come back.
+    paths = {s["path"] for s in r["samples"]}
+    # C is in compatible_keys for Em target (Em=9A -> 9B=G, 10A=Bm, 8A=Am)...
+    # so the exact membership depends on the Camelot wheel. What matters:
+    # the one_shot P_HAT MUST NOT appear.
+    assert P_HAT not in paths
+
+
+def test_find_compatible_default_excludes_cross_kind(seeded_db):
+    # Target is a one_shot (P_HAT). Default kind filter should exclude loops.
+    r = mcp_server.dispatch("find_compatible", {"path": P_HAT})
+    assert r["target"]["kind"] == "one_shot"
+    assert r["filter_kind"] == "one_shot"
+    paths = {s["path"] for s in r["samples"]}
+    # P_SYNTH is a loop, P_KICK is a loop (acid_beats=4); both excluded.
+    assert P_SYNTH not in paths
+    assert P_KICK not in paths
+
+
+def test_find_compatible_kind_any_overrides(seeded_db):
+    # With kind="any", the old behavior is back: a one_shot target finds loops.
+    r = mcp_server.dispatch("find_compatible", {
+        "path": P_HAT, "kind": "any",
+    })
+    assert r["filter_kind"] == "any"
+    paths = {s["path"] for s in r["samples"]}
+    assert P_SYNTH in paths
+
+
+def test_find_compatible_min_duration_override(seeded_db):
+    r = mcp_server.dispatch("find_compatible", {
+        "path": P_HAT, "kind": "any", "min_duration": 2.0,
+    })
+    paths = {s["path"] for s in r["samples"]}
+    # P_KICK (1.2s) excluded, P_SYNTH (8s) kept
+    assert P_KICK not in paths
+    assert P_SYNTH in paths
+
+
+def test_find_compatible_infer_kind_helper():
+    assert mcp_server.infer_kind(0.5, 0) == "one_shot"
+    assert mcp_server.infer_kind(0.5, None) == "one_shot"
+    assert mcp_server.infer_kind(8.0, 0) == "loop"
+    assert mcp_server.infer_kind(1.2, 4) == "loop"
+    # 1.0 to 2.0 with no beats is genuinely ambiguous
+    assert mcp_server.infer_kind(1.5, 0) == "any"
+
+
+def test_tag_sample(seeded_db):
+    r = mcp_server.dispatch("tag_sample", {
+        "path": P_HAT, "add_tags": ["bright", "tight"],
+    })
+    assert "bright" in r["tags"]
+    assert "tight" in r["tags"]
+
+    r2 = mcp_server.dispatch("tag_sample", {
+        "path": P_HAT, "remove_tags": ["bright"],
+    })
+    assert "bright" not in r2["tags"]
+    assert "tight" in r2["tags"]
+
+
+def test_describe_sample(seeded_db):
+    r = mcp_server.dispatch("describe_sample", {
+        "path": P_HAT, "description": "crispy closed hat",
+    })
+    assert r["description"] == "crispy closed hat"
+    got = mcp_server.dispatch("get_sample", {"path": P_HAT})
+    assert got["description"] == "crispy closed hat"
+
+
+def test_analysis_tools_degrade_without_librosa(seeded_db, monkeypatch):
+    monkeypatch.setattr(mcp_server, "_librosa_available", lambda: False)
+
+    r = mcp_server.dispatch("analyze_sample", {"path": P_HAT})
+    assert "error" in r
+    assert "acidcat[analysis]" in r["fix"]
+
+    r = mcp_server.dispatch("detect_bpm_key", {"path": P_HAT})
+    assert "error" in r
+
+    r = mcp_server.dispatch("reindex_features", {})
+    assert "error" in r
+
+
+def test_find_similar_no_features_no_librosa(seeded_db, monkeypatch):
+    monkeypatch.setattr(mcp_server, "_librosa_available", lambda: False)
+    r = mcp_server.dispatch("find_similar", {"path": P_HAT})
+    assert "error" in r
+
+
+def test_unknown_tool(seeded_db):
+    with pytest.raises(mcp_server.ToolError):
+        mcp_server.dispatch("nope", {})

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,185 @@
+"""Tests for `acidcat query` -- filtering over the SQLite index."""
+
+import io
+import time
+
+import pytest
+
+from acidcat.commands import query as query_cmd
+from acidcat.core import index as idx
+
+
+class _Args:
+    def __init__(self, **kw):
+        defaults = {
+            "db": None,
+            "bpm": None, "key": None, "duration": None, "tag": [],
+            "file_format": None, "text": None, "root": None,
+            "limit": 50,
+            "output_format": "json",
+            "output": None,
+            "paths_only": False,
+        }
+        defaults.update(kw)
+        for k, v in defaults.items():
+            setattr(self, k, v)
+
+
+ROOT_A = idx.normalize_path("/tmp/lib/a")
+ROOT_B = idx.normalize_path("/tmp/lib/b")
+P_KICK = ROOT_A + "/kick_120.wav"
+P_HAT = ROOT_A + "/hat_128.wav"
+P_SYNTH = ROOT_B + "/synth_124.flac"
+
+
+def _seed(db_path):
+    conn = idx.open_db(db_path)
+    now = time.time()
+    rows = [
+        {
+            "path": P_KICK, "scan_root": ROOT_A,
+            "format": "wav", "duration": 1.2, "bpm": 120.0, "key": "C",
+            "title": "kick one", "artist": None, "album": None,
+            "genre": None, "comment": "booming sub", "mtime": now,
+            "size": 100, "indexed_at": now, "last_seen_at": now,
+            "chunks": "acid,smpl",
+            "acid_beats": 4, "root_note": 60,
+            "sample_rate": 44100, "channels": 1, "bits_per_sample": 16,
+        },
+        {
+            "path": P_HAT, "scan_root": ROOT_A,
+            "format": "wav", "duration": 0.5, "bpm": 128.0, "key": "Am",
+            "title": "closed hat", "artist": None, "album": None,
+            "genre": None, "comment": None, "mtime": now,
+            "size": 100, "indexed_at": now, "last_seen_at": now,
+            "chunks": None, "acid_beats": None, "root_note": None,
+            "sample_rate": None, "channels": None, "bits_per_sample": None,
+        },
+        {
+            "path": P_SYNTH, "scan_root": ROOT_B,
+            "format": "flac", "duration": 8.0, "bpm": 124.0, "key": "Fm",
+            "title": "dusty synth", "artist": "someone",
+            "album": "dust pack", "genre": "electronic",
+            "comment": "warm and lofi", "mtime": now,
+            "size": 200, "indexed_at": now, "last_seen_at": now,
+            "chunks": None, "acid_beats": None, "root_note": None,
+            "sample_rate": 44100, "channels": 2, "bits_per_sample": 16,
+        },
+    ]
+    for r in rows:
+        idx.upsert_sample(conn, r)
+
+    idx.upsert_tags(conn, P_KICK, ["drums", "kick", "punchy"])
+    idx.upsert_tags(conn, P_HAT, ["drums", "hat"])
+    idx.upsert_tags(conn, P_SYNTH, ["synth", "pad"])
+
+    idx.record_scan_root(conn, ROOT_A, 2, now)
+    idx.record_scan_root(conn, ROOT_B, 1, now)
+
+    conn.commit()
+    conn.close()
+
+
+def test_bpm_range(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+
+    rows = _run(db, bpm="120:125")
+    paths = {r["path"] for r in rows}
+    assert paths == {P_KICK, P_SYNTH}
+
+
+def test_bpm_exact(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, bpm="128")
+    assert len(rows) == 1
+    assert rows[0]["bpm"] == 128.0
+
+
+def test_duration_range(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, duration=":1")
+    assert len(rows) == 1
+    assert rows[0]["path"] == P_HAT
+
+
+def test_key_filter(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, key="am")
+    assert len(rows) == 1
+    assert rows[0]["path"] == P_HAT
+
+
+def test_format_filter(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, file_format="flac")
+    assert len(rows) == 1
+
+
+def test_tag_filter_and(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, tag=["drums"])
+    paths = {r["path"] for r in rows}
+    assert paths == {P_KICK, P_HAT}
+
+    rows = _run(db, tag=["drums", "kick"])
+    assert len(rows) == 1
+    assert rows[0]["path"] == P_KICK
+
+
+def test_root_filter(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, root=ROOT_A)
+    assert len(rows) == 2
+    rows = _run(db, root=ROOT_B)
+    assert len(rows) == 1
+
+
+def test_text_fts(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+
+    rows = _run(db, text="dusty")
+    assert len(rows) == 1
+    assert rows[0]["path"] == P_SYNTH
+
+    rows = _run(db, text="punchy")
+    assert len(rows) == 1
+    assert rows[0]["path"] == P_KICK
+
+    rows = _run(db, text="synth")
+    paths = {r["path"] for r in rows}
+    assert paths == {P_SYNTH}
+
+
+def test_limit(tmp_path):
+    db = tmp_path / "q.db"
+    _seed(str(db))
+    rows = _run(db, limit=1)
+    assert len(rows) == 1
+
+
+def test_no_index_returns_error(tmp_path, capsys):
+    args = _Args(db=str(tmp_path / "nope.db"))
+    rc = query_cmd.run(args)
+    assert rc == 1
+
+
+def _run(db, **kwargs):
+    buf = io.StringIO()
+    args = _Args(db=str(db), output_format="json", **kwargs)
+    # capture to a buffer via the output arg path
+    out_file = str(db) + ".out.json"
+    args.output = out_file
+    rc = query_cmd.run(args)
+    assert rc == 0
+    import json
+    with open(out_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data if isinstance(data, list) else [data]


### PR DESCRIPTION
- new `acidcat index` walks a directory and upserts samples into a global SQLite db at ~/.acidcat/index.db; tracks scan_roots for multi-library use, skips unchanged files, prunes missing files
- new `acidcat query` filters by bpm/key/duration/tag/text/root with FTS5 under the hood
- new `acidcat-mcp` stdio server exposes 16 MCP tools: fast metadata discovery (search_samples, get_sample, locate_sample, list_*, index_stats, find_compatible), slow librosa analysis (find_similar, analyze_sample, detect_bpm_key), index management (reindex, reindex_features), and tagging (tag_sample, describe_sample). Tool descriptions carry Fast./SLOW. prefixes plus readOnlyHint/ destructiveHint annotations so LLM clients self-select
- new `core/camelot.py` for harmonic mixing: parse common key notations, compute Camelot wheel neighbors, expand enharmonic spellings
- key parsing: strip octave from SMPL/ACID root_note so key column holds "C" not "C4"; treat MIDI 0 as unset (was producing "C-1"); extend enharmonic map to cover Cb and Fb; new parse_key_from_path walks filename + parent folders
- bpm filename parser uses zero-width lookarounds so `_03_126_A#` finds 126 not 03; fix off-by-one where "C major" was classified as Cm
- walker skips `._*` sidecars and .DS_Store/Thumbs.db/desktop.ini
- `_librosa_available` uses importlib.util.find_spec to avoid cold-starting numba on every index_stats call (60s hang -> 3ms)
- `find_compatible` auto-infers loop vs one-shot from duration + acid_beats and filters to target's kind by default
- new `[mcp]` optional dep group + `acidcat-mcp` console script
- README updated with index/query/MCP sections; 70 new tests