### PR TITLE
add architecture and DSP internals docs, lock in acid_beats=0 handling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,594 @@
+# Architecture
+
+How acidcat is wired together: the data flow from a file on disk to a query
+result on stdout or over MCP.
+
+Last updated: 2026-04-23
+
+---
+
+## High-level picture
+
+```
+                            ┌─────────────────────┐
+                            │  sample files on    │
+                            │  disk               │
+                            └──────────┬──────────┘
+                                       │ walker + mtime cache
+                                       ▼
+            ┌───────────────────────────────────────────────┐
+            │  format detection  (commands/info._detect_fmt) │
+            └─┬──────────────┬──────────────┬──────────────┬─┘
+              │              │              │              │
+              ▼              ▼              ▼              ▼
+          core/riff.py   core/aiff.py   core/midi.py   core/serum.py
+         core/tagged.py  (mutagen wrap for mp3/flac/ogg/m4a)
+                                       │
+                                       ▼
+            ┌───────────────────────────────────────────────┐
+            │  core/detect.py  (filename + librosa + verify)│
+            │  core/features.py  (optional feature vector)  │
+            └──────────┬────────────────────────────────────┘
+                       │ upsert_sample / upsert_tags / upsert_features
+                       ▼
+            ┌───────────────────────────────────────────────┐
+            │  SQLite index  (~/.acidcat/index.db)          │
+            │  samples, tags, descriptions, samples_fts,    │
+            │  features, scan_roots, meta                   │
+            └──────────┬────────────────────────────────────┘
+                       │ query API
+                       ▼
+            ┌──────────────────┬────────────────────────────┐
+            │  CLI transport   │  MCP transport             │
+            │  commands/*.py   │  mcp_server.py             │
+            └──────────────────┴────────────────────────────┘
+```
+
+Four layers, each replaceable: scanner, parsers, index, transports. The DSP
+subsystem (`detect.py`, `features.py`) hangs off the parser layer as an
+optional extension. Transports share the same query API so that
+`acidcat query --bpm 120:140` and the MCP `search_samples` tool run the
+same SQL against the same schema.
+
+---
+
+## Source tree map
+
+```
+src/acidcat/
+  __main__.py            entrypoint (python -m acidcat)
+  cli.py                 argparse wiring + dispatch
+  commands/              user-facing command handlers (one per verb)
+    info.py              single-file metadata dump
+    scan.py              batch directory walk with CSV output
+    chunks.py            RIFF chunk walker
+    survey.py            chunk frequency counter
+    dump.py              hex-dump chunk payload
+    detect.py            librosa BPM/key estimator
+    features.py          feature extraction to CSV
+    similar.py           similarity + clustering over features CSV
+    search.py            legacy CSV text search
+    index.py             global SQLite index management
+    query.py             filter the SQLite index
+  core/                  reusable library layer
+    riff.py              RIFF/WAV chunk parser
+    aiff.py              AIFF/IFF chunk parser
+    midi.py              MIDI meta parser
+    serum.py             XferJson preset parser
+    tagged.py            mutagen wrapper (mp3/flac/ogg/m4a)
+    detect.py            filename parsing + librosa + validation pipeline
+    features.py          librosa feature vector extractor
+    camelot.py           Camelot wheel math + enharmonic normalization
+    index.py             SQLite schema, upsert, query
+    formats.py           output formatters (table/json/csv)
+  util/
+    midi.py              MIDI note number / name helpers
+    csv_helpers.py       pandas shim for features commands
+    stdin.py             piped-input detection + tempfile landing
+    deps.py              optional-dependency error messages
+  mcp_server.py          MCP tool definitions + dispatch
+```
+
+Two hard rules keep the tree healthy:
+
+1. `commands/` depends on `core/`. `core/` never imports from `commands/`.
+2. Anything that holds a DB connection is in `core/index.py` or `mcp_server.py`.
+   Command handlers receive a connection, they never manage one.
+
+---
+
+## Data flow: indexing a directory
+
+`acidcat index DIR` or its MCP equivalent `reindex({path})`.
+
+```
+caller                    walker                parser              index
+  │                         │                      │                   │
+  │  acidcat index DIR      │                      │                   │
+  │────────────────────────▶│                      │                   │
+  │                         │  os.walk(DIR)        │                   │
+  │                         │──────────────┐       │                   │
+  │                         │              │       │                   │
+  │                         │   for each file:     │                   │
+  │                         │              │       │                   │
+  │                         │  mtime / size │      │                   │
+  │                         │  diff against DB     │                   │
+  │                         │              │       │                   │
+  │                         │  if changed: │       │                   │
+  │                         │──────────────┼──────▶│                   │
+  │                         │              │       │  detect format    │
+  │                         │              │       │  parse chunks     │
+  │                         │              │       │  extract metadata │
+  │                         │              │       │                   │
+  │                         │◀─────────────┼───────│  dict of fields   │
+  │                         │              │       │                   │
+  │                         │  upsert_sample(row) ─┼──────────────────▶│
+  │                         │                      │                   │
+  │                         │  (optional) extract_features             │
+  │                         │  upsert_features ────┼──────────────────▶│
+  │                         │                      │                   │
+  │  summary counts         │                      │                   │
+  │◀────────────────────────│                      │                   │
+```
+
+Skip-if-unchanged uses `get_sample_stat(conn, path)` to pull the stored
+`(mtime, size)` pair and compares against `os.stat`. If both match, the
+walker calls `touch_last_seen` and moves on. This is what makes reindexing
+idempotent and fast on the common case of unchanged libraries.
+
+Deletions are detected as a separate pass: after the walk, any row whose
+`last_seen_at` is older than the walk's start time and whose `scan_root`
+matches the one we just walked gets pruned.
+
+---
+
+## Data flow: a query
+
+`acidcat query --bpm 120:140 --key F` and MCP `search_samples` take the
+same path through the layers.
+
+```
+caller                         query API                       SQLite
+  │                                │                              │
+  │  filters: bpm=120-140, key=F   │                              │
+  │───────────────────────────────▶│                              │
+  │                                │  compatible_keys(key="F")    │
+  │                                │  -> {"F", "C", "A#", "Dm"}   │
+  │                                │                              │
+  │                                │  build WHERE clause          │
+  │                                │                              │
+  │                                │  SELECT * FROM samples       │
+  │                                │   WHERE bpm BETWEEN ?        │
+  │                                │     AND (key IN (?,?,?,?))   │
+  │                                │   LIMIT N                    │
+  │                                │────────────────────────────▶│
+  │                                │                              │
+  │                                │◀────────────────────────────│
+  │                                │  rows                        │
+  │  list[dict]                    │                              │
+  │◀───────────────────────────────│                              │
+```
+
+Enharmonic expansion happens at the SQL boundary. If a user asks for `F`,
+the query layer expands that to the set of enharmonic spellings that exist
+in the DB and uses `IN` instead of `=`. This is why the
+`enharmonic_spellings` function in `core/camelot.py` exists as a public
+helper.
+
+---
+
+## The two transports
+
+The CLI and MCP server are thin shells over the same core API. Neither
+implements domain logic; both call into `core/`.
+
+### CLI (commands/*.py)
+
+Each command module follows the same pattern:
+
+```python
+def register(subparsers):
+    p = subparsers.add_parser("info", help="...")
+    p.add_argument("target")
+    p.add_argument("-f", "--format", choices=["table","json","csv"])
+    p.set_defaults(func=run)
+
+def run(args):
+    # args parsed, call into core/
+    rec = _info_wav(args.target, args)
+    output(rec, fmt=args.format)
+    return 0
+```
+
+`cli.py` discovers command modules, calls `register()` on each, parses, and
+dispatches to `args.func(args)`. Output formatting goes through
+`core/formats.py` so every verb can emit table/json/csv on the same flag.
+
+### MCP (mcp_server.py)
+
+Each tool is registered via `_tool(name, description, input_schema,
+handler, annotations)`. The handlers call into the same `core/` functions
+as the CLI counterparts, so no logic is duplicated. For example:
+
+```
+CLI:   acidcat query --bpm 120:140 --key F --json
+MCP:   search_samples({ bpm_min: 120, bpm_max: 140, key: "F" })
+```
+
+Both resolve to the same SQL SELECT generated by the same Python code.
+The surface has one rule: MCP tool input schemas never reshape the core
+function's arguments. If you find yourself translating between two
+parameter conventions, push the rename down into the core API.
+
+### Why the symmetry matters
+
+- No drift between transports. Bug in one surface is a bug in the core.
+- LLM-suggested shell pipelines can be copy-pasted back into the CLI.
+- Shell pipelines can be suggested back through the LLM.
+- Documentation writes itself: one example illustrates both surfaces.
+
+### Current gap
+
+The MCP server opens a fresh SQLite connection on every tool call
+(`_get_conn`). For a small DB this is fast, but two observations:
+
+1. `index_stats` has been observed timing out at 60s. Fresh-connection
+   cost isn't that high for SQLite, so the timeout is more likely a
+   symptom of a specific aggregation query rather than connection setup.
+   Worth profiling the query itself with a warm connection before
+   attributing the cost to reopen.
+2. Long-running agents that make many rapid MCP calls would benefit from
+   a long-lived connection or a small pool. Not a correctness issue,
+   just a perf improvement.
+
+---
+
+## The SQLite schema
+
+One DB at `~/.acidcat/index.db`. WAL journaling, foreign keys on. Schema
+version tracked in the `meta` table.
+
+### `samples` table
+
+Primary table. One row per indexed file. Immutable facts from parsers,
+plus bookkeeping.
+
+```sql
+CREATE TABLE samples (
+    path             TEXT PRIMARY KEY,
+    scan_root        TEXT,
+    mtime            REAL,
+    size             INTEGER,
+    format           TEXT,       -- wav, aiff, mp3, flac, ogg, m4a, midi, serum
+    duration         REAL,
+    bpm              REAL,
+    key              TEXT,       -- "Am", "C#", "F", etc. (sharps preferred)
+    title            TEXT,
+    artist           TEXT,
+    album            TEXT,
+    genre            TEXT,
+    comment          TEXT,
+    acid_beats       INTEGER,    -- from ACID chunk
+    root_note        INTEGER,    -- MIDI note, from smpl or acid chunk
+    sample_rate      INTEGER,
+    channels         INTEGER,
+    bits_per_sample  INTEGER,
+    chunks           TEXT,       -- comma-separated chunk IDs for forensic queries
+    indexed_at       REAL,
+    last_seen_at     REAL
+);
+
+CREATE INDEX idx_samples_bpm       ON samples(bpm);
+CREATE INDEX idx_samples_key       ON samples(key);
+CREATE INDEX idx_samples_duration  ON samples(duration);
+CREATE INDEX idx_samples_format    ON samples(format);
+CREATE INDEX idx_samples_scan_root ON samples(scan_root);
+```
+
+Design notes:
+
+- Path is the primary key. Paths are normalized with forward slashes
+  regardless of OS (`normalize_path` in `index.py`). This keeps Windows
+  and Unix paths comparable.
+- The `chunks` column stores a CSV of chunk IDs seen in the file. It's
+  denormalized on purpose. Forensic queries like "show me all files with
+  a `bext` chunk" are much cheaper against a text column with `LIKE
+  '%bext%'` than a proper chunks junction table would be, and the data
+  is low-volume per row.
+- `root_note` is a MIDI note number (0-127). This is what ACID and SMPL
+  chunks natively store.
+- `acid_beats` is the `beats` field from the ACID chunk. Combined with
+  `bpm` it gives loop length in beats, which is a reliable loop-vs-one-shot
+  signal for files that have ACID metadata.
+
+### `tags` junction
+
+```sql
+CREATE TABLE tags (
+    path TEXT,
+    tag  TEXT,
+    PRIMARY KEY (path, tag)
+);
+CREATE INDEX idx_tags_tag ON tags(tag);
+```
+
+User-assigned tags. Many-to-many. No cascade from `samples` deletion
+because tags are user intent and outlive the file lifecycle (though
+orphans are cleaned on reindex).
+
+### `descriptions` table
+
+```sql
+CREATE TABLE descriptions (
+    path        TEXT PRIMARY KEY,
+    description TEXT
+);
+```
+
+One free-text description per sample. User-writable. Populated either
+manually by the user, or (in the LLM-era workflow) by an agent reading
+the analysis + metadata and writing back a natural-language description.
+
+### `samples_fts` virtual table (FTS5)
+
+```sql
+CREATE VIRTUAL TABLE samples_fts USING fts5(
+    path, title, artist, album, genre, comment, description, tags,
+    tokenize='porter'
+);
+```
+
+Full-text search index. Populated from the other tables via
+`rebuild_fts_for_path`. Porter stemming so "dusty" matches "dust". The
+`tags` column is a space-joined flat string of all tags on the row, which
+lets a single FTS query match across structural metadata + descriptive
+text + user tags in one shot.
+
+### `features` blob table
+
+```sql
+CREATE TABLE features (
+    path             TEXT PRIMARY KEY,
+    features_json    TEXT,       -- JSON blob, 50+ float fields
+    features_version INTEGER,    -- bump when extractor changes
+    extracted_at     REAL
+);
+```
+
+Optional. Populated by `acidcat index --features` or the MCP
+`reindex_features` tool. Stored as JSON on purpose: the column schema
+for a feature vector changes as librosa versions and extractor choices
+evolve. JSON preserves whatever shape was written, and a version number
+per row lets future code detect stale vectors and trigger recompute.
+
+### `scan_roots` table
+
+```sql
+CREATE TABLE scan_roots (
+    path             TEXT PRIMARY KEY,
+    added_at         REAL,
+    last_indexed_at  REAL,
+    file_count       INTEGER
+);
+```
+
+One row per directory ever passed to `acidcat index`. Tracks provenance:
+when a sample row's `scan_root` points here, the user can remove the
+whole root in one call.
+
+### `meta` table
+
+```sql
+CREATE TABLE meta (
+    k TEXT PRIMARY KEY,
+    v TEXT
+);
+```
+
+Key-value store. Currently just `schema_version`. Reserved for future
+use: feature extractor version, last global reindex timestamp, etc.
+
+---
+
+## Format detection dispatch
+
+`commands/info.py:_detect_format` chooses the parser for a file by magic
+bytes first, extension second:
+
+```
+is_midi(filepath)         -> "midi"    (looks for "MThd")
+is_aiff(filepath)         -> "aiff"    (looks for "FORM"/"AIFF"/"AIFC")
+is_serum_preset(filepath) -> "serum"   (looks for "XferJson" prefix)
+ext in (.aif, .aiff)      -> "aiff"
+ext in (.mid, .midi)      -> "midi"
+ext == .serumpreset       -> "serum"
+is_tagged_format(filepath)-> "tagged"  (mutagen can read it)
+default                   -> "wav"
+```
+
+Order matters: magic-byte sniffers run first so a misnamed file still
+reaches the right parser. The `.wav` fallback is safe because RIFF's
+`RIFF` header is checked inside the WAV parser; non-RIFF files that
+reach that path produce an empty result rather than crashing.
+
+Adding a new format is a three-step process:
+1. Add a `core/<format>.py` module with `is_<format>`, `parse_<format>`, and a documented return dict.
+2. Extend `_detect_format` to route to it.
+3. Add an `_info_<format>(filepath, args)` builder in `commands/info.py`.
+4. Add a doc under `docs/formats/<format>.md`.
+
+---
+
+## The validation pipeline (core/detect.py)
+
+The most subtle logic in the project, worth calling out because it's the
+difference between a library with plausible BPM/key values and a library
+with correct ones.
+
+```
+filename_bpm  = parse_bpm_from_filename(path)    # regex extraction
+detected_bpm  = librosa.beat.tempo(...)          # audio analysis
+
+final_bpm, source = validate_and_improve_bpm(detected_bpm, filename_bpm)
+```
+
+Rules inside `validate_and_improve_bpm`:
+
+```
+filename_bpm is None              -> use detected, source="detected"
+detected_bpm is None              -> use filename, source="filename"
+detected not in [60, 200]         -> reject detected, use filename
+|detected - filename| <= 20       -> accept detected, source="detected"
+|detected*2  - filename| <= 20    -> use detected*2, source="corrected"
+|detected/2  - filename| <= 20    -> use detected/2, source="corrected"
+|detected*1.5 - filename| <= 20   -> use detected*1.5, source="corrected"
+|detected/1.5 - filename| <= 20   -> use detected/1.5, source="corrected"
+else                              -> use filename, source="filename"
+```
+
+This catches the two most common librosa failure modes:
+
+- **Octave doubling**. librosa reports half-time or double-time when the
+  track emphasizes a different metric level (e.g. a 140 BPM track with
+  strong 70 BPM accents). If the filename says 140 and librosa says 70,
+  the `*2` rule fires and we store 140.
+- **Triplet feel**. Swing or triplet-heavy material can pull the
+  estimate toward `2/3x` or `1.5x` of the true tempo. The 1.5 rules
+  catch these.
+
+Key detection has a simpler pipeline (currently `argmax` of median
+chroma) but a similar pattern: audio-estimated key is compared against
+a filename-parsed key, and they're reconciled. See
+`dsp/chroma_and_key.md` for the signal-processing details and a
+proposed upgrade to Krumhansl-Schmuckler.
+
+### `source` fields are the confidence channel
+
+Every field that can come from multiple origins carries a source tag:
+
+```
+bpm_source  = "chunk" | "detected" | "filename" | "corrected" | "oneshot" | "failed"
+key_source  = "chunk" | "detected" | "filename" | "failed"
+```
+
+Callers can filter by source to get high-confidence results only:
+
+```python
+# only use chunk-authored BPM (ACID metadata)
+SELECT * FROM samples WHERE bpm_source = "chunk"
+```
+
+**Current gap**: these source fields are computed inside `detect.py` but
+aren't plumbed through into the `samples` table columns yet. Adding
+`bpm_source` and `key_source` columns (plus a `confidence` float) is on
+the near-term work list.
+
+---
+
+## The optional-dependency story
+
+Core metadata reading has zero non-stdlib dependencies. `pip install
+acidcat` gives you RIFF/AIFF/MIDI/Serum out of the box.
+
+Four extras add capability:
+
+```
+[tags]      mutagen               MP3/FLAC/OGG/M4A support
+[analysis]  librosa, numpy, scipy BPM/key detection, feature extraction
+[ml]        pandas, scikit-learn  similarity + clustering
+[mcp]       mcp SDK               MCP server binary
+```
+
+The MCP server registers analysis-backed tools even when librosa isn't
+installed, but the handlers return a structured error message explaining
+the install step. This is deliberate: it lets the LLM discover what's
+possible and surface the fix to the user, rather than hiding the tool
+entirely.
+
+The check is implemented as:
+
+```python
+def _librosa_available():
+    # cheap: does python see librosa + numpy on the import path?
+    return (importlib.util.find_spec("librosa") is not None
+            and importlib.util.find_spec("numpy") is not None)
+```
+
+`importlib.util.find_spec` avoids actually importing librosa on every
+tool call, which is crucial because the import itself takes several
+hundred milliseconds cold.
+
+---
+
+## Known performance characteristics
+
+**Fast path (SQLite-backed tools)**. All `list_*`, `search_samples`,
+`get_sample`, `locate_sample`, `find_compatible`: sub-100ms on indexes
+up to tens of thousands of files. FTS queries on `samples_fts` are
+well-indexed by FTS5 internals.
+
+**Slow path (librosa tools)**. `analyze_sample`, `detect_bpm_key`,
+`find_similar` when features aren't pre-indexed: 0.5-10s per file
+warm. First call after server start can be much slower because numba
+and scipy JIT-compile hot paths on first use.
+
+**Bulk operations**. `reindex` walks a directory. Rough ceiling is
+limited by filesystem stat() throughput and file-open rate, not by
+Python. On an NVMe SSD, expect a few thousand files per second for
+metadata-only indexing (no `--features`).
+
+**Cold librosa**. First call can take 60s+ because of numba JIT
+compilation. A pre-warm pattern on server startup would cut
+time-to-first-analysis dramatically:
+
+```python
+# spin this up at server launch, non-blocking
+def _prewarm_analysis():
+    import librosa, numpy as np
+    silence = np.zeros(22050, dtype=np.float32)
+    librosa.beat.beat_track(y=silence, sr=22050)
+    librosa.feature.chroma_cqt(y=silence, sr=22050)
+```
+
+---
+
+## Extension points
+
+Three clean places to extend without touching existing code:
+
+### New parser
+
+Add `core/<format>.py`. Provide `is_<format>(path) -> bool` and
+`parse_<format>(path) -> dict`. Add routing in
+`commands/info.py:_detect_format`.
+
+### New command
+
+Add `commands/<verb>.py`. Implement `register(subparsers)` and
+`run(args)`. Commands are auto-discovered by `cli.py`.
+
+### New MCP tool
+
+Add a `_tool(...)` registration in `mcp_server.py`. The handler should
+call into `core/` rather than duplicate logic. If the tool needs a new
+primitive that doesn't exist in `core/` yet, add the primitive to
+`core/` first and call it from both the MCP handler and any CLI
+equivalent.
+
+---
+
+## Non-goals (architectural)
+
+These are deliberately not part of the system and shouldn't be added
+without re-reading the direction doc:
+
+- No daemon process, no long-running server beyond what MCP requires.
+- No background indexing. Indexing runs when the user asks for it.
+- No cloud sync or remote DB.
+- No per-user auth or multi-user permissions.
+- No GUI layer.
+- No workflow verbs that fuse multiple primitives.
+
+The composable primitives are the whole product. Anything that looks
+like "acidcat decides how to use itself" belongs in the client, which in
+the MCP case is the LLM agent.

--- a/docs/dsp/camelot_wheel.md
+++ b/docs/dsp/camelot_wheel.md
@@ -1,0 +1,490 @@
+# Camelot Wheel
+
+Harmonic compatibility math: why two keys sound good together, how the
+Camelot notation encodes that, and how `core/camelot.py` implements the
+lookup.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+The Camelot wheel is a DJ-friendly renaming of the circle of fifths. It
+assigns every major and minor key a code of the form `NL` where `N` is
+a number 1-12 and `L` is either `A` (minor) or `B` (major). Two keys are
+harmonically compatible when their codes are close on the wheel under a
+specific set of relations: same code, same number (relative major/minor),
+adjacent number same letter (perfect 4th or 5th).
+
+Why the notation exists: most DJs don't want to reason about "Eb major's
+subdominant is Ab major and its relative is Cm." They want to see `5B`
+and know that `5A`, `4B`, and `6B` are safe.
+
+---
+
+## The circle of fifths, briefly
+
+Western tonal music uses 12 pitch classes numbered 0-11:
+
+```
+pc 0  C
+pc 1  C#  (Db)
+pc 2  D
+pc 3  D#  (Eb)
+pc 4  E
+pc 5  F
+pc 6  F#  (Gb)
+pc 7  G
+pc 8  G#  (Ab)
+pc 9  A
+pc 10 A#  (Bb)
+pc 11 B
+```
+
+The circle of fifths orders these so each neighbor is a perfect fifth
+(7 semitones) away:
+
+```
+C -> G -> D -> A -> E -> B -> F# -> C# -> G# -> D# -> A# -> F -> C
+```
+
+Two keys feel harmonically close when they share many of the same notes
+in their scales. A perfect-fifth relationship shares 6 of 7 scale tones,
+which is why it's the canonical "safe" modulation. A perfect-fourth
+relationship (the inverse, also 6 shared tones) is equally safe. The
+relative minor of a major key (the key starting on its 6th scale degree)
+shares all 7 notes, just with a different tonic. That's 3 of the 4 most
+useful compatibility relations right there.
+
+---
+
+## The Camelot numbering
+
+Camelot walks the circle of fifths starting from A minor / C major and
+assigns sequential numbers. A and B labels distinguish minor (inner ring)
+from major (outer ring).
+
+```
+            1B (B maj)
+         12B      2B
+   (E maj)        (F# maj)
+
+ 11B                    3B
+(A maj)              (Db maj)
+
+10B    inner ring is       4B
+(D maj)   A (minor)    (Ab maj)
+          outer ring is
+ 9B          B (major)        5B
+(G maj)                   (Eb maj)
+
+   8B                    6B
+(C maj)              (Bb maj)
+         7B
+      (F maj)
+```
+
+And for the minor ring, same wheel, same numbers, different tonics:
+
+```
+            1A (Abm / G#m)
+         12A      2A
+   (C#m)           (D#m / Ebm)
+
+ 11A                    3A
+(F#m)                   (Bbm)
+
+10A                      4A
+(Bm)                     (Fm)
+
+ 9A                       5A
+(Em)                     (Cm)
+
+   8A                    6A
+  (Am)                  (Gm)
+         7A
+       (Dm)
+```
+
+Same number means relative major/minor. `8A` (Am) and `8B` (C) share all
+7 scale tones. That's why the "letter swap" relation is compatible.
+
+---
+
+## Compatibility rules
+
+For any code `NL` (say `8A`, which is A minor), the harmonically
+compatible set is:
+
+| relation | code | example for 8A |
+|----------|------|----------------|
+| same key | `NL` | `8A` (A minor) |
+| relative | `N{swap L}` | `8B` (C major) |
+| down one | `(N-1)L` | `7A` (D minor) |
+| up one | `(N+1)L` | `9A` (E minor) |
+
+Wrapping: going down from `1A` gives `12A`, going up from `12A` gives `1A`.
+The wheel is cyclic.
+
+The down-one / up-one relations correspond to perfect fourth and perfect
+fifth modulations, respectively. Why that's true mechanically: each step
+on the Camelot wheel is a perfect fifth in pitch-class space (7 semitones
+modulo 12). Going from `8A` (A minor) up to `9A` gives E minor, whose
+tonic E is 7 semitones above A. Going down to `7A` gives D minor, whose
+tonic D is 5 semitones above A (which is the same as 7 semitones below
+via octave wrap, i.e. a perfect fourth down or a perfect fifth up
+depending on register).
+
+This produces four compatible keys per input. Some DJs expand further
+(diagonals, energy boost, mood change) but acidcat currently implements
+the core four.
+
+---
+
+## Implementation in `core/camelot.py`
+
+### The pitch-class map
+
+```python
+_PITCH_CLASS = {
+    "c": 0, "b#": 0,
+    "c#": 1, "db": 1,
+    "d": 2,
+    "d#": 3, "eb": 3,
+    "e": 4, "fb": 4,
+    "f": 5, "e#": 5,
+    "f#": 6, "gb": 6,
+    "g": 7,
+    "g#": 8, "ab": 8,
+    "a": 9,
+    "a#": 10, "bb": 10,
+    "b": 11, "cb": 11,
+}
+```
+
+Every enharmonic spelling maps to the same integer. `Cb` -> 11 (B),
+`B#` -> 0 (C), `Fb` -> 4 (E), `E#` -> 5 (F). This is where enharmonic
+equivalence gets resolved in the lookup direction.
+
+### The Camelot map
+
+```python
+_CAMELOT_MAP = {
+    # major (B ring)
+    (11, 0): "1B",   # B
+    (6,  0): "2B",   # F#
+    (1,  0): "3B",   # Db
+    (8,  0): "4B",   # Ab
+    (3,  0): "5B",   # Eb
+    (10, 0): "6B",   # Bb
+    (5,  0): "7B",   # F
+    (0,  0): "8B",   # C
+    (7,  0): "9B",   # G
+    (2,  0): "10B",  # D
+    (9,  0): "11B",  # A
+    (4,  0): "12B",  # E
+    # minor (A ring)
+    (8,  1): "1A",   # G#m
+    (3,  1): "2A",   # Ebm
+    (10, 1): "3A",   # Bbm
+    (5,  1): "4A",   # Fm
+    (0,  1): "5A",   # Cm
+    (7,  1): "6A",   # Gm
+    (2,  1): "7A",   # Dm
+    (9,  1): "8A",   # Am
+    (4,  1): "9A",   # Em
+    (11, 1): "10A",  # Bm
+    (6,  1): "11A",  # F#m
+    (1,  1): "12A",  # C#m
+}
+```
+
+Reading the pattern: on the major ring, each entry is 7 pitch classes
+higher (mod 12) than the previous, which is the fifth-by-fifth stepping.
+Same for the minor ring. The ring offset between a major code and its
+relative minor is 9 pitch classes: C (pc 0) -> Am (pc 9), which is a
+minor 6th up or a major 3rd down, the standard relative-minor
+relationship.
+
+### Parsing input keys
+
+`parse_key` is intentionally lenient. It accepts:
+
+- `"C"`, `"Cm"`, `"C#m"`, `"Db"`
+- `"A minor"`, `"F#min"`, `"Bb maj"`
+- Camelot codes directly: `"5A"`, `"12B"`
+- MIDI-note-ish spellings: `"C4"` (treated as C, octave ignored)
+
+The regex is:
+
+```python
+r"^\s*([A-Ga-g])([#b]?)\s*(m|min|minor|maj|major|M)?\s*(\d+)?\s*$"
+```
+
+Groups:
+
+1. Root letter (A-G)
+2. Accidental (# or b, optional)
+3. Mode suffix (m/min/minor = minor, maj/major/M = major)
+4. Trailing octave digit (ignored, exists to eat "C4" style notations)
+
+Absence of a mode suffix defaults to major. This matches common sample
+pack convention where "F" means F major unless explicitly marked `Fm`.
+
+### Camelot neighbors
+
+Given a code, compute the compatible set:
+
+```python
+def camelot_neighbors(code):
+    num, letter = _split_camelot(code)   # "8A" -> (8, "A")
+    other = "B" if letter == "A" else "A"
+    down = 12 if num == 1 else num - 1
+    up   = 1  if num == 12 else num + 1
+    return [
+        f"{num}{letter}",    # same
+        f"{num}{other}",     # relative
+        f"{down}{letter}",   # perfect 4th
+        f"{up}{letter}",     # perfect 5th
+    ]
+```
+
+The wrap logic at `num == 1` and `num == 12` is where the cyclic nature
+of the wheel shows up. `12A + 1 -> 1A`, not `13A`.
+
+### Turning neighbors back into pretty names
+
+`compatible_keys(key_str)` returns a set of canonical names like
+`{"Am", "C", "Dm", "Em"}`. It does the inverse lookup: for each
+neighbor code, find the `(pc, mode)` tuple in `_CAMELOT_MAP`, then
+render that via `pitch_class_to_name`:
+
+```python
+def pitch_class_to_name(pc, mode):
+    name = _NOTE_NAMES_SHARP[pc % 12]
+    return name + ("m" if mode == 1 else "")
+```
+
+Always renders to sharps. This is the "sharps preferred" policy used
+throughout the index.
+
+---
+
+## Enharmonic normalization policy
+
+Flats and sharps that name the same pitch class are equivalent
+harmonically. `Db == C#`, `Eb == D#`, `Gb == F#`, etc. Two rarely-used
+equivalences: `Cb == B` and `Fb == E` (these are enharmonic but not
+accidental-less, so they appear in real sample pack filenames only
+occasionally).
+
+### At ingest (parse_bare_key_token in core/detect.py)
+
+When parsing a key out of a filename, flats are normalized to sharps
+using a lookup table:
+
+```python
+flat_to_sharp = {"Db": "C#", "Eb": "D#", "Gb": "F#",
+                 "Ab": "G#", "Bb": "A#",
+                 "Cb": "B",  "Fb": "E"}
+```
+
+This gives the DB consistent spellings (all sharps) so a simple
+equality filter works.
+
+**However**, if the key comes from a chunk (SMPL/ACID) or from the
+filename via `parse_key_from_filename` (which preserves the original),
+the spelling may end up in the DB as a flat. This is by design: we
+don't want to destroy user intent at ingest time.
+
+### At query time (enharmonic_spellings in core/camelot.py)
+
+To prevent the DB storing `F#` from missing a user query for `Gb`, the
+query layer expands the input into every equivalent spelling before
+hitting SQL:
+
+```python
+def enharmonic_spellings(key_str):
+    parsed = parse_key(key_str)
+    if parsed is None:
+        return set()
+    pc, mode = parsed
+    canonical = _NOTE_NAMES_SHARP[pc]
+    suffix = "m" if mode == 1 else ""
+    out = {name + suffix for name in _ENHARMONICS.get(canonical, {canonical})}
+    out.add(str(key_str).strip())
+    return out
+```
+
+So a filter for `Gb` becomes SQL:
+
+```sql
+WHERE key IN ("Gb", "F#")
+```
+
+And a filter for `F#` becomes:
+
+```sql
+WHERE key IN ("F#", "Gb")
+```
+
+Both match the same DB rows.
+
+### The two-layer policy
+
+| layer | behavior | why |
+|-------|----------|-----|
+| ingest | normalize flats to sharps when parsing bare tokens | keeps the DB clean |
+| chunk/filename | preserve original spelling | don't destroy intent |
+| query | expand enharmonics before SQL | match regardless of DB spelling |
+
+This is why `Cb` can legitimately appear in the key column (from
+`TAB - Kalimba Shot Cb.wav`) and still match a query for `B`: the query
+layer expands `B -> {B, Cb}` before hitting SQL.
+
+---
+
+## Why Camelot is what we use
+
+Alternatives considered:
+
+**Raw note names**: "F" and "Dm" are compatible, but that's only
+discoverable by running through the circle-of-fifths logic every time.
+Keeps the DB simple but pushes math into the query path.
+
+**Scale degree sets**: represent each key as a set of pitch classes and
+compute Jaccard overlap. More expressive (you can encode non-diatonic
+scales, modes), but slower, fuzzier, and loses the human-meaningful
+"compatible vs not" binary.
+
+**Just the circle of fifths**: sufficient for major-key work, but
+conflates relative majors and minors.
+
+Camelot gives us:
+
+- A single lookup table mapping `(pc, mode) -> 2-char code`.
+- Four neighbor codes per input, computable in constant time.
+- Direct interop with DJ tools that already speak Camelot (Mixed In Key,
+  Rekordbox, Serato, Traktor).
+- Enharmonic-agnostic matching via the pitch-class integer space.
+
+The tradeoff is that we hardcode diatonic tonality. Modal or non-tonal
+material (a drone in Phrygian, an atonal texture, a microtonal sample)
+doesn't fit. For those, raw feature-vector similarity via
+`find_similar` is the escape hatch.
+
+---
+
+## Edge cases worth knowing
+
+### C4, F3 in the DB
+
+Some sample tools embed the root note as a MIDI-note-with-octave
+(`C4`, `F3`, `B2`). These end up in the key column verbatim. The
+Camelot parser handles them by consuming the trailing digit in the
+regex (group 4) and treating the result as a major key on that pitch
+class.
+
+This is not ideal. The value is really a `root_note`, not a `key`.
+Future work: route octave-suffixed values into the `root_note` column
+at ingest and leave `key` empty in those cases. Until then, querying
+for `C` will match `C4` rows via the regex fallback.
+
+### Bare note vs mode-free key
+
+`F` is interpreted as F major. `F3` is interpreted as F major (octave
+ignored). There's no way to currently express "F as a root note, mode
+unknown." If we ever need that distinction, it goes in `root_note`.
+
+### Cb and B
+
+They're the same pitch class but different spellings. Preserved in the
+DB, normalized at query time. Users who want strict spelling matching
+would need an escape hatch flag; not currently exposed.
+
+### Modal content
+
+`Dorian on D` has the same pitch classes as `C major` and `A minor`.
+acidcat doesn't model modes, so a `D dorian` sample labeled `Dm` will
+be Camelot-compatible with `D minor` even though the parallel major of
+D (D major) would be more accurate from a modal standpoint. This is a
+limitation of the underlying model, not a bug in the parser.
+
+---
+
+## Test vectors for verification
+
+Useful for sanity-checking any change to the parser or lookup table.
+
+| input | parse_key | camelot | compatible_keys |
+|-------|-----------|---------|-----------------|
+| `"C"` | `(0, 0)` | `8B` | `{C, Am, F, G}` |
+| `"Am"` | `(9, 1)` | `8A` | `{Am, C, Dm, Em}` |
+| `"F#"` | `(6, 0)` | `2B` | `{F#, D#m, B, Db}` |
+| `"Gb"` | `(6, 0)` | `2B` | `{Gb, F#, D#m, Eb, B, Db}` (enharmonic expansion) |
+| `"Cb"` | `(11, 0)` | `1B` | `{B, Cb, G#m, E, F#}` |
+| `"8A"` | `(9, 1)` | `8A` | `{Am, C, Dm, Em}` (same as Am) |
+| `"C4"` | `(0, 0)` | `8B` | `{C, Am, F, G}` (octave ignored) |
+| `"Bbm"` | `(10, 1)` | `3A` | `{Bbm, A#m, Db, Abm, Ebm, D#m, G#m}` (enharmonic expansion) |
+
+When the direct neighbor and its enharmonic spelling both resolve, the
+`compatible_keys` output contains both. This is a feature, not a bug:
+the DB might contain either spelling and both should match.
+
+---
+
+## Proposed extensions
+
+None of these are implemented. Notes for future consideration.
+
+### Energy/mood shifts
+
+DJ literature defines two additional useful relations:
+
+- **Energy boost**: +7 on the wheel (up a whole step, same letter).
+  `8A -> 3A`. Pitches the key up a major second, common for set-rising
+  transitions.
+- **Mood change**: diagonal moves (e.g. `8A -> 9B`). Shifts major/minor
+  while also stepping the wheel, good for contrast.
+
+These could be exposed via an optional `extended: true` flag on
+`find_compatible`.
+
+### Semitone and tritone filters
+
+Some producers want "anything within 3 semitones" or "tritone-away
+only." These require different pitch-class math than the wheel. A
+separate `find_by_pc_distance` primitive would cover this without
+muddying Camelot.
+
+### Mode-aware scoring
+
+Real modal music (Phrygian flamenco, Dorian jazz) shares more tones
+with some keys than others. A full modal-scale Jaccard score would be
+more accurate for these cases but significantly more expensive. Would
+live as a separate primitive, not an override of Camelot.
+
+### Configurable BPM tolerance
+
+Current default is 6%, derived from the commonly accepted DJ rule of
+thumb that most tracks can be pitched ±6% without dramatic timbre
+artifacts. Could be a user preference in config, not just a per-call
+argument.
+
+---
+
+## References
+
+- **Camelot Wheel**: Mark Davis, "Harmonic Mixing." Original notation
+  introduced in the 1980s, popularized by Mixed In Key software in
+  the 2000s.
+- **Circle of Fifths**: standard Western music theory, treated in
+  Krumhansl's *Cognitive Foundations of Musical Pitch* (1990) for the
+  cognitive-psychology angle.
+- **Pitch class set theory**: Allen Forte, *The Structure of Atonal
+  Music* (1973). Not directly relevant to tonal Camelot work, but
+  useful background on pitch-class arithmetic.
+- **librosa chroma**: see `dsp/chroma_and_key.md` for how we get from
+  an audio waveform to a key estimate that can be fed into this
+  Camelot machinery.

--- a/docs/dsp/chroma_and_key.md
+++ b/docs/dsp/chroma_and_key.md
@@ -1,0 +1,508 @@
+# Chroma and Key Detection
+
+How acidcat goes from a raw audio waveform to a single letter like "Am"
+that can be fed into the Camelot wheel. Covers chroma vector theory, the
+STFT vs CQT variants librosa offers, the current argmax-based key
+estimator, and a proposed upgrade to Krumhansl-Schmuckler correlation.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+A **chroma vector** is a 12-dimensional representation of the pitch
+content in a short audio frame, one element per pitch class (C, C#, D,
+... B). Each element says roughly "how much energy is in this pitch
+class, regardless of octave."
+
+A 10-second guitar riff in C major played across three octaves collapses
+into a chroma matrix of shape `(12, T)` where `T` is the number of
+analysis frames. Summing or taking the median across the time axis
+gives a single 12-vector representing the pitch-class distribution of
+the whole clip.
+
+**Key detection** is the problem of taking that 12-vector and picking
+the major or minor key whose characteristic pitch-class distribution it
+most closely resembles. In principle this is a classification problem
+over 24 classes (12 major + 12 minor keys).
+
+---
+
+## The math
+
+### Pitch class as octave equivalence
+
+The perceptual-musical fact chroma exploits: the pitches C3 (~130 Hz),
+C4 (~261 Hz), and C5 (~523 Hz) all feel "the same note" to a listener.
+Mathematically, two frequencies are the same pitch class iff their
+ratio is a power of 2. Pitch class is frequency modulo octave.
+
+Formally, given frequency `f` in Hz, the continuous pitch class is
+
+```
+    pc(f) = (12 * log2(f / 440) + 69) mod 12
+```
+
+which maps 440 Hz (A4) to pitch class 9 (A). Pitch class is a real
+number in [0, 12); quantizing it to integers [0, 11] gives the 12
+semitones.
+
+### From spectrum to chroma
+
+Given a spectrum `X[k]` where `k` indexes frequency bins of center
+frequencies `f[k]`, the chroma vector `C[n]` for pitch class `n` is
+the sum of spectral energy at all frequencies that fall into pitch
+class `n`:
+
+```
+    C[n] = sum over k where round(pc(f[k])) == n  of  |X[k]|^2
+```
+
+In practice librosa uses a weighted mapping (not a hard bin assignment)
+so that bin energy is split across adjacent pitch classes based on
+distance. This is a triangular or Gaussian weighting in log-frequency
+space.
+
+### Why a 12-vector and not 12 separate analyses
+
+The elegance is that all 12 pitch classes can be computed in one pass
+over a single spectrum. The chroma operation is essentially a linear
+projection from the frequency axis onto a 12-dimensional log-folded
+axis. For a spectrum of length K, the operation is an `O(K)` sum.
+
+---
+
+## STFT vs CQT chroma
+
+librosa provides two chroma extractors with different frequency-domain
+backbones. acidcat uses both, in different places.
+
+### chroma_stft
+
+```
+chroma = librosa.feature.chroma_stft(y=y, sr=sr)
+```
+
+Backbone: short-time Fourier transform. Linearly-spaced frequency bins
+with constant bandwidth `sr / n_fft`. For `n_fft=2048, sr=44100`, bin
+spacing is ~21.5 Hz.
+
+The problem: musical pitch is logarithmic in frequency. A semitone at
+A2 (110 Hz) spans ~6 Hz, while a semitone at A6 (1760 Hz) spans
+~100 Hz. Linear STFT bins:
+
+- over-resolve the high octaves: dozens of bins inside a single
+  semitone, energy smeared across many tiny bins
+- under-resolve the low octaves: one or two bins per semitone, pitch
+  ambiguity at bass frequencies
+
+For key detection on pitched content this asymmetry hurts. A low bass
+note can get mis-classified because not enough frequency resolution
+exists to separate adjacent semitones.
+
+Where we use it: `core/features.py`, as part of the general feature
+vector used for similarity scoring. Here the bias is acceptable
+because all samples go through the same extractor and the feature is
+used comparatively, not as an absolute pitch-class reading.
+
+### chroma_cqt
+
+```
+chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=512)
+```
+
+Backbone: constant-Q transform. Log-spaced frequency bins with constant
+relative bandwidth. By construction, each semitone gets the same number
+of bins regardless of octave. Low bass and high treble are equally
+resolved in pitch.
+
+The tradeoff is computational cost: CQT is slower than FFT-based
+STFT. For per-file key detection this is fine; for real-time or
+per-frame work it matters.
+
+Where we use it: `core/detect.py:estimate_librosa_metadata`, as the
+backbone for the key estimator. Key detection is the one place we
+actually want absolute pitch-class accuracy, so the CQT's uniform
+semitone resolution matters.
+
+### Policy
+
+| use case | choice | why |
+|----------|--------|-----|
+| key detection | `chroma_cqt` | uniform semitone resolution, accurate at low frequencies |
+| feature vector for similarity | `chroma_stft` | cheaper, bias is acceptable when comparing like-to-like |
+
+---
+
+## Current key estimator (argmax of median chroma)
+
+In `core/detect.py`:
+
+```python
+chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=512)
+if chroma.size > 0:
+    chroma_median = np.median(chroma, axis=1)
+    if np.any(chroma_median > 0):
+        note_number = int(np.argmax(chroma_median))
+        note_names = ["C", "C#", "D", "D#", "E", "F",
+                      "F#", "G", "G#", "A", "A#", "B"]
+        detected_key = note_names[note_number]
+```
+
+Three steps:
+
+1. Compute a chroma matrix of shape `(12, T)` across the whole signal.
+2. Median-aggregate along the time axis to get a single 12-vector.
+3. Take the pitch class with the highest median energy as the key.
+
+### Why median, not mean
+
+Median is robust to transient spikes. A snare hit adds broadband
+energy that briefly pushes every chroma bin up; the median ignores
+those frames. Mean would be pulled toward the spikes. For a clip
+dominated by a few chord tones, median captures the sustained
+harmonic content and ignores the attack transients.
+
+### What this estimator gets right
+
+- Strongly tonic-heavy material (e.g. a bass loop that hammers the
+  root note).
+- Sustained pad sounds with clear harmonic content.
+- Simple melodies centered on the tonic.
+
+### What it gets wrong
+
+- **Mode**: it always returns a letter with no `m` suffix. A piece in
+  A minor and a piece in A major with the same tonic produce the same
+  argmax output. acidcat currently reconciles this by combining with
+  the filename-parsed key (which does carry mode), but if the filename
+  has no key, we return major by convention.
+- **Non-tonic heaviness**: a lot of modern music emphasizes the 5th
+  or 3rd scale degree as loudly as the tonic. A piece in A minor where
+  the E string drones can register as E, not A.
+- **Borrowed chords**: a clip that spends time outside its home key
+  (e.g. a funky passage with many extensions) can get dominant-pitch
+  artifacts.
+- **Inharmonic material**: drums, glitch textures, or noisy material
+  produce essentially uniform chroma. The argmax is then meaningless;
+  it picks whichever bin happens to edge out the others by tiny amounts.
+
+The 40% or so accuracy we'd estimate for this algorithm on a diverse
+sample library isn't bad for a one-line function, but there's a known
+upgrade path.
+
+---
+
+## Proposed upgrade: Krumhansl-Schmuckler
+
+Published in Krumhansl's *Cognitive Foundations of Musical Pitch*
+(1990). The core idea: build 24 "key profiles" (one per major and minor
+key), and pick the key whose profile best correlates with the
+observed chroma vector.
+
+### The profiles
+
+Each profile is a 12-vector indexed by pitch class, where the value at
+position `n` says "how characteristic is pitch class `n` of this key."
+Krumhansl's original weights were derived from probe-tone experiments
+(subjects rated how well each chromatic note fit a given tonal
+context).
+
+Canonical major profile (in C major, so pc 0 = C):
+
+```
+    C   C#   D    D#   E    F    F#   G    G#   A    A#   B
+   [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88]
+```
+
+Canonical minor profile (in A minor, so pc 9 = A is the tonic):
+
+```
+    A   A#   B    C    C#   D    D#   E    F    F#   G    G#
+   [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
+```
+
+Reading these: the tonic has the highest weight. The dominant (5th
+above tonic) and median (3rd above tonic) are next. Scale tones in
+general outrank chromatic non-scale tones.
+
+To get the profile for a different key, the vector is rotated. Major
+in G is the C major profile circularly shifted by 7 (G is 7 semitones
+above C). Minor in D is the A minor profile shifted by -7 (D is 7
+semitones below A, or equivalently 5 above).
+
+### The algorithm
+
+```
+1. Compute observed chroma vector x (length 12), time-averaged.
+2. For each of 24 keys k (12 major + 12 minor):
+     a. Build profile p_k by rotating the canonical major or minor
+        profile to put the tonic at the right pitch class.
+     b. Compute Pearson correlation r(x, p_k).
+3. Pick the key with the highest r.
+```
+
+Pearson correlation is the right similarity measure because it's
+scale-invariant and mean-invariant. The observed chroma has arbitrary
+absolute scale (depends on signal loudness); we only care about the
+pattern.
+
+### Why this outperforms argmax
+
+- **Uses the whole pattern**, not just the peak. Ambiguous cases where
+  two pitch classes have similar energy are resolved by checking which
+  overall distribution fits better.
+- **Models mode explicitly**. Major and minor profiles are distinct,
+  so a piece in A minor is correctly distinguished from A major by the
+  relative energies of C/C# (minor/major third of A) and the scale
+  tones.
+- **Robust to missing tonic**. If the tonic is quieter than the 5th
+  (which happens often), the full-profile correlation still finds the
+  right key because the rest of the scale pattern still fits.
+
+### Implementation sketch
+
+```python
+_KS_MAJOR = np.array([6.35, 2.23, 3.48, 2.33, 4.38, 4.09,
+                      2.52, 5.19, 2.39, 3.66, 2.29, 2.88])
+_KS_MINOR = np.array([6.33, 2.68, 3.52, 5.38, 2.60, 3.53,
+                      2.54, 4.75, 3.98, 2.69, 3.34, 3.17])
+
+def _correlate(x, p):
+    # pearson correlation, stable form
+    xm = x - x.mean()
+    pm = p - p.mean()
+    denom = np.sqrt((xm * xm).sum() * (pm * pm).sum())
+    if denom == 0:
+        return 0.0
+    return float((xm * pm).sum() / denom)
+
+def estimate_key_ks(chroma_median):
+    best = (-2.0, None)   # correlation, (pc, mode)
+    for pc in range(12):
+        profile_maj = np.roll(_KS_MAJOR, pc)
+        r_maj = _correlate(chroma_median, profile_maj)
+        if r_maj > best[0]:
+            best = (r_maj, (pc, 0))
+        profile_min = np.roll(_KS_MINOR, pc)   # note: minor profile is rooted at A (pc 9)
+        # rotate so tonic ends at pc
+        rotated_min = np.roll(_KS_MINOR, pc - 9)
+        r_min = _correlate(chroma_median, rotated_min)
+        if r_min > best[0]:
+            best = (r_min, (pc, 1))
+    pc, mode = best[1]
+    return pitch_class_to_name(pc, mode)
+```
+
+Costs: 24 correlations of 12-vectors per clip. Negligible compared to
+the CQT itself.
+
+### Variants worth knowing
+
+- **Temperley-Kostka-Payne profiles** (Temperley 2004): re-derived
+  from corpus statistics rather than probe tones. Slightly different
+  weighting, often slightly better real-world accuracy.
+- **Albrecht-Shanahan profiles** (Albrecht & Shanahan 2013): modern
+  re-derivation from a large MIDI corpus, claimed to outperform
+  Krumhansl and Temperley on classical, jazz, and rock test sets.
+- **Smoothed profiles**: convolve the profile with a small Gaussian
+  in pitch-class space to be more forgiving of off-scale notes.
+
+Any of these drops in as a different constant vector. The algorithm
+around it doesn't change.
+
+---
+
+## Chroma CQT parameters in detail
+
+The `chroma_cqt` call in `detect.py`:
+
+```python
+chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=512)
+```
+
+Relevant librosa defaults (as of librosa 0.10):
+
+| parameter | default | what it controls |
+|-----------|---------|------------------|
+| `hop_length` | 512 | samples between frame centers; sets time resolution |
+| `fmin` | C1 (~32.7 Hz) | lowest pitch the CQT analyzes |
+| `n_chroma` | 12 | number of chroma bins per octave |
+| `n_octaves` | 7 | number of octaves analyzed above fmin |
+| `bins_per_octave` | `n_chroma * 3` = 36 | CQT resolution; 3 bins per semitone |
+| `norm` | `2` | L2 normalization per frame |
+
+Time resolution at `sr=44100, hop_length=512` is `512/44100 ≈ 11.6ms`
+per frame. A 10-second clip gives ~860 frames of chroma.
+
+`bins_per_octave = 36` means each semitone is resolved with 3 CQT bins.
+This allows detection of microtonal deviations within a semitone (useful
+in some modern production contexts) while still producing a 12-bin
+chroma output after folding.
+
+The default `fmin = C1` is low enough to catch sub-bass fundamentals
+but not so low that anti-aliasing artifacts dominate. For material
+heavier on high-frequency content (percussion, synths) this doesn't
+matter much; for bass-heavy material the low fmin is crucial.
+
+---
+
+## Mode ambiguity: why we currently return only major
+
+The argmax estimator has no access to mode information. It returns a
+pitch class, period. In `detect.py`:
+
+```python
+note_names = ["C", "C#", "D", "D#", "E", "F",
+              "F#", "G", "G#", "A", "A#", "B"]
+detected_key = note_names[note_number]
+```
+
+No `m` suffix ever appears in the detected_key output. If the filename
+contains a mode indication (`Am`, `F#min`), `improve_key_detection`
+reconciles and uses the filename's mode. Otherwise the final stored
+value is a bare letter, which Camelot interprets as major.
+
+This is a known limitation. The Krumhansl upgrade resolves it by
+returning `(pc, mode)` directly from the correlation.
+
+---
+
+## Why the two-source reconciliation works
+
+acidcat combines analyzed + filename key via `improve_key_detection`:
+
+```python
+def improve_key_detection(detected_key, filename_key):
+    if filename_key is None:
+        return detected_key, 'detected'
+    if detected_key is None:
+        return filename_key, 'filename'
+    if detected_key == filename_key:
+        return detected_key, 'detected'
+    return filename_key, 'filename'
+```
+
+When they agree, confidence is high. When they disagree, filename
+wins. This is the right default because:
+
+- Filenames in sample packs are authored by producers who know the
+  key.
+- Audio-detected keys can be wrong for all the reasons enumerated
+  above.
+
+The exception is when the filename parser itself fires a false
+positive on a non-key token (e.g. "Analog" matching `A`). The
+whole-token matcher `parse_bare_key_token` in `detect.py` guards
+against this by requiring the key to be a standalone dot/dash/space
+separated token, not a substring.
+
+When the upgraded Krumhansl estimator lands, the reconciliation rule
+should get smarter: if the estimator's best-fit correlation is below
+some threshold (say 0.6), we should trust filename unconditionally
+because the audio is too ambiguous to override it.
+
+---
+
+## Interpretation
+
+A normalized chroma vector's values lie roughly in [0, 1]. A strongly
+tonal sample produces a peaked distribution with a clear maximum
+(often 2-3x the median). An inharmonic sample produces a nearly flat
+distribution with all bins within ~20% of each other.
+
+### Example chroma patterns
+
+```
+strongly-tonal C major:
+       C   C#   D   D#   E    F   F#   G   G#   A   A#   B
+     [1.0, 0.1, 0.5, 0.1, 0.7, 0.6, 0.1, 0.8, 0.1, 0.4, 0.1, 0.2]
+      ^tonic                   ^5th      ^3rd
+
+weakly-tonal / ambiguous:
+     [0.5, 0.4, 0.6, 0.3, 0.5, 0.5, 0.4, 0.5, 0.4, 0.5, 0.3, 0.4]
+      noticeable but not dominant peaks; argmax picks randomly
+
+drum loop (inharmonic):
+     [0.45, 0.42, 0.44, 0.47, 0.43, 0.46, 0.41, 0.48, 0.43, 0.45, 0.44, 0.46]
+      effectively uniform; key detection meaningless
+
+noise / glitch:
+     [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+      perfectly flat after normalization; any key is equally wrong
+```
+
+### Quality heuristics
+
+A **peakiness** measure like `max / median` distinguishes tonal from
+non-tonal content:
+
+```python
+peakiness = chroma_median.max() / (np.median(chroma_median) + 1e-9)
+```
+
+Values above ~2.5 indicate strong tonality. Values near 1 indicate
+effectively uniform distribution (drum hits, noise). A future
+`key_confidence` field could expose this.
+
+---
+
+## Gotchas
+
+### Transient-heavy material
+
+A clip that's 80% transient (drum-heavy, percussive) has most of its
+energy in broadband attacks, not in sustained pitch content. Chroma
+analysis produces a nearly flat vector. The argmax output is
+effectively random.
+
+Fix options: use HPR (harmonic-percussive residual) separation before
+chroma analysis. `librosa.effects.hpss(y)` returns harmonic and
+percussive components; running chroma on just the harmonic part
+dramatically cleans up results for percussive music.
+
+### Very short samples
+
+Samples under 250ms can have so few analysis frames that the median
+isn't statistically meaningful. `detect.py` already guards against
+samples shorter than 256 samples (about 6ms at 44.1k), but the
+sensible lower bound for key estimation is closer to 500ms.
+
+### Reference tuning
+
+The pitch-class mapping assumes A4 = 440 Hz. Material tuned to A4 =
+432 Hz, A4 = 415 Hz (baroque), or any non-standard reference will
+have its pitches fall between bins. librosa has a `tuning` parameter
+that can be pre-estimated with `librosa.estimate_tuning`. We don't
+currently use it; for strictly-tuned modern material this doesn't
+matter.
+
+### Frequency-dependent octave errors
+
+Very low bass (below ~60 Hz) can fold into the wrong octave because
+the CQT runs out of resolution. In practice this means sub-bass
+fundamentals can be misclassified. Mitigations: either raise `fmin`
+to exclude the sub-bass region, or use overtone-based key estimation
+which infers root from upper partials.
+
+---
+
+## References
+
+- Krumhansl, C. L. (1990). *Cognitive Foundations of Musical Pitch*.
+  Oxford University Press. The original source for the KS profiles.
+- Temperley, D. (2004). "Bayesian models of musical structure and
+  cognition." *Musicae Scientiae* 8: 175-205. Alternative corpus-derived
+  profiles.
+- Albrecht, J., & Shanahan, D. (2013). "The use of large corpora to train
+  a new type of key-finding algorithm." *Music Perception* 31(1): 59-67.
+  Modern re-derivation with improved accuracy.
+- Bello, J. P., Daudet, L., Abdallah, S., Duxbury, C., Davies, M., &
+  Sandler, M. B. (2005). "A tutorial on onset detection in music
+  signals." *IEEE Transactions on Speech and Audio Processing*
+  13(5): 1035-1047. Background for `rhythm_and_bpm.md`.
+- librosa documentation: <https://librosa.org/doc/latest/>
+- See `camelot_wheel.md` for how the output of this pipeline gets
+  turned into compatibility matches.
+- See `rhythm_and_bpm.md` for the BPM side of the same extraction.

--- a/docs/dsp/feature_pipeline.md
+++ b/docs/dsp/feature_pipeline.md
@@ -1,0 +1,583 @@
+# Feature Pipeline
+
+How `core/features.py` composes all the DSP primitives into a single
+feature vector per audio file. The capstone doc that ties together
+the spectral, cepstral, rhythmic, and tonal components.
+
+Last updated: 2026-04-23
+
+---
+
+## What it does
+
+`extract_audio_features(filepath)` takes one audio file path and
+returns a flat Python dict of roughly 50 scalar features. That dict
+becomes the row stored in the SQLite `features` table (as a JSON
+blob) or serialized into a CSV row for the `acidcat features`
+command.
+
+The features are used for:
+
+- Similarity search via `find_similar` (cosine distance over the vector)
+- Clustering via k-means or agglomerative methods (`acidcat similar cluster`)
+- ML experiments that treat the sample library as a labeled or unlabeled dataset
+- Any downstream analysis that needs a compact numerical description of each sample
+
+---
+
+## The 50-field vector
+
+Grouped by type:
+
+### Time domain (5 fields)
+
+```
+duration_sec                length in seconds
+sample_rate                 Hz (provenance, not a discriminating feature)
+audio_length_samples        raw frame count
+zcr_mean, zcr_std           zero-crossing rate statistics
+rms_mean, rms_std           RMS energy statistics
+```
+
+### Spectral descriptors (12 fields)
+
+```
+spectral_centroid_mean / std      brightness
+spectral_rolloff_mean / std       high-frequency cutoff
+spectral_bandwidth_mean / std     spread around centroid
+spectral_contrast_mean / std      peak-to-valley ratio (collapsed)
+chroma_mean / std                 pitch class energy (collapsed)
+mel_mean / std                    mel-band energy (collapsed)
+```
+
+### Cepstral (26 fields)
+
+```
+mfcc_1_mean, mfcc_1_std
+mfcc_2_mean, mfcc_2_std
+...
+mfcc_13_mean, mfcc_13_std
+```
+
+### Rhythm (2 fields)
+
+```
+tempo_librosa       raw librosa tempo estimate
+beat_count          detected beat count
+```
+
+### Tonal geometry (2 fields)
+
+```
+tonnetz_mean, tonnetz_std       collapsed 6D tonal centroid
+```
+
+Total: ~50 fields depending on exact counting. The cepstral group
+dominates the vector by count.
+
+---
+
+## The extraction flow
+
+```python
+def extract_audio_features(filepath):
+    y, sr = librosa.load(filepath, sr=None, mono=True)
+    if len(y) < 256:
+        return None
+    features = {}
+
+    # basic properties
+    features['duration_sec']          = len(y) / sr
+    features['sample_rate']           = sr
+    features['audio_length_samples']  = len(y)
+
+    # spectral
+    sc  = librosa.feature.spectral_centroid(y=y, sr=sr)[0]
+    sro = librosa.feature.spectral_rolloff(y=y, sr=sr)[0]
+    sb  = librosa.feature.spectral_bandwidth(y=y, sr=sr)[0]
+    features['spectral_centroid_mean']  = np.mean(sc)
+    features['spectral_centroid_std']   = np.std(sc)
+    features['spectral_rolloff_mean']   = np.mean(sro)
+    features['spectral_rolloff_std']    = np.std(sro)
+    features['spectral_bandwidth_mean'] = np.mean(sb)
+    features['spectral_bandwidth_std']  = np.std(sb)
+
+    # zero-crossing rate
+    zcr = librosa.feature.zero_crossing_rate(y)[0]
+    features['zcr_mean'] = np.mean(zcr)
+    features['zcr_std']  = np.std(zcr)
+
+    # mfcc
+    mfccs = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13)
+    for i in range(13):
+        features[f'mfcc_{i+1}_mean'] = np.mean(mfccs[i])
+        features[f'mfcc_{i+1}_std']  = np.std(mfccs[i])
+
+    # chroma
+    chroma = librosa.feature.chroma_stft(y=y, sr=sr)
+    features['chroma_mean'] = np.mean(chroma)
+    features['chroma_std']  = np.std(chroma)
+
+    # mel spectrogram
+    mel = librosa.feature.melspectrogram(y=y, sr=sr)
+    features['mel_mean'] = np.mean(mel)
+    features['mel_std']  = np.std(mel)
+
+    # tempo and beats
+    onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+    tempo, beats = librosa.beat.beat_track(onset_envelope=onset_env, sr=sr)
+    features['tempo_librosa'] = float(np.atleast_1d(tempo)[0])
+    features['beat_count']    = len(beats)
+
+    # rms energy
+    rms = librosa.feature.rms(y=y)[0]
+    features['rms_mean'] = np.mean(rms)
+    features['rms_std']  = np.std(rms)
+
+    # spectral contrast
+    contrast = librosa.feature.spectral_contrast(y=y, sr=sr)
+    features['spectral_contrast_mean'] = np.mean(contrast)
+    features['spectral_contrast_std']  = np.std(contrast)
+
+    # tonnetz
+    tonnetz = librosa.feature.tonnetz(y=y, sr=sr)
+    features['tonnetz_mean'] = np.mean(tonnetz)
+    features['tonnetz_std']  = np.std(tonnetz)
+
+    return features
+```
+
+Essentially one librosa call per feature family, followed by
+`np.mean` and `np.std` aggregation.
+
+---
+
+## Pipeline shape: why every feature is mean + std
+
+Each librosa feature call returns a 1D or 2D array indexed by time
+frame. The file might have 200 frames or 20000 depending on
+length. To get fixed-size features usable for distance metrics, we
+aggregate across time.
+
+Mean captures the "typical value" of the feature. Std captures how
+much it varies. A sample with static timbre has low std; a sample
+that evolves has high std.
+
+Two numbers per feature is the lightest informative summary. You
+could use:
+
+- **mean only**: loses dynamic information. A steady pad and a
+  pulsing pad with the same average look identical.
+- **mean + std**: captures location + spread. Current choice.
+- **mean + std + skewness + kurtosis**: full four-moment summary.
+  More discriminating but 4x the field count and diminishing
+  returns on most features.
+- **median + IQR**: more robust to outliers than mean + std. Could
+  be better for transient-heavy material.
+- **full time series**: maximum information, but variable length
+  and doesn't fit into a flat row.
+
+acidcat's choice (mean + std) is the pragmatic standard for audio
+feature vectors.
+
+---
+
+## The "collapse" problem
+
+Four features in the current vector are aggregated across both
+time AND frequency/dimension, which loses the internal structure:
+
+- **`spectral_contrast`**: natively 7 bands x T frames. Collapsed to
+  a single mean+std, losing per-band information.
+- **`chroma`**: natively 12 pitch classes x T frames. Collapsed.
+- **`mel`**: natively 128 mel bands x T frames. Collapsed.
+- **`tonnetz`**: natively 6 dimensions x T frames. Collapsed.
+
+What we lose:
+
+- A kick-heavy sample and a hi-hat-heavy sample have different
+  contrast band distributions but might collapse to similar scalar
+  means.
+- Two tonal samples in different keys have different chroma peak
+  locations but collapse to similar scalar means.
+- Two chords at different tonal-wheel positions have different
+  Tonnetz vectors but collapse to similar scalar means.
+
+The collapse was a historical choice for vector compactness. With
+modern storage it's not worth it. The better approach:
+
+```
+# preserve per-dimension stats for multi-dim features
+for i in range(n_bands):
+    features[f'contrast_band_{i}_mean'] = np.mean(contrast[i])
+    features[f'contrast_band_{i}_std']  = np.std(contrast[i])
+```
+
+Expanded feature counts per extractor:
+
+| feature | current fields | proposed fields | net gain |
+|---------|---------------|-----------------|----------|
+| contrast | 2 | 14 | +12 |
+| chroma | 2 | 24 | +22 |
+| mel | 2 | 256 | +254 |
+| tonnetz | 2 | 12 | +10 |
+
+Mel is the outlier. Keeping mel collapsed and expanding only
+contrast, chroma, and tonnetz gives:
+
+- Total fields: ~50 → ~96
+- Storage per row: ~400 bytes → ~800 bytes (JSON)
+- Similarity accuracy: meaningfully improved for harmonic and
+  timbral distinctions
+
+Schema change would require a `features_version` bump. The existing
+`features_version INTEGER` column in the `features` table was added
+exactly for this kind of migration. See "versioning" below.
+
+### Why keep mel collapsed
+
+128 mel bands x 2 stats = 256 extra fields. Most of them are
+highly correlated (adjacent bands produce similar values).
+Dimensionality-reduction of mel (via PCA or an autoencoder) would
+give better compression with similar information preservation.
+MFCCs already do exactly this: DCT of log-mel is a principled
+dimensionality reduction.
+
+If you want mel-derived features beyond MFCC, consider just
+increasing MFCC count to 20 or 26 instead of expanding raw mel.
+
+---
+
+## Current similarity strategy
+
+In `commands/similar.py`, similarity uses cosine distance over the
+feature vector:
+
+```python
+from sklearn.metrics.pairwise import cosine_similarity
+sim = cosine_similarity(vec_a.reshape(1, -1), vec_b.reshape(1, -1))[0, 0]
+```
+
+Cosine similarity measures the angle between two vectors,
+independent of magnitude. Two samples with proportional feature
+values (same "shape" of vector) get similarity 1; orthogonal
+vectors get 0; opposite vectors get -1.
+
+### Why cosine and not Euclidean
+
+Features have wildly different scales:
+- `duration_sec`: 0.1 to 300+
+- `sample_rate`: 8000 to 96000
+- `mfcc_*_mean`: typically -20 to 20
+- `zcr_mean`: 0 to 1
+- `rms_mean`: 0 to 1
+
+Euclidean distance on unnormalized features is dominated by the
+biggest-magnitude fields (sample rate, then duration). Two samples
+with wildly different MFCCs but the same sample rate end up close.
+
+Cosine is less sensitive because it normalizes by vector length,
+but it's still biased by the relative magnitude of each dimension.
+A proper approach requires per-feature normalization before
+distance computation:
+
+```python
+# proposed: StandardScaler across the full indexed set
+from sklearn.preprocessing import StandardScaler
+scaler = StandardScaler().fit(all_feature_vectors)
+normalized = scaler.transform(feature_vectors)
+sim = cosine_similarity(normalized_a, normalized_b)
+```
+
+This is what `acidcat features --ml-ready` does: runs the extraction,
+then fits and applies a StandardScaler to produce a normalized CSV.
+The MCP `find_similar` tool does not currently do this. Adding
+scaler state to the index (or computing a per-query scaler from the
+current feature population) is on the near-term work list.
+
+### Weighted similarity
+
+Different features matter differently for different similarity
+questions. For "find samples with similar timbre":
+
+```
+weight mfcc     highly
+weight contrast moderately
+weight chroma   zero (pitch isn't timbre)
+weight bpm      zero (tempo isn't timbre)
+```
+
+For "find samples that could layer harmonically":
+
+```
+weight chroma   highly
+weight tonnetz  highly
+weight bpm      highly
+weight mfcc     zero
+```
+
+The current implementation treats all features equally, which is
+a reasonable default but not optimal for any specific query. A
+weighted-similarity API would let the caller (or agent) express
+intent:
+
+```python
+similar(target, weights={'mfcc': 3.0, 'chroma': 0, 'rhythm': 0})
+```
+
+Not currently exposed. Would be a clean addition that doesn't
+change storage, just query-time scoring.
+
+---
+
+## Feature versioning
+
+The schema includes a `features_version INTEGER` column for exactly
+the kind of migration scenarios above. Current version is 1.
+
+When the feature extractor changes in a way that invalidates old
+vectors, bump the version. `reindex_features` can then skip or
+recompute rows based on their version:
+
+```python
+# pseudocode
+for path in indexed_paths:
+    stored_version = get_features_version(path)
+    if stored_version != CURRENT_VERSION:
+        recompute(path)
+```
+
+Currently not plumbed through the code, but the schema supports it.
+
+Trigger scenarios for a version bump:
+
+- Adding new fields (contrast per-band, tonnetz per-dim): version 2
+- Changing librosa to a version with different defaults: version 3
+- Switching from chroma_stft to chroma_cqt for features: version 4
+
+---
+
+## Pipeline failure modes
+
+### Import failures
+
+```python
+try:
+    import librosa
+    import numpy as np
+except ImportError:
+    from acidcat.util.deps import require
+    require("librosa", "numpy", group="analysis")
+    return None
+```
+
+Returns `None` if librosa isn't available. Upstream callers should
+check for `None` and handle gracefully.
+
+### Short audio
+
+```python
+if len(y) < 256:
+    return None
+```
+
+Samples shorter than 256 samples (~6ms at 44.1k) are too short for
+meaningful feature extraction. Return `None`.
+
+This is conservative; many one-shots longer than this are still too
+short for reliable feature stats. A better threshold might be 5000
+samples (~100ms), below which most time-frequency features produce
+only a handful of frames.
+
+### librosa errors
+
+```python
+try:
+    ...
+except Exception as e:
+    return None
+```
+
+Catch-all. If anything in the extraction pipeline fails, return
+None. Lossy but prevents a bad file from crashing a batch index.
+
+Improvements:
+
+- Log the specific failure reason instead of silently returning None.
+- Distinguish recoverable failures (bad header, unusual codec) from
+  unrecoverable (out of memory, disk I/O).
+- Have different fallback strategies for different failure types
+  (e.g. retry with mono-forced or resampled audio on codec errors).
+
+### Cold librosa
+
+First call after Python starts takes 30-60 seconds because of numba
+JIT compilation. Subsequent calls in the same process are fast.
+This is why the MCP server benefits from the pre-warm pattern
+documented in `architecture.md`.
+
+For batch CLI use (`acidcat features ~/Samples -n 500`), the cold
+cost amortizes over the batch. For one-off MCP calls it matters.
+
+---
+
+## Proposed pipeline improvements
+
+Ordered by ease and impact.
+
+### 1. Expand collapsed features
+
+Preserve per-band and per-dimension stats for contrast, chroma,
+tonnetz. ~50 → ~96 features. Done in a single commit, bump version
+to 2, reindex.
+
+### 2. Per-feature normalization in similarity
+
+Fit a StandardScaler across the current index's feature vectors.
+Apply before cosine distance. Significant accuracy improvement with
+no schema change.
+
+### 3. Weighted similarity API
+
+Expose `weights` parameter on `find_similar` that multiplies each
+feature family's contribution. Enables intent-driven similarity
+queries.
+
+### 4. HPR (harmonic-percussive separation) pre-pass
+
+For harmonic-heavy analysis, run `librosa.effects.hpss(y)` and use
+just the harmonic component for chroma/tonnetz/key. For
+percussive-heavy analysis, use just the percussive component for
+onset and beat tracking. Modest compute cost, big accuracy win for
+mixed content.
+
+### 5. Confidence/quality fields
+
+Derive per-file "this feature is trustworthy" scores:
+
+- Key confidence: peakiness of chroma (see `chroma_and_key.md`)
+- BPM confidence: energy at detected tempo peak in tempogram
+- Timbre stability: 1 / (1 + std of mfcc_1)
+- Tonality: magnitude of tonnetz vector mean
+
+Low-confidence fields can be excluded from similarity by the
+caller.
+
+### 6. Learned embeddings
+
+Eventually, a learned embedding from a pretrained model (CLAP,
+encodec, etc.) would outperform hand-crafted features for many
+similarity tasks. Not a replacement for the current feature vector
+but a parallel field.
+
+Major caveats: adds a large model dependency, introduces
+uncertainty about bias and domain mismatch, and complicates the
+"zero deps for core metadata" principle. If added, should be
+strictly opt-in through a new optional extra like `[embeddings]`.
+
+---
+
+## When to recompute features
+
+Features should be recomputed when:
+
+- The file changes (`mtime` or `size` differs from stored value)
+- The extractor version bumps (`features_version < CURRENT_VERSION`)
+- The user explicitly requests (`--force` flag on reindex)
+
+Features should NOT be recomputed when:
+
+- Only tags or description change (user-editable metadata doesn't
+  affect the feature vector)
+- The file moves but content is unchanged (new path, same content,
+  but the index uses path as primary key so it looks like a new
+  file anyway)
+
+Currently `reindex_features` skips files that already have feature
+rows, regardless of version. A small upgrade would check version
+and recompute stale rows.
+
+---
+
+## Gotchas
+
+### Sample rate in the vector
+
+We store `sample_rate` but it's not discriminating for music
+samples (most are 44.1k or 48k). It's there for provenance and
+sanity checking, not for similarity scoring. If computing distance,
+this field can be excluded without loss of information.
+
+### Duration dominates distance
+
+If duration is included in the feature vector (it is), samples with
+very different durations end up far apart in cosine space
+regardless of their timbral similarity. A 0.5 second drum hit and
+a 30 second drone cannot possibly be "similar" by Euclidean or
+cosine distance if duration is weighted.
+
+Mitigations:
+
+- Exclude duration from similarity computation (use it as a filter
+  instead)
+- Normalize duration strongly before distance (log-transform or
+  quantile-transform)
+- Use it only in weighted queries where the caller decides
+
+### NaN handling
+
+Some feature values can be NaN under specific conditions (silent
+frames, all-zero inputs). Not currently guarded. A single NaN in
+the vector makes cosine distance NaN, breaking similarity.
+
+Fix: post-process features, replace NaN with 0 (or the feature's
+median across indexed samples).
+
+### Cross-library comparability
+
+Features computed with different librosa versions can disagree
+slightly. For within-library similarity this doesn't matter
+(consistent extractor). For cross-library or cross-tool comparison
+(sharing vectors with another user's acidcat instance), record the
+librosa version in the features blob as provenance.
+
+---
+
+## Summary
+
+The pipeline is a sequence of independent librosa calls, each
+producing a feature array, each reduced to mean+std, all assembled
+into a flat dict. Simple, robust, and mostly correct for the scope
+of "a sample library I can search over."
+
+The primary improvements needed (in priority order):
+
+1. Fix the feature collapse for contrast, chroma, tonnetz.
+2. Add StandardScaler normalization before similarity distance.
+3. Expose weighted similarity.
+4. HPR pre-pass for mixed content.
+5. Confidence/quality fields.
+
+Each is a focused change. None require rethinking the architecture.
+
+---
+
+## References
+
+- Peeters, G. (2004). "A large set of audio features for sound
+  description." *IRCAM*. Canonical reference for what to include in
+  a general-purpose audio feature vector.
+- Gouyon, F., et al. (2006). "Evaluating rhythmic descriptors for
+  musical genre classification." *AES*. On combining rhythmic and
+  timbral features.
+- Chen, K., Du, X., Zhu, B., Ma, Z., Berg-Kirkpatrick, T., & Dubnov,
+  S. (2022). "HTS-AT: A hierarchical token-semantic audio
+  transformer for sound classification and detection." *ICASSP*.
+  Modern learned alternative to hand-crafted features.
+- librosa feature overview:
+  <https://librosa.org/doc/latest/feature.html>
+- sklearn similarity metrics:
+  <https://scikit-learn.org/stable/modules/metrics.html>
+- See `dsp/spectral_features.md`, `dsp/mfcc.md`, `dsp/tonnetz.md`,
+  `dsp/chroma_and_key.md`, and `dsp/rhythm_and_bpm.md` for deep
+  dives on each feature family this pipeline composes.

--- a/docs/dsp/hpr.md
+++ b/docs/dsp/hpr.md
@@ -1,0 +1,556 @@
+# HPR (Harmonic-Percussive Separation)
+
+Decomposing an audio signal into its harmonic (sustained tonal) and
+percussive (transient rhythmic) components. Cheap, effective, and a
+meaningful accuracy win for any analysis that only cares about one
+half of a mixed signal.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+Most music has two kinds of content sitting in the same spectrogram:
+
+- **Harmonic content**: horizontal stripes in the spectrogram. A
+  sustained note lights up specific frequency bins over many
+  consecutive time frames. Pads, vocals, basslines, guitar chords.
+- **Percussive content**: vertical stripes. A drum hit lights up
+  many frequency bins simultaneously in a single time frame.
+  Kicks, snares, cymbals, plucks.
+
+HPR separation pulls these apart into two signals that sum (roughly)
+to the original. You end up with a "percussion-only" version and a
+"harmonic-only" version of the same audio.
+
+For analysis, this is a big deal. Running key detection on a
+drum-heavy loop is hard because the drums flood the chroma. Run key
+detection on the harmonic residual instead and the pitch content is
+suddenly clear. Running beat tracking on a pad-heavy track is hard
+because the sustained tones create false onsets. Run it on the
+percussive residual and onsets are sharp.
+
+acidcat doesn't currently use HPR, but it's the single most
+impactful preprocessing step we could add. Most documented accuracy
+improvements in chroma/key/beat-tracking papers since ~2010 rely on
+it as a preprocessing step.
+
+---
+
+## The intuition
+
+Look at a spectrogram:
+
+```
+freq
+ ^
+ |  ■■■■■■■■■■■         ■           ■■■    (drum hit at two moments)
+ |                                          (mostly vertical)
+ |  ■   ■       ■   ■       ■
+ |       ■   ■       ■          ■
+ |   ■        ■        ■            ■       (sustained tones)
+ |       ■    ■   ■    ■    ■       ■      (mostly horizontal)
+ |                                           
+ +─────────────────────────────────────> time
+```
+
+A drum hit is visually a vertical stripe. A sustained note is
+visually a horizontal stripe. You can tell them apart just by
+looking. The question is how to do that mathematically.
+
+The answer (Fitzgerald 2010): median filter the spectrogram twice.
+
+- A **horizontal median filter** (along the time axis) smooths out
+  anything that doesn't persist. Transients get flattened; sustained
+  tones survive. The output is the harmonic estimate.
+- A **vertical median filter** (along the frequency axis) smooths out
+  anything that isn't broadband. Sustained tones get flattened;
+  transients survive. The output is the percussive estimate.
+
+Then build soft masks from the two estimates and multiply them back
+into the original spectrogram. Invert back to time domain. Done.
+
+---
+
+## The math
+
+### Starting point: a magnitude spectrogram
+
+```
+    S[k, t]     magnitude at frequency bin k, time frame t
+```
+
+### Horizontal median filter
+
+For each bin `k`, replace the value at frame `t` with the median of
+its neighbors along time:
+
+```
+    H[k, t] = median( S[k, t-w : t+w] )
+```
+
+for some window width `w` (e.g. 17 frames, ~200ms at 44.1k/512 hop).
+
+A transient event at frame `t` has high energy only at that one
+frame; the median of a window around it is dominated by the quiet
+neighbors, so `H[k, t]` is low. A sustained tone at frame `t` has
+similar energy in surrounding frames; the median matches the
+original, so `H[k, t] ≈ S[k, t]`.
+
+Result: `H` is the harmonic estimate. Transients are suppressed.
+
+### Vertical median filter
+
+For each frame `t`, replace the value at bin `k` with the median of
+its neighbors along frequency:
+
+```
+    P[k, t] = median( S[k-w : k+w, t] )
+```
+
+for some window width `w` (e.g. 17 bins).
+
+A sustained tone lights up a narrow range of frequency bins (the
+fundamental and its harmonics). The median across a wider window
+includes many quiet bins, so `P[k, t]` is low. A broadband transient
+lights up every bin equally; the median matches the original, so
+`P[k, t] ≈ S[k, t]`.
+
+Result: `P` is the percussive estimate. Sustained tones are
+suppressed.
+
+### Soft masks
+
+From the two estimates, build masks that sum to 1 at every
+(k, t) cell:
+
+```
+    mask_h[k, t] = H[k, t]^p / ( H[k, t]^p + P[k, t]^p )
+    mask_p[k, t] = P[k, t]^p / ( H[k, t]^p + P[k, t]^p )
+```
+
+The exponent `p` sharpens the separation. `p = 1` gives a smooth
+Wiener-like mask; `p = 2` gives a harder split; `p → ∞` gives
+binary masks (cell belongs fully to one side).
+
+Apply masks to the original spectrogram:
+
+```
+    S_h[k, t] = mask_h[k, t] * S[k, t]    harmonic component
+    S_p[k, t] = mask_p[k, t] * S[k, t]    percussive component
+```
+
+By construction, `S_h + S_p = S`. No energy lost.
+
+### Back to time domain
+
+Inverse STFT of the complex spectrogram (using the masks times the
+original magnitude, keeping original phase):
+
+```
+    y_h = iSTFT( mask_h * X )
+    y_p = iSTFT( mask_p * X )
+```
+
+Where `X` is the original complex STFT (not just magnitude).
+
+`y_h` is the harmonic-only audio; `y_p` is the percussive-only audio.
+Concatenate them by summing and you get back the original.
+
+### Why median and not mean
+
+Median is the whole trick. Mean filters smooth everything; they
+don't discriminate between "a single spike" and "a consistent
+value." Median treats the spike as an outlier, ignores it, returns
+the surrounding consistent value. This is what makes transients
+collapse under the horizontal filter (and sustained tones collapse
+under the vertical filter).
+
+### Three-way split with a residual
+
+Some implementations add a third "residual" or "noise" component for
+content that doesn't fit either archetype:
+
+- strong harmonic mask ∧ weak percussive mask → harmonic
+- strong percussive mask ∧ weak harmonic mask → percussive
+- both weak → residual (noise, texture, atmospherics)
+
+librosa offers this via a threshold parameter. Most applications
+use the two-way split and throw the residual into either side or
+drop it entirely.
+
+---
+
+## librosa implementation
+
+Two entry points with slightly different semantics:
+
+### `librosa.effects.hpss`
+
+```python
+y_h, y_p = librosa.effects.hpss(y, kernel_size=31, margin=(1.0, 1.0))
+```
+
+Takes the audio signal directly. Internally runs STFT, applies
+masks, runs iSTFT. Returns time-domain harmonic and percussive
+components.
+
+Parameters:
+
+- `kernel_size`: median filter width. Scalar applies the same
+  width to both filters. Tuple (h_kernel, p_kernel) specifies
+  them separately.
+- `margin`: sharpness of the mask. `(margin_h, margin_p)`. Higher
+  margin gives harder separation, more residual.
+- `power`: the exponent in the mask formula. Default 2.
+
+Use when you want the separated time-domain signals (for listening,
+re-mixing, or running a non-librosa analysis on them).
+
+### `librosa.decompose.hpss`
+
+```python
+D = librosa.stft(y)
+D_h, D_p = librosa.decompose.hpss(D, kernel_size=31, margin=1.0)
+```
+
+Takes a complex STFT and returns the masked STFT components. Saves
+the iSTFT step if you're going to re-compute a spectrogram anyway.
+
+Use when you plan to run chroma, onset, or any spectrogram-based
+analysis on the separated signals: skip the iSTFT, feed the masked
+STFT straight into the next step.
+
+---
+
+## Use cases
+
+### Clean chroma for key detection
+
+Currently `core/detect.py` runs chroma_cqt on the full signal. For
+drum-heavy material, the drum onsets add broadband energy that
+flattens the chroma vector, hurting key estimation.
+
+Better:
+
+```python
+y_h, y_p = librosa.effects.hpss(y)
+chroma = librosa.feature.chroma_cqt(y=y_h, sr=sr)  # harmonic-only
+```
+
+The drums don't contribute to the chroma. Key estimates become
+more reliable on percussive content.
+
+Cost: one extra librosa call. The HPR itself takes roughly the
+same time as a chroma computation, so total is about 2x. For
+per-file analysis this is acceptable.
+
+### Clean onsets for beat tracking
+
+librosa's beat tracker often struggles with pad-heavy or drone-heavy
+material because sustained tones create false onsets (the low-level
+energy fluctuations from sustained notes look like onsets). The
+percussive component removes those.
+
+```python
+y_h, y_p = librosa.effects.hpss(y)
+onset_env = librosa.onset.onset_strength(y=y_p, sr=sr)  # percussive-only
+tempo, beats = librosa.beat.beat_track(onset_envelope=onset_env, sr=sr)
+```
+
+Cleaner onsets, better BPM estimates on ambient-meets-drums
+material.
+
+### Cleaner timbral features
+
+For samples where you want timbre of the "pitched" part:
+
+```python
+y_h, y_p = librosa.effects.hpss(y)
+mfcc = librosa.feature.mfcc(y=y_h, sr=sr)     # timbre of harmonic part
+```
+
+Or for drum-sample similarity where you want only the transient:
+
+```python
+mfcc = librosa.feature.mfcc(y=y_p, sr=sr)     # timbre of percussive part
+```
+
+A drum loop analyzed for MFCC on the percussive component produces
+features centered on the drum kit's character, independent of
+whatever melodic element is layered over it.
+
+### Tonnetz on harmonic only
+
+Same argument as chroma. Percussive events create tonnetz noise
+because the chroma is noisy. Running on `y_h` stabilizes the tonal
+centroid trajectories.
+
+---
+
+## acidcat integration plan
+
+The cleanest way to add HPR without disrupting the existing
+pipeline:
+
+### Add an optional `mode` parameter to the extractors
+
+```python
+def estimate_librosa_metadata(filepath, hpr_mode=None):
+    y, sr = librosa.load(filepath, sr=None, mono=True)
+
+    if hpr_mode == "harmonic":
+        y_h, _ = librosa.effects.hpss(y)
+        y = y_h
+    elif hpr_mode == "percussive":
+        _, y_p = librosa.effects.hpss(y)
+        y = y_p
+    elif hpr_mode == "auto":
+        # default to harmonic for key detection
+        y_h, _ = librosa.effects.hpss(y)
+        y_for_chroma = y_h
+        # use full signal for BPM
+        y_for_tempo = y
+```
+
+Default mode: `None` (current behavior, no HPR). Opt-in per tool.
+
+### Automatic mode selection
+
+Better still: detect whether the signal has mixed content and apply
+HPR automatically. A simple heuristic:
+
+```python
+def needs_hpr(y, sr):
+    # measure harmonic-percussive balance in the first HPSS pass
+    D = librosa.stft(y)
+    D_h, D_p = librosa.decompose.hpss(D)
+    harmonic_energy = np.sum(np.abs(D_h)**2)
+    percussive_energy = np.sum(np.abs(D_p)**2)
+    ratio = min(harmonic_energy, percussive_energy) / \
+            (harmonic_energy + percussive_energy + 1e-9)
+    return ratio > 0.15  # substantial energy in the minor component
+```
+
+If both components have meaningful energy, HPR is worthwhile. If
+one dominates (pure drum loop, pure drone), HPR isn't needed.
+
+The cost of this check is the HPR itself. So in practice you just
+run HPR unconditionally when the analysis downstream benefits from
+it, and skip it when the analysis doesn't care about the split.
+
+### As an MCP tool
+
+A `separate_hpss` primitive that returns structural separation info
+(ratio, time-series of harmonic/percussive energy) without
+exposing the audio itself would be useful forensically. Something
+like:
+
+```
+separate_hpss(path) -> {
+    harmonic_ratio: 0.72,
+    percussive_ratio: 0.28,
+    content_type: "mostly harmonic",
+    dynamic: true        # whether content changes over time
+}
+```
+
+This lets an agent reason about a sample's character without
+downloading or processing audio.
+
+---
+
+## Gotchas
+
+### Parameter tuning matters
+
+The default `kernel_size=31` works for typical pop/rock/electronic
+material at 44.1k. For very different material the defaults may
+need adjustment:
+
+- **Fast drums**: smaller kernel (17 or 19) captures shorter
+  transients as percussive.
+- **Slow pads**: larger kernel (51 or 63) better captures
+  sustained tones without leaking.
+- **Odd sample rates**: kernel should scale proportionally if you
+  care about preserving time/frequency resolution semantics.
+
+For acidcat's general-purpose use, the default is fine.
+
+### Soft masks leak
+
+Even with `power=2` (default), some harmonic content leaks into
+`y_p` and vice versa. Not a problem for most analysis because the
+dominant character is correct, but fine-grained timbral separation
+is imperfect.
+
+For "clean isolation" use cases, spectrogram-based neural methods
+(Spleeter, Demucs) are much better but dramatically more expensive
+and require large models.
+
+### Phase and transients
+
+The iSTFT uses the original phase, which is correct for the
+dominant component at each cell. For cells where both harmonic and
+percussive are present, phase belongs to neither cleanly. You can
+hear artifacts in the resulting audio, typically a slight "phase
+pumping" quality. Not audible if you're just running further analysis
+on the result.
+
+### Harmonic content can fail the "horizontal stripe" test
+
+Pitched percussion (tuned toms, melodic synth leads with fast
+attacks) straddles the line. A tuned tom hit is percussive in
+attack and harmonic in decay. HPR usually assigns the attack to
+percussive and the decay to harmonic, which is often the right
+split for analysis purposes.
+
+Vibrato and tremolo (wobbling frequencies) can also partially leak
+into percussive because the frequency modulation looks slightly
+"vertical" in short-window spectrograms.
+
+### Noise and residual
+
+True noise (hiss, tape noise, broadband texture) doesn't fit
+either category. HPR typically splits it roughly evenly between
+harmonic and percussive outputs. If noise is a meaningful part of
+the sample's character, consider the three-way split with explicit
+residual.
+
+### Computational cost
+
+HPR roughly doubles analysis time per file. For a 1449-file index
+running the current feature extraction path, add another pass of
+chroma+onset on harmonic+percussive components and you've roughly
+tripled total compute. Batch feature extraction with HPR
+preprocessing is a bigger undertaking.
+
+For on-demand query (one file at a time), HPR cost is imperceptible
+to the user.
+
+---
+
+## When NOT to use HPR
+
+### Pure drum libraries
+
+If you know a priori the sample is a drum one-shot, running HPR
+is wasted compute. The percussive component will be nearly
+identical to the input, and the harmonic component will be
+essentially empty.
+
+A `kind` prefilter (see `kind_inference.md`) can skip HPR for
+one-shots.
+
+### Pure tonal libraries
+
+Same argument in reverse. A pad or drone has essentially zero
+percussive content. Running HPR produces a nearly-empty y_p and a
+y_h that matches the input.
+
+### Extremely short samples
+
+HPR needs enough time frames to compute the horizontal median.
+Samples under ~300ms (about 26 frames at 512 hop) don't have
+enough context for the median filter to work. Results will be
+unreliable.
+
+### Where simple features suffice
+
+If the downstream task is "measure brightness" (spectral centroid),
+HPR doesn't help because the centroid is a global measure that
+averages everything. The overhead is pure waste.
+
+Use HPR specifically when the analysis targets one component type:
+pitch/chroma/key/tonnetz benefits from harmonic-only; onset/BPM
+benefits from percussive-only. General timbral descriptors don't
+care.
+
+---
+
+## Alternatives
+
+### Spleeter / Demucs (deep learning)
+
+Much better separation quality. Can extract vocals, bass, drums,
+"other" as separate stems. Cost: multi-hundred-MB model weights,
+significantly slower, GPU-preferred.
+
+Not the right choice for acidcat given the Unix-tool philosophy
+and the zero-dependencies-for-core principle. If an opt-in heavy
+preprocessing path becomes useful, this is what would live in a
+hypothetical `[spleeter]` extra.
+
+### REPET (REpeating Pattern Extraction Technique)
+
+Designed to separate repetitive (loop-like) content from unique
+elements. Good for stripping a backing loop from a vocal, different
+problem from HPR. Less relevant for sample-library use.
+
+### NMF (Non-negative Matrix Factorization)
+
+Classical method for source separation. Decomposes a spectrogram
+into a product of two non-negative matrices (basis × activation).
+More flexible than HPR (can separate into N components) but much
+harder to parameterize sensibly for arbitrary audio.
+
+HPR is specifically the "two-components-with-well-known-structure"
+case where the math is cheap and the result is interpretable.
+
+### Filterbank-based separation
+
+Split into frequency bands and apply different thresholds per band.
+Crude but cheap. Doesn't actually separate harmonic from percussive;
+only separates by frequency range.
+
+---
+
+## Summary
+
+HPR is the single most impactful preprocessing step we could add to
+the analysis pipeline. The math is clean (two median filters), the
+library support is excellent (librosa native), the accuracy
+improvements are well-documented across the ISMIR literature.
+
+Primary applications in acidcat:
+
+- Clean chroma input for key detection (harmonic only)
+- Clean onset input for BPM/beat tracking (percussive only)
+- Cleaner timbral features for mixed-content samples
+
+Primary costs:
+
+- Roughly 2x-3x analysis time
+- Some parameter tuning for edge-case material
+- Not meaningful on single-component samples (drum-only, pad-only)
+
+On the roadmap as a medium-term improvement. Best implemented as
+an opt-in `mode` parameter on the extractor functions, with an
+`auto` mode that detects mixed content and applies HPR only where
+it helps.
+
+---
+
+## References
+
+- Fitzgerald, D. (2010). "Harmonic/percussive separation using
+  median filtering." *Proceedings of the International Conference
+  on Digital Audio Effects (DAFx-10)*. The foundational paper
+  introducing the median-filter approach.
+- Driedger, J., Müller, M., & Disch, S. (2014). "Extending
+  harmonic-percussive separation of audio signals." *ISMIR 2014*.
+  Adds the three-way split with residual and refines the margin
+  parameter.
+- Rafii, Z., & Pardo, B. (2011). "A simple music/voice separation
+  method based on the extraction of the repeating musical
+  structure." *ICASSP 2011*. REPET, the related-but-different
+  method.
+- librosa HPSS documentation:
+  <https://librosa.org/doc/latest/generated/librosa.effects.hpss.html>
+- See `dsp/chroma_and_key.md` for key detection that benefits from
+  HPR preprocessing.
+- See `dsp/rhythm_and_bpm.md` for BPM estimation that benefits
+  from HPR preprocessing.
+- See `dsp/feature_pipeline.md` for where HPR would integrate in
+  the extractor.

--- a/docs/dsp/kind_inference.md
+++ b/docs/dsp/kind_inference.md
@@ -1,0 +1,502 @@
+# Kind Inference (Loop vs One-Shot)
+
+A small but high-value classification: is this sample a loop or a
+one-shot? The heuristic is simple but it prevents a whole class of
+"wrong result type" failures in search and compatibility queries.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+"Kind" in acidcat refers to one of three categories:
+
+- **one_shot**: a single event, meant to trigger once. Drum hits,
+  vocal chops, stabs, plucks. Usually under 1 second.
+- **loop**: a rhythmic or tonal passage meant to play repeatedly.
+  Bars of drums, chord progressions, basslines. Usually 1-16 bars.
+- **ambiguous**: can't tell from available metadata. Drones, pads,
+  sound design elements, uncertain short files.
+
+The classification is a hint, not a hard category. Samples can live
+at edges: a very long one-shot (like a crash cymbal with 6 second
+decay) looks like a loop by duration, a very short loop (a 1-beat
+fill) looks like a one-shot. The heuristic handles the common case
+well and flags edge cases as `ambiguous`.
+
+---
+
+## Why it matters
+
+Most sample-library use cases care about this distinction:
+
+- **Search**: when a user searches for "128 bpm samples," they
+  usually want loops, not every one-shot that happens to match
+  the BPM band.
+- **Similarity**: "find samples like this kick" should return other
+  drum hits, not 4-bar kick-heavy loops.
+- **Compatibility**: "find samples compatible with this loop"
+  should return layering candidates of similar duration (other
+  loops, pads), not 0.25-second one-shots.
+- **Layering**: loops can be stacked and synced; one-shots are
+  rhythmic punctuation.
+
+Without kind inference, `find_compatible` can return one-shots as
+matches for loop queries (a real bug observed during testing).
+
+---
+
+## The heuristic
+
+Three signals, combined:
+
+```python
+def infer_kind(duration, acid_beats):
+    dur = duration or 0
+    beats = acid_beats or 0
+
+    # strong signals
+    if beats > 0 and dur >= 1.0:
+        return "loop"
+    if dur < 1.0 and beats <= 0:
+        return "one_shot"
+
+    # weaker signals
+    if dur >= 2.0 and beats > 0:
+        return "loop"
+    if dur < 0.5:
+        return "one_shot"
+
+    return "ambiguous"
+```
+
+The inputs are already in the index:
+
+- `duration`: in seconds, from the RIFF/AIFF parser or librosa.
+- `acid_beats`: from the ACID chunk when present. `> 0` means
+  producer-authored loop metadata.
+
+Two strong signals that match the archetypes:
+
+1. **ACID beats present + duration >= 1 second**: definitely a
+   loop. The producer explicitly marked it as such.
+2. **Short duration + no ACID beats**: definitely a one-shot. No
+   rhythmic context declared, too short for a musical phrase.
+
+The weaker signals handle samples without ACID metadata:
+
+3. **Duration >= 2 seconds + ACID beats present**: loop (even
+   without the 1-second threshold being met, ACID beats are
+   authoritative).
+4. **Duration < 0.5 seconds**: one-shot (too short to be a loop
+   regardless of metadata).
+
+Everything else: `ambiguous`. This includes mid-length samples
+(0.5-2 seconds) without ACID metadata, long drones, and sound
+design elements that could be either.
+
+---
+
+## Why these thresholds
+
+### 1 second boundary for one-shot
+
+At 120 BPM, one bar is 2 seconds and one beat is 500ms. A 1-second
+clip could be:
+
+- 2 beats of a loop (half-bar, common in breakbeat culture)
+- A long one-shot with decay (crash cymbal, long kick tail)
+- A short vocal phrase
+
+Setting the lower bound at 1 second keeps most legitimate
+half-bar loops on the loop side. Dropping the bound would
+misclassify those as one-shots.
+
+### 0.5 second boundary for strong one-shot
+
+Anything under 500ms is almost certainly not musical material. A
+kick drum decay, a single vocal word, a plucked sample. Even at
+240 BPM, one beat is 250ms, so 500ms is 2 beats which is the edge
+of loop-ness.
+
+### 2 second boundary for strong loop
+
+At 60 BPM, two seconds is two beats. At 120 BPM, it's four beats
+(one bar). The 2-second threshold captures "at least a full bar"
+for most common tempos.
+
+### ACID beats is authoritative
+
+If ACID beats is present and greater than zero, the producer
+intentionally labeled the clip as a rhythmic pattern. Even a very
+short loop (like a 1-beat 170 BPM DnB hit at ~350ms with ACID
+beats=1) gets classified as a loop. This is the whole point of
+ACID chunks: producer intent.
+
+### `acid_beats == 0` is not authoritative
+
+Important inverse rule: `acid_beats == 0` is treated as equivalent
+to `NULL`, not as a one-shot signal. The current implementation
+reflects this:
+
+```python
+b = acid_beats or 0   # both None and 0 collapse to 0
+if b > 0: ...         # only positive values are informative
+```
+
+And in the SQL filters:
+
+```sql
+-- loop filter (acid_beats=0 does NOT reject, falls through to duration)
+WHERE (s.acid_beats > 0 OR s.duration >= 2.0)
+
+-- one_shot filter (explicitly allows acid_beats=0)
+WHERE ((s.acid_beats IS NULL OR s.acid_beats = 0)
+   AND (s.duration IS NULL OR s.duration < 1.0))
+```
+
+**Why this matters in practice**: some commercial sample packs
+write an ACID chunk to the file but leave the `beats` field at
+zero. The Producer Loops Hypnotize pack is one observed example:
+126 BPM wav stems with `chunks: "inst,LIST,ID3 ,acid,strc"` (ACID
+chunk present), `acid_beats: 0`, and durations of 7.619s or 15.238s
+(exact 2-bar and 4-bar loops). These are unambiguously loops despite
+the zero beats field. The duration fallback catches them.
+
+**Do not "fix" this to treat `acid_beats == 0` as a one-shot
+signal.** It would misclassify legitimate loops from any pack that
+uses this writing convention.
+
+The general rule: `acid_beats > 0` is a strong loop signal;
+`acid_beats == 0` is uninformative and must fall through to
+duration-based classification.
+
+---
+
+## Integration with the index
+
+Currently kind is computed on the fly, not stored. A proposed
+addition to the `samples` table:
+
+```sql
+ALTER TABLE samples ADD COLUMN kind TEXT;
+-- values: "loop", "one_shot", "ambiguous", null
+CREATE INDEX idx_samples_kind ON samples(kind);
+```
+
+Populated at index time:
+
+```python
+row['kind'] = infer_kind(duration, acid_beats)
+```
+
+With this column:
+
+- `search_samples({kind: "loop"})` fast-path filters to loops.
+- `find_compatible(target, kind_match=True)` auto-filters to samples
+  of the same kind as target.
+- Tag taxonomies can be kind-aware ("drums" cluster of one-shots
+  vs "drum loops" cluster of loops).
+
+Schema migration is small. This is on the near-term work list.
+
+---
+
+## Augmentations
+
+The simple heuristic works well but misses a few cases. Possible
+enrichments if accuracy matters.
+
+### RMS envelope shape
+
+A one-shot typically has a percussive envelope: sharp attack, decay
+to silence. A loop typically has a flatter envelope with sustained
+energy throughout.
+
+```python
+rms_env = librosa.feature.rms(y=y)[0]
+decay_ratio = rms_env[-10:].mean() / rms_env[:10].mean()
+```
+
+- `decay_ratio < 0.2`: strong decay to silence, likely one-shot.
+- `decay_ratio > 0.8`: sustained, likely loop.
+- In between: less certain.
+
+Costs a feature extraction step, so not free. Could be computed
+lazily only for ambiguous cases.
+
+### Onset density
+
+Number of onsets per second. Loops tend to have regular onset
+patterns (one or more per beat). One-shots usually have one big
+onset at the start and nothing else.
+
+```python
+onsets = librosa.onset.onset_detect(y=y, sr=sr)
+density = len(onsets) / duration
+```
+
+- Density > 2 per second: rhythmic content, likely loop.
+- Density < 0.5: sparse, likely drone or one-shot.
+
+### Spectral stationarity
+
+Loops have relatively stable spectral content over time. One-shots
+evolve rapidly during the attack-decay envelope.
+
+```python
+mfcc_std = np.std(mfcc, axis=1).mean()
+```
+
+- Low mfcc_std: stable timbre, loop-like.
+- High mfcc_std: rapidly evolving, one-shot-like.
+
+### Bar-count check
+
+If BPM is known, we can compute "is the duration a clean multiple
+of a bar?":
+
+```python
+seconds_per_bar = 60 / bpm * 4  # assuming 4/4
+bars = duration / seconds_per_bar
+is_clean = abs(bars - round(bars)) < 0.05
+```
+
+Sample-pack loops are almost always exact multiples (1, 2, 4 bars).
+A sample whose duration is an integer number of bars at its
+declared BPM is almost certainly a loop. This is the highest-
+confidence secondary signal after ACID metadata.
+
+### File-naming patterns
+
+Producers commonly encode kind in filenames:
+
+- `_loop`, `_lp`, `loop_` in filename: strong loop signal
+- `_shot`, `_stab`, `_hit`, `_oneshot` in filename: strong one-shot signal
+- Drum-name patterns (kick, snare, hat, clap): strong one-shot
+- Loop-name patterns (drums, groove, beat): strong loop
+
+A regex-based classifier over filenames would catch many cases
+where duration and ACID metadata are unclear.
+
+---
+
+## Proposed enhanced classifier
+
+Combining signals:
+
+```python
+def infer_kind_full(sample):
+    # strong authoritative signals
+    if sample.acid_beats and sample.acid_beats > 0:
+        return "loop"
+    if sample.duration and sample.duration < 0.3:
+        return "one_shot"
+
+    # filename hints
+    path_lower = sample.path.lower()
+    if any(kw in path_lower for kw in ["_loop", "_lp", "loop_", "groove", "beat"]):
+        return "loop"
+    if any(kw in path_lower for kw in ["_shot", "_stab", "_hit", "_oneshot",
+                                         "kick_", "snare_", "hat_", "clap_"]):
+        return "one_shot"
+
+    # bar count check (requires bpm)
+    if sample.bpm and sample.duration:
+        seconds_per_bar = 60 / sample.bpm * 4
+        bars = sample.duration / seconds_per_bar
+        if abs(bars - round(bars)) < 0.05 and bars >= 0.5:
+            return "loop"
+
+    # duration heuristic (fallback)
+    if sample.duration:
+        if sample.duration < 1.0:
+            return "one_shot"
+        if sample.duration > 4.0:
+            return "loop"
+
+    return "ambiguous"
+```
+
+Runs through signals in confidence order. First match wins. Falls
+back to the simple duration heuristic if nothing else fires.
+
+---
+
+## Edge cases
+
+### Drones and pads
+
+Long sustained samples without rhythmic content: duration > 2s,
+no ACID beats, probably no clean bar-count match. The classifier
+returns "loop" based on duration, which is arguably wrong (a
+drone doesn't loop in the rhythmic sense).
+
+Options:
+- Add "drone" as a fourth kind category.
+- Accept the loop classification and use additional features
+  (zcr, onset density) to distinguish "rhythmic loop" from
+  "sustained loop" at search time.
+
+Probably option 2 for now. A drone classified as a loop is still
+useful in compatibility and layering queries because both are
+sustained content.
+
+### Long one-shots with decay
+
+A cymbal crash can decay for 6+ seconds. Classified as loop by
+duration. But there's no rhythm, no ACID metadata, and the file
+is just a single event.
+
+Fix: the RMS envelope shape augmentation would catch this. If the
+envelope decays sharply to silence in the second half, it's a
+one-shot regardless of total duration.
+
+Current classifier misclassifies these. Not a priority if the use
+case is rare.
+
+### Very short loops
+
+A half-beat fill at 160 BPM is 190ms. ACID-labeled as 1 beat, but
+duration < 0.3 threshold would classify it as one-shot. Since ACID
+beats > 0 wins in the classifier, this works out correctly.
+
+### Vocal phrases and atmospherics
+
+A 3-second vocal phrase without ACID metadata classifies as loop
+by duration. It's not rhythmic, but it's also not a one-shot. Might
+actually want "sample" or "clip" as a category.
+
+The current "loop" classification works OK because vocal phrases
+do often layer like loops. The distinction might not be worth the
+complexity.
+
+---
+
+## Kind filter in search
+
+Once kind is indexed, search by kind is trivial SQL:
+
+```sql
+SELECT * FROM samples
+WHERE bpm BETWEEN 118 AND 128
+  AND kind = 'loop'
+LIMIT 20;
+```
+
+Or via the MCP:
+
+```
+search_samples({
+    bpm_min: 118,
+    bpm_max: 128,
+    kind: "loop"
+})
+```
+
+New parameter on `search_samples`. Matches the existing filter
+pattern.
+
+Similarly for `find_compatible`:
+
+```
+find_compatible({
+    path: "/path/to/loop.wav",
+    kind: "loop"              # default: match target kind
+})
+```
+
+Default should auto-match to the target's kind. Explicit override
+lets the caller cross-kind (e.g. "find one-shots that harmonically
+match this loop" for drop-in decoration material).
+
+---
+
+## Gotchas
+
+### Kind is a hint, not truth
+
+The classifier is lossy. There will always be misclassifications.
+Treat kind as a soft filter that can be relaxed with an explicit
+override, not a hard categorical assertion.
+
+### Mid-duration ambiguity is real
+
+Samples between 0.5 and 2 seconds without ACID metadata are
+often ambiguous by design. The classifier marks them as such. UI and
+query surfaces should expose this as a first-class category, not
+hide it under "loop" or "one_shot" randomly.
+
+### Kind might change with upstream improvements
+
+If `acid_beats` becomes more reliable (better parsers, more format
+support), the ACID-beats-authoritative rule becomes more useful.
+If RMS envelope becomes part of the index, decay shape becomes a
+signal. Kind is a derived field; re-derive it when inputs improve.
+
+### Caching vs recomputing
+
+Store kind in the DB for fast filtering, but mark it as a derived
+field. If the inference rules change, all stored kinds should be
+re-derived. Same migration pattern as features versioning.
+
+---
+
+## Integration with the agent workflow
+
+Kind classification enables entire query patterns that don't work
+without it:
+
+### "Find me drums at 128 BPM"
+
+```
+search_samples({
+    bpm_min: 126, bpm_max: 130,
+    kind: "one_shot",
+    text: "drum"            # could be filename/tag hit
+})
+```
+
+Without kind filter, returns loops too and the user has to manually
+sort.
+
+### "Find me tonal loops in F that could go under this loop"
+
+```
+find_compatible({
+    path: target_loop,
+    kind: "loop",            # auto-match from target
+    min_duration: 2.0        # at least a 1-bar loop
+})
+```
+
+Without kind, returns compatible one-shots mixed with loops.
+
+### "Suggest layering candidates for this kick"
+
+```
+find_compatible({
+    path: kick_oneshot,
+    kind: "loop"             # explicit override to cross-kind
+})
+```
+
+Returns loops that harmonically match the kick's detected root
+note, so you can sit the kick under a tonal loop.
+
+---
+
+## References
+
+- No direct academic reference; this is engineering pragmatics.
+- The loop/one-shot distinction comes from sample-library
+  conventions established by ReCycle / ACID / Ableton Live
+  browsers in the 1990s-2000s.
+- Duration-based classification is standard in commercial sample
+  librarians (Sononym, Atlas, ADSR) but rarely documented.
+- See `riff.py` for how `acid_beats` gets into the index.
+- See `dsp/rhythm_and_bpm.md` for how `bpm` and `beat_count` are
+  computed (needed for the bar-count augmentation).
+- See `dsp/similarity.md` for how kind filtering integrates with
+  similarity search.

--- a/docs/dsp/mfcc.md
+++ b/docs/dsp/mfcc.md
@@ -1,0 +1,482 @@
+# MFCC (Mel-Frequency Cepstral Coefficients)
+
+The workhorse timbre descriptor for almost every audio classification
+and similarity task for the last 40 years. Covers the mel scale, the
+log-mel spectrogram, the cepstrum concept, the DCT step that produces
+the coefficients, and what each of the 13 coefficients tends to encode.
+
+Last updated: 2026-04-23
+
+---
+
+## What they are
+
+An MFCC is one of a set of scalars, typically 13 per analysis frame,
+that together describe the **shape of the short-term power spectrum**
+on a perceptual frequency scale. The key properties:
+
+- **Compact**: 13 numbers instead of 1024+ spectral bins.
+- **Decorrelated**: the DCT step produces coefficients that are
+  roughly independent, so they play well with distance metrics.
+- **Perceptually scaled**: the mel warp matches human pitch
+  perception.
+- **Discriminative for timbre**: two instruments playing the same
+  note but with different tones produce clearly different MFCC
+  profiles.
+
+"Cepstral" comes from reversing "spectral": the cepstrum is the
+spectrum of a spectrum. It captures structure in how energy is
+distributed across frequency, separated from the absolute level of
+any individual frequency bin.
+
+---
+
+## The four-step pipeline
+
+Mental model:
+
+```
+    signal
+       │ STFT
+       ▼
+    power spectrum         (linear frequency axis, raw power)
+       │ mel filter bank
+       ▼
+    mel spectrogram        (mel frequency axis, perceptually scaled)
+       │ log
+       ▼
+    log-mel spectrogram    (compressed dynamic range)
+       │ DCT
+       ▼
+    MFCCs                  (decorrelated, low-dim timbre vector)
+```
+
+Four operations, each doing one well-understood thing. The output of
+each step is a valid and useful feature in its own right; MFCC is
+just the most compact and most common final form.
+
+---
+
+## Step 1: STFT power spectrum
+
+Standard short-time Fourier transform. For frame `t` and bin `k`:
+
+```
+    |X[t, k]|^2   =  squared magnitude of STFT bin
+```
+
+This is the raw frequency content, on a linear Hz axis. Usually
+`n_fft = 2048` at sr=44100 gives 1025 unique frequency bins from
+0 Hz to ~22 kHz.
+
+---
+
+## Step 2: The mel scale and filter bank
+
+The linear Hz axis isn't perceptually uniform. Humans hear pitch on
+a roughly logarithmic scale: the interval between 100 Hz and 200 Hz
+feels like the same musical distance as 1000 Hz and 2000 Hz (an
+octave each). The **mel scale** is a perceptually-motivated warp.
+
+### Hz to mel formula
+
+```
+    m = 2595 * log10(1 + f / 700)
+```
+
+At low frequencies (below ~500 Hz) this is roughly linear. At high
+frequencies it becomes logarithmic. Some alternative formulas exist
+(Slaney, Zwicker-Bark) but librosa uses the above by default.
+
+### The filter bank
+
+A mel filter bank is a set of triangular filters, each centered at a
+mel-equal-spaced frequency, with width spanning the distance between
+neighbors:
+
+```
+  mag
+   │        ___
+   │       /   \
+   │    __/     \__
+   │   /           \_ ...
+   │  /              \
+   └──┴───┴───┴────┴──── freq
+      f1  f2   f3   f4
+```
+
+Passing the linear power spectrum through this filter bank produces
+a mel-warped representation where each output is the energy in a
+perceptual band. With `n_mels = 128` (librosa default for
+melspectrogram), you get 128 values per frame instead of the 1025
+raw STFT bins.
+
+For MFCC use, a smaller bank (40 or 64 mel filters) is more
+traditional, because too many filters makes subsequent DCT
+compression less meaningful.
+
+### Why triangular and not rectangular
+
+Triangular filters have smooth rolloff. A sharp rectangular edge
+causes ringing artifacts in the output. Triangles are the simplest
+shape that smoothly averages adjacent bins without artifacts, and
+they're what every speech processing pipeline has used since the
+1970s.
+
+---
+
+## Step 3: Log compression
+
+Human loudness perception is roughly logarithmic. A sound 10x more
+intense is perceived as twice as loud, not 10x. To make downstream
+distance metrics behave more like perceptual distances, take the
+logarithm of the mel spectrogram:
+
+```
+    log_mel[t, m]  =  log( max(mel[t, m], epsilon) )
+```
+
+`epsilon` is a small positive value (like 1e-10) to avoid log(0).
+Alternative: `log(1 + mel)`, which is more stable for quiet frames.
+
+Log compression has two effects:
+
+1. **Compresses dynamic range**. A transient 100x louder than the
+   surrounding content becomes 2 log units higher instead of 100x
+   larger. Subsequent processing is less dominated by loudest frames.
+2. **Converts multiplicative to additive**. Source-filter models of
+   sound production say a signal is `source * filter` in frequency
+   domain. Taking logs turns this into `log(source) + log(filter)`,
+   which the DCT can then partially separate.
+
+---
+
+## Step 4: Discrete Cosine Transform
+
+The log-mel vector for one frame is `N_mels`-dimensional (e.g. 40).
+The DCT projects this vector onto a set of cosine basis functions
+and keeps the first `N_mfcc` coefficients (typically 13).
+
+### The DCT basis
+
+For a length-N signal, the DCT produces coefficients:
+
+```
+    C[k] = sum over n in [0, N-1] of  x[n] * cos( pi * (n + 0.5) * k / N )
+```
+
+for `k` from 0 to N-1. The basis functions are cosines at increasing
+frequencies:
+
+```
+    k=0:  ──────────    (flat, captures overall mean/level)
+    k=1:  ───     ───   (one half-cycle, captures tilt)
+    k=2:  ─  ─  ─  ─    (one cycle, captures broad shape)
+    k=3:  - - - - - -   (higher cycles, finer detail)
+    ...
+```
+
+Keeping only the first `N_mfcc` coefficients throws away the
+high-frequency details in the log-mel spectrum, keeping the smooth
+shape.
+
+### Why this is the trick
+
+The log-mel spectrogram of a typical signal has a smooth envelope
+plus high-frequency fluctuations. The envelope encodes the vocal
+tract shape, instrument body resonance, or other slowly-varying
+timbre characteristics. The high-frequency fluctuations mostly
+encode noise and fine spectral detail that's not perceptually
+distinguishing.
+
+The DCT compactly represents the envelope in the first few
+coefficients and pushes the noise into higher coefficients that
+get discarded. This is dimensionality reduction that preserves the
+discriminative information.
+
+### Why 13 coefficients
+
+Standard choice from the speech recognition literature. The first
+13 coefficients capture most of the envelope information for speech
+(which is the historical use case). Some applications use more (20,
+26, or 40); ours uses 13 because it's the standard and
+cross-compatible with most published feature datasets.
+
+### Coefficient 0
+
+`MFCC[0]` encodes the overall log-energy (roughly the average of the
+log-mel vector). Some implementations discard it explicitly because
+it's essentially a loudness measure and correlates heavily with RMS.
+librosa returns it by default; acidcat keeps it.
+
+---
+
+## What each coefficient tends to mean
+
+This is hand-wavy because exact interpretation depends on the
+specific filter bank, window size, and input content. But general
+tendencies:
+
+| coefficient | loose interpretation |
+|-------------|----------------------|
+| MFCC[0] | overall log-energy (level/loudness proxy) |
+| MFCC[1] | spectral tilt (brighter vs darker overall) |
+| MFCC[2] | bimodality (two-peaked vs one-peaked spectrum) |
+| MFCC[3] | finer shape: three lobes |
+| MFCC[4-12] | progressively finer spectral shape detail |
+
+For distinguishing a kick drum from a snare, the first 3-4
+coefficients do most of the work. For distinguishing two similar
+violins, you need coefficients 5-12 to pick up the finer body
+resonance differences.
+
+### Visualizing MFCC differences
+
+Two samples with different timbres plotted as 13-D points:
+
+```
+kick drum:     [4.2,  -1.1,  0.3,  -0.2,  0.1, ...] (dark, one big peak in bass)
+snare:         [3.8,   0.5,  2.1,  -0.4,  1.3, ...] (mid-forward, multi-peak)
+hi-hat:        [2.1,   3.2,  1.8,   1.5, -0.2, ...] (bright, narrow high peak)
+pad (dark):    [3.5,  -2.3,  0.1,  -0.1,  0.0, ...] (sustained, low coefficients small)
+pad (bright):  [3.5,   1.8,  0.2,  -0.1,  0.0, ...] (same shape category, brightness inverted)
+```
+
+Distance in 13-D MFCC space correlates reasonably well with
+perceptual timbre distance, which is why similarity scoring works.
+
+---
+
+## librosa implementation
+
+```python
+mfccs = librosa.feature.mfcc(y=y, sr=sr,
+                              n_mfcc=13,
+                              n_fft=2048,
+                              hop_length=512,
+                              n_mels=128,
+                              htk=False,
+                              lifter=0)
+```
+
+Returns shape `(n_mfcc, T)` where `T` is the number of frames.
+
+Parameters worth knowing:
+
+| parameter | default | effect |
+|-----------|---------|--------|
+| `n_mfcc` | 13 | how many coefficients to keep |
+| `n_mels` | 128 | size of mel filter bank before DCT |
+| `htk` | False | use HTK's slightly different mel formula vs Slaney's |
+| `lifter` | 0 | cepstral liftering, emphasizes higher coefficients |
+| `dct_type` | 2 | DCT variant; type 2 is the standard |
+| `norm` | 'ortho' | orthonormal DCT, preserves energy |
+
+### HTK vs Slaney mel
+
+Two competing definitions of the mel scale exist. HTK's formula:
+
+```
+    m = 2595 * log10(1 + f / 700)
+```
+
+Slaney's auditory toolbox formula:
+
+```
+    piecewise: linear below 1000 Hz, logarithmic above
+```
+
+librosa's default (`htk=False`) uses Slaney's version, which is
+slightly closer to human perception measurements. Most published
+MFCC datasets use HTK. If comparing against external datasets, set
+`htk=True`.
+
+---
+
+## acidcat implementation
+
+In `core/features.py`:
+
+```python
+mfccs = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13)
+for i in range(13):
+    features[f'mfcc_{i+1}_mean'] = np.mean(mfccs[i])
+    features[f'mfcc_{i+1}_std']  = np.std(mfccs[i])
+```
+
+Stores 26 values total: mean and std of each of the 13 coefficients.
+Indexed 1-13 in the field names (acidcat uses 1-based naming to match
+MPEG-7 conventions; librosa returns 0-indexed rows).
+
+The mean captures the average timbre character over the clip; the
+std captures how much the timbre varies. A static drone has low
+std across all coefficients; a dynamic synth lead has higher std
+especially in coefficients 1-3 (which track brightness).
+
+---
+
+## Why MFCCs work so well for similarity
+
+Three properties that are hard to find together in other features:
+
+### Decorrelation
+
+The DCT projects onto orthogonal basis functions. The coefficients
+are therefore much less correlated with each other than raw
+spectrogram bins would be. This matters for distance metrics:
+Euclidean or cosine distance assumes independent dimensions, and
+redundant dimensions effectively double-count.
+
+### Dimensionality
+
+13 numbers is small enough to store cheaply, index efficiently, and
+compute distances over without special tricks. The full mel
+spectrogram of a 10-second clip is ~100k numbers.
+
+### Robustness
+
+MFCCs are relatively insensitive to:
+
+- Overall loudness changes (coefficient 0 captures this separately
+  and can be discarded)
+- Pitch shifts within reason (the log-mel envelope shifts vertically,
+  coefficients 1+ largely preserve shape)
+- Minor spectral noise (DCT discards high-frequency fluctuations)
+
+They are sensitive to:
+
+- Timbre differences (which is what we want)
+- Major formant shifts
+- Time-varying articulation (when looking at the time series)
+
+---
+
+## Interpretation examples
+
+Numerical intuition for the first three coefficients across common
+sample types. Values are approximate, from a handful of test clips.
+
+```
+                        MFCC[0]  MFCC[1]  MFCC[2]
+808 kick, long decay    4.1      -2.8     0.2
+snare, tight            3.9       0.1     1.8
+closed hi-hat           2.0       3.5     1.2
+crash cymbal            2.2       4.1     2.8
+deep pad                3.3      -1.9    -0.3
+bright pad              3.3       1.4     0.1
+piano C4 chord          3.5      -0.3     0.4
+distorted guitar chord  3.8       0.8     1.9
+vocal "ah" sustained    3.2      -0.1     1.5
+white noise             2.5       0.0     0.0
+```
+
+Patterns to notice:
+
+- Low MFCC[0] (under 3) correlates with quieter or more sparse signal.
+- Negative MFCC[1] correlates with darkness (bass-heavy content).
+- Positive MFCC[1] correlates with brightness.
+- MFCC[2] distinguishes mid-forward (piano, snare, vocal) from
+  purely high (cymbal) or purely low (kick).
+
+These patterns are not rigid rules but they hold well enough that
+humans can often classify unlabeled samples by looking at the first
+three coefficients.
+
+---
+
+## Gotchas
+
+### Linearly separable is not the same as perceptually matching
+
+Two samples with close MFCC vectors usually sound similar. Two
+samples with different MFCC vectors usually sound different. But the
+mapping isn't 1:1. Two distinct timbres can produce similar MFCCs
+(e.g. a muted guitar and a soft woodblock have surprisingly close
+profiles). Useful for "close matches" but not for absolute
+perceptual classification.
+
+### Log-mel before DCT vs power-mel before DCT
+
+Some papers use power (mel-spectrogram without log). This produces
+very different coefficients because the log compression was critical
+to getting a smooth envelope. librosa's default is log-mel, which
+is correct. Don't mix conventions across datasets.
+
+### Silence and near-silence
+
+For silent or near-silent frames, the log-mel vector is dominated by
+the `epsilon` floor. MFCC values become numerically unstable or
+content-free. The extractor doesn't special-case this; frames where
+`rms < threshold` could be excluded from the mean/std aggregation,
+but currently aren't.
+
+### Very short clips
+
+Samples under ~200ms produce only a few MFCC frames. Mean and std
+are unreliable estimators of the distribution. For one-shots, the
+coefficient values from a single frame in the middle of the sample
+are often more meaningful than statistics over a few frames.
+
+### Window length tradeoff
+
+`n_fft=2048` gives 46ms analysis windows. For percussive samples
+with fast transients (< 50ms), this window is longer than the
+sample itself, smearing the attack across multiple frames. For
+analysis of transient-rich material, `n_fft=512` or `1024` is a
+better choice at the cost of frequency resolution.
+
+acidcat uses the librosa default. If the index grows and we find
+percussive material poorly discriminated, switching to `n_fft=1024`
+specifically for percussive-classified samples would be worth
+trying.
+
+### Cepstral liftering
+
+The `lifter` parameter applies a sinusoidal weighting to the MFCCs
+that de-emphasizes the lowest coefficients and emphasizes the
+higher. This was useful in old speech recognition systems; modern
+feature vectors usually set `lifter=0` (no liftering). acidcat uses
+the default.
+
+---
+
+## Alternatives to MFCC worth knowing
+
+- **PLP (Perceptual Linear Prediction)**: similar idea, different
+  filter bank (Bark scale) and a linear prediction step instead of
+  DCT. Used more in speech than music.
+- **RASTA-PLP**: PLP with adaptive temporal filtering, good for
+  noisy environments.
+- **Constant-Q Cepstral Coefficients (CQCC)**: same idea but using a
+  CQT instead of STFT for the initial spectrum, giving uniform
+  semitone resolution. More musically appropriate but less widely
+  used.
+- **Spectrogram features**: raw mel spectrogram as input to a CNN.
+  Modern deep-learning approach, sidesteps the dimensionality
+  reduction question by letting the network learn it.
+
+For acidcat's current scope (fast similarity over a local library),
+MFCC is the right choice. If we add learned embeddings later,
+they'd go alongside MFCC, not replace it.
+
+---
+
+## References
+
+- Davis, S. B., & Mermelstein, P. (1980). "Comparison of parametric
+  representations for monosyllabic word recognition in continuously
+  spoken sentences." *IEEE Transactions on Acoustics, Speech, and
+  Signal Processing* 28(4): 357-366. The original MFCC paper.
+- Logan, B. (2000). "Mel frequency cepstral coefficients for music
+  modeling." *ISMIR 2000*. Makes the case for MFCC in music contexts.
+- Slaney, M. (1998). "Auditory toolbox." *Technical Report 1998-010,
+  Interval Research Corporation*. Defines Slaney's mel formula that
+  librosa uses by default.
+- Young, S., et al. (2006). *The HTK Book*. Cambridge University
+  Engineering Department. Reference for HTK-style mel formula and
+  MFCC conventions used in most published speech datasets.
+- librosa MFCC documentation: <https://librosa.org/doc/latest/generated/librosa.feature.mfcc.html>
+- See `dsp/spectral_features.md` for the non-cepstral timbre features
+  that complement MFCC.
+- See `dsp/feature_pipeline.md` for how MFCC fits into the full
+  feature vector acidcat stores.

--- a/docs/dsp/onset_detection.md
+++ b/docs/dsp/onset_detection.md
@@ -1,0 +1,543 @@
+# Onset Detection
+
+Finding where in time "something happens" in an audio signal. The
+input to beat tracking, rhythmic analysis, and any slicing or
+segmentation task. The `rhythm_and_bpm.md` doc covers how onsets
+feed tempo estimation; this one goes deeper on how the onsets
+themselves are computed.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+An **onset** is the perceptual start of a musical event. In most
+common sense: the attack of a note, the hit of a drum, the pluck
+of a string. More formally, it's the moment at which a new energy
+pattern becomes perceptually salient.
+
+Onset detection has two outputs:
+
+- **Onset strength envelope**: a continuous one-dimensional
+  function of time whose value is high at candidate onset moments
+  and low otherwise. This is what librosa's
+  `onset.onset_strength` returns.
+- **Onset times**: discrete times picked from peaks in the onset
+  strength envelope. This is what `onset.onset_detect` returns.
+
+acidcat uses the envelope directly for BPM estimation (via
+`beat.tempo` or `beat.beat_track`), but the discrete times are
+useful for slicing, segmentation, and "count the hits" queries.
+
+---
+
+## The general approach
+
+```
+    audio waveform
+          │
+          ▼
+    short-time spectral analysis    (STFT or mel-STFT)
+          │
+          ▼
+    detection function              (some form of "change" signal)
+          │
+          ▼
+    optional post-processing        (normalize, smooth)
+          │
+          ▼
+    onset strength envelope         (continuous)
+          │
+          ▼
+    peak picking                    (adaptive threshold + local max)
+          │
+          ▼
+    onset times                     (discrete list)
+```
+
+The interesting part is the **detection function**: what measure of
+"change in the spectrum" best captures onsets.
+
+---
+
+## Detection function variants
+
+### Simple spectral flux
+
+The baseline. For each time frame `t` and frequency bin `k`,
+compute how much louder the spectrum got compared to the previous
+frame:
+
+```
+    flux_simple[t] = sum over k of max(0, |X[t, k]| - |X[t-1, k]|)
+```
+
+Only positive differences contribute. Decreasing energy (release
+tails of notes) doesn't add to the onset signal.
+
+Properties:
+
+- Cheap to compute.
+- Works well for drum hits and strongly-articulated notes.
+- Fails for soft onsets (legato passages, glissando, crossfades).
+
+### Log-amplitude spectral flux
+
+Take log of magnitudes before the difference:
+
+```
+    flux_log[t] = sum over k of max(0, log(|X[t, k]| + 1) - log(|X[t-1, k]| + 1))
+```
+
+Log compression equalizes the dynamic range. A quiet onset
+contributes similarly to a loud onset. Without log, loud onsets
+dominate and quiet ones get lost.
+
+This is librosa's default.
+
+### Mel-weighted spectral flux
+
+Instead of linear frequency bins, use mel-scaled filter bank
+outputs. The mel scale compresses the frequency axis
+perceptually; mid-range frequencies (where most rhythmic content
+lives) get emphasis, extreme lows and highs get less.
+
+```
+    mel_spec = librosa.feature.melspectrogram(y=y, sr=sr)
+    mel_log = librosa.power_to_db(mel_spec)
+    flux[t] = sum over m of max(0, mel_log[m, t] - mel_log[m, t-1])
+```
+
+More robust than linear-frequency flux for music because it
+de-emphasizes low-frequency noise and high-frequency cymbal wash
+that can mask onsets.
+
+### Complex spectral difference
+
+Instead of just magnitude difference, include phase information:
+
+```
+    D[t, k] = |X[t, k] * exp(-jφ_predicted[t, k]) - X[t, k]|
+```
+
+Where `φ_predicted` is the phase expected if the spectrum had
+evolved smoothly from the previous frame (based on phase advance
+from adjacent frames' frequency).
+
+For a pure sustained tone, phase advances predictably between
+frames, so the complex difference is small. For an onset, phase
+changes abruptly, so the complex difference is large. This catches
+soft onsets that pure magnitude methods miss.
+
+More expensive but more accurate for pitched material with gentle
+attacks.
+
+### Superflux
+
+A variant of spectral flux that uses the maximum filter across
+frequency bins:
+
+```
+    superflux[t, k] = max(0, mag[t, k] - max(mag[t-1, k-1:k+1]))
+```
+
+The inner `max` looks across a small frequency window. Effect:
+vibrato, pitch-bend, and frequency modulation that would normally
+create spurious onsets in pure spectral flux get smoothed out. Real
+onsets still produce peaks.
+
+Good for sustained pitched material with ornamentation. Available
+in madmom but not in librosa core.
+
+### Phase-based methods
+
+Onset detection using only phase information, no magnitude. Phase
+changes abruptly at onsets because the signal transitions from one
+predictable phase evolution to another. Works well for quiet
+onsets but is noisy and rarely used alone; usually combined with
+magnitude methods.
+
+### Energy-based methods
+
+Just look at the RMS envelope and pick its derivatives. Simplest
+possible method. Works for percussive material but fails for
+everything else because sustained tones change energy only during
+attack and release.
+
+---
+
+## librosa's implementation
+
+### `onset_strength`
+
+```python
+librosa.onset.onset_strength(y=y, sr=sr,
+                              S=None,               # optional pre-computed mel-spectrogram
+                              n_fft=2048,
+                              hop_length=512,
+                              aggregate=np.mean,    # how to aggregate bands
+                              feature=librosa.feature.melspectrogram,
+                              center=True,
+                              detrend=False)
+```
+
+Default pipeline (when `S=None`):
+
+1. Compute mel spectrogram (`n_mels=128`).
+2. Take log: `librosa.power_to_db`.
+3. Compute positive first-order difference along time axis.
+4. Aggregate across mel bands via `np.mean`.
+5. Return 1D array sampled at frame rate.
+
+Output shape: `(T,)` where T is number of frames.
+
+Frame rate: `sr / hop_length`. At 44.1k/512 = 86.1 Hz, each sample
+represents ~11.6ms.
+
+### `onset_detect`
+
+```python
+librosa.onset.onset_detect(y=y, sr=sr,
+                            onset_envelope=None,
+                            units='frames',
+                            pre_max=0.03 * sr // hop_length,   # 30ms
+                            post_max=0.00 * sr // hop_length,
+                            pre_avg=0.10 * sr // hop_length,   # 100ms
+                            post_avg=0.10 * sr // hop_length,
+                            delta=0.07,
+                            wait=0.03 * sr // hop_length)       # 30ms
+```
+
+Picks peaks from the onset envelope using adaptive thresholding.
+Parameters control the peak-picking behavior (covered below).
+
+Returns array of frame indices (or seconds, or samples, depending
+on `units`).
+
+---
+
+## Peak picking
+
+The onset strength envelope has peaks at candidate onsets and dips
+between. Not every peak is a real onset: small peaks are noise, and
+large peaks within a few ms of a previous onset are echoes or
+partial re-articulations.
+
+### Local maximum requirement
+
+A point `t` is a candidate peak iff it's the maximum within a
+window `[t - pre_max, t + post_max]`. This handles noise that
+creates small fluctuations; a real peak must dominate its
+neighborhood.
+
+### Adaptive threshold
+
+A point is only kept as an onset iff it exceeds a running local
+mean by some delta:
+
+```
+    threshold[t] = mean(envelope[t - pre_avg : t + post_avg]) + delta
+    if envelope[t] > threshold[t]: keep as onset
+```
+
+`delta` is an absolute offset. Higher delta = fewer, more confident
+onsets. Lower delta = more onsets including false positives.
+
+### Refractory period
+
+After detecting an onset at `t0`, no new onset is allowed within
+`wait` frames. Prevents double-detection of a single event.
+
+Default `wait = 30ms` prevents a drum hit from being detected
+twice due to secondary excitation of the drum's body resonance.
+
+### Tuning for different material
+
+Defaults are general-purpose. For specific needs:
+
+- **Dense polyphony**: reduce `delta` (allow more onsets), increase
+  `pre_avg` and `post_avg` (smoother threshold).
+- **Sparse percussion**: increase `delta` (require stronger peaks).
+- **Fast drums**: decrease `wait` (allow closer-together detections).
+- **Legato material**: decrease `delta` aggressively or use the
+  complex spectral difference method.
+
+---
+
+## acidcat usage
+
+Currently in two places:
+
+### `core/detect.py` (BPM pipeline)
+
+```python
+onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+tempos_1 = librosa.beat.tempo(onset_envelope=onset_env, sr=sr, aggregate=None)
+tempos_2 = librosa.beat.tempo(y=y, sr=sr, aggregate=None)
+```
+
+Uses onset envelope as input to tempo estimation. The envelope
+drives the autocorrelation that finds periodicity.
+
+### `core/features.py` (feature extraction)
+
+```python
+onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+tempo, beats = librosa.beat.beat_track(onset_envelope=onset_env, sr=sr)
+features['tempo_librosa'] = float(np.atleast_1d(tempo)[0])
+features['beat_count'] = len(beats)
+```
+
+The `beats` array is the output of beat tracking, which internally
+uses peak picking on the onset envelope.
+
+### What's not exposed
+
+Currently acidcat doesn't expose the raw onset times to the index
+or the MCP surface. Two opportunities:
+
+- **Onset density** as an index field: `onsets_per_second`. Useful
+  for kind inference (drums have high density, pads low) and for
+  search ("find me busy, percussive material").
+- **`detect_onsets(path)` MCP tool**: return the list of onset
+  times for a file. Useful for slicing workflows, rhythmic analysis,
+  and agent-driven "what's happening in this file" questions.
+
+Both would be small additions. Neither changes the architecture.
+
+---
+
+## Interpretation
+
+### The envelope shape
+
+```
+    onset strength
+     ^
+     |   ___                    ___
+     |  |   \                  |   \
+     |  |    \                 |    \___
+     |__|     \________________|         \____
+     |                                         
+     +─────────────────────────────────────> time
+        onset 1                  onset 2
+```
+
+Sharp peaks at the hits, near-zero between. Duration and shape of
+each peak depend on the attack characteristics and the window
+size.
+
+For a clean kick drum: envelope rises from 0 to peak in 1-2 frames
+(~12-24ms), falls over 5-10 frames (~60-120ms). Very clean peak.
+
+For a soft pad swell: envelope rises smoothly over 30-50 frames
+(~350-600ms), with no clear single peak. Peak picking has trouble
+here; the complex spectral difference method works better.
+
+### Counting onsets
+
+Given onset times, the count per unit time tells you:
+
+- **0-1 onsets/second**: drone, sustained note, very slow material.
+- **1-3 onsets/second**: ambient, slow melody, soft percussion.
+- **3-6 onsets/second**: moderate rhythmic content, mid-tempo drums.
+- **6-12 onsets/second**: busy percussion, fast ornamentation, fills.
+- **12+ onsets/second**: very dense material, noise textures.
+
+### Onset patterns
+
+Periodic onsets at regular intervals indicate rhythmic content
+(loops, drums, ostinato). Irregular onsets indicate melodic or
+ornamental content.
+
+Inter-onset interval (IOI) histograms show the rhythmic structure:
+
+```
+    IOI count
+     ^
+     |       |       
+     |       |       
+     |       |        |
+     |__|____|__|_____|____|_____ IOI (ms)
+        125  250      500  1000
+        
+    drum beat       1/2 beat       2 beats
+```
+
+Peaks at multiples of a base interval indicate a clear meter. A
+flat IOI distribution indicates unmetered content.
+
+---
+
+## Gotchas
+
+### Window length tradeoff
+
+Larger `n_fft` = better frequency resolution but worse time
+resolution. For onset detection you want sharp time resolution, so
+smaller `n_fft` (512, 1024) is often better than the 2048 default.
+
+librosa's onset_strength default uses 2048. Overriding to 1024
+typically produces slightly tighter onset detection on percussive
+material at the cost of some noise on sustained material.
+
+### Sensitivity parameter (`delta`)
+
+The single biggest lever for tuning peak picking. Wrong value is
+the most common cause of bad onset detection.
+
+Too low: many false positives (detecting noise or slight
+modulations as onsets).
+
+Too high: missing real onsets, especially quiet ones.
+
+Default 0.07 works for many cases but not all. For drum-heavy
+material, 0.15 is often better. For pad-heavy material with soft
+onsets, 0.04 is better. No one value is correct for all material.
+
+### Attack vs note start
+
+The "onset" detected by these algorithms is the audible attack,
+which is slightly after the actual note start. The attack is what
+the ear responds to, and that's what the envelope picks up.
+
+For some applications (MIDI transcription, score alignment), you
+want the note start, which is earlier. Heuristic: subtract 5-10ms
+from each detected onset.
+
+For BPM and rhythmic analysis, attack time is the right thing.
+
+### Polyphonic onset smearing
+
+When multiple events happen within a few ms (e.g. a drum fill's
+last two hits), they can blur into a single peak. Peak picking
+with a low `wait` setting can separate them, but at the cost of
+more false positives elsewhere.
+
+Neural onset detectors (madmom's RNN-based detector) handle this
+much better. For acidcat's scope, the librosa approach is
+"good enough."
+
+### Frequency-specific onsets
+
+A bass-heavy sample with kicks and a treble-heavy sample with
+hi-hats produce different onset envelopes when analyzed with a
+broadband method. If you care specifically about one frequency
+range, run onset detection on the mel-spectrogram restricted to
+that range:
+
+```python
+S = librosa.feature.melspectrogram(y=y, sr=sr, fmin=50, fmax=200)
+onset_env = librosa.onset.onset_strength(S=S, sr=sr)
+# bass-only onset envelope
+```
+
+Useful for separating kick onsets from snare onsets on full-mix
+drum loops.
+
+### Edge effects
+
+The first and last frames of a file produce unreliable onset
+values because the difference computation needs a previous frame.
+librosa handles this by padding, but the first 2-3 frames'
+onset values should be considered suspect.
+
+Not a practical problem for samples longer than ~100ms but worth
+knowing for very short clips.
+
+---
+
+## Advanced techniques worth knowing
+
+### Madmom's RNN onset detector
+
+Madmom is a music information retrieval library with a
+recurrent-neural-network-based onset detector trained on
+hand-labeled data. Much more accurate than librosa's signal
+processing methods, especially for:
+
+- Soft onsets
+- Dense polyphonic material
+- Non-standard instrumentation
+- Noisy or low-quality audio
+
+Cost: large model weights (hundreds of MB), slower inference,
+additional dependency.
+
+Integration approach if we ever added it: optional `[madmom]`
+extra, use it only for `detect_onsets` and hi-quality beat
+tracking, default remains librosa for speed.
+
+### Multi-source onset fusion
+
+Run multiple detection functions and combine their outputs:
+
+```python
+flux = librosa.onset.onset_strength(y=y, sr=sr,
+                                     feature=librosa.feature.melspectrogram)
+cplx = complex_onset(y, sr)
+phase = phase_onset(y, sr)
+
+fused = 0.5 * flux + 0.3 * cplx + 0.2 * phase
+```
+
+Different methods catch different onset types. Fusion improves
+recall without sacrificing much precision, at the cost of 3x
+compute.
+
+### Rhythm-aware tracking
+
+Some methods use a predictive model: once you've detected several
+onsets at a regular interval, bias subsequent detection toward
+expected beat positions. librosa's beat tracker does this via
+dynamic programming. More sophisticated methods (PLP, particle
+filters) can adapt more gracefully to tempo changes.
+
+---
+
+## Summary
+
+Onset detection is a one-line call in acidcat but it's worth
+understanding because:
+
+1. The onset envelope is the foundation for all rhythmic analysis.
+   Bad envelope = bad BPM, bad beat_count, bad tempogram.
+2. The parameters have significant effect on accuracy but currently
+   use librosa defaults.
+3. Exposing onset density as an indexed feature would enable a
+   whole category of queries we don't currently support.
+4. A `detect_onsets` MCP tool would enable slicing and
+   segmentation workflows.
+
+Priority level: not urgent. Current defaults work well enough for
+the typical sample library. But when we want to handle edge cases
+(drone libraries, heavy ornamentation, soft-onset material), the
+parameter tuning and alternative methods documented here are the
+levers to reach for.
+
+---
+
+## References
+
+- Bello, J. P., Daudet, L., Abdallah, S., Duxbury, C., Davies, M., &
+  Sandler, M. B. (2005). "A tutorial on onset detection in music
+  signals." *IEEE Transactions on Speech and Audio Processing*
+  13(5): 1035-1047. Canonical overview of onset detection methods.
+- Böck, S., & Widmer, G. (2013). "Maximum filter vibrato suppression
+  for onset detection." *DAFx 2013*. Introduces superflux.
+- Böck, S., Krebs, F., & Schedl, M. (2012). "Evaluating the online
+  capabilities of onset detection methods." *ISMIR 2012*. Benchmark
+  comparison of major methods including RNN-based.
+- Lerch, A. (2012). *An Introduction to Audio Content Analysis:
+  Applications in Signal Processing and Music Informatics*. IEEE
+  Press. Chapter on onset detection covers the theoretical
+  background.
+- librosa onset documentation:
+  <https://librosa.org/doc/latest/onset.html>
+- madmom onset documentation (if we ever integrate it):
+  <https://madmom.readthedocs.io/en/latest/modules/features/onsets.html>
+- See `dsp/rhythm_and_bpm.md` for how the onset envelope feeds
+  tempo estimation and beat tracking.
+- See `dsp/hpr.md` for HPR preprocessing that gives cleaner onset
+  envelopes on mixed content.

--- a/docs/dsp/rhythm_and_bpm.md
+++ b/docs/dsp/rhythm_and_bpm.md
@@ -1,0 +1,584 @@
+# Rhythm and BPM
+
+How acidcat estimates beats-per-minute from an audio waveform: onset
+detection, autocorrelation of the onset envelope, beat tracking, and
+the validation pipeline that catches librosa's common octave-error
+failure mode.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+**Tempo** is the rate at which musical beats occur, measured in beats
+per minute (BPM). For a 4-on-the-floor kick at 128 BPM, there are
+128 kick hits per minute and the inter-onset interval is 60000/128 =
+469 milliseconds.
+
+**Beat tracking** is the problem of identifying the time position of
+each individual beat, not just the rate. For acidcat's indexing
+purposes we mostly care about the aggregate tempo, but beat positions
+are also returned by `librosa.beat.beat_track` and exposed as
+`beat_count` in the feature vector.
+
+---
+
+## The pipeline
+
+Three conceptual steps:
+
+```
+    audio waveform
+          │
+          ▼
+    onset strength envelope      (continuous curve peaking at note starts)
+          │
+          ▼
+    autocorrelation / tempogram  (which inter-onset intervals are common)
+          │
+          ▼
+    beat tracking                 (fit a periodic pulse to the onsets)
+          │
+          ▼
+    BPM + beat times
+```
+
+Each step has well-understood math and well-understood failure modes.
+
+---
+
+## Step 1: onset strength
+
+An **onset** is a perceptual event in audio, usually corresponding to
+the start of a note, a drum hit, or any sudden spectral change. The
+onset strength envelope is a one-dimensional function of time whose
+value says "how strong is the onset at this time."
+
+### Spectral flux
+
+The core observation: an onset causes a sudden increase in spectral
+energy across many frequency bands at once. Spectral flux is the sum
+of positive frame-to-frame differences in a spectrogram:
+
+```
+    F[t] = sum over k of max(0, |X[t, k]| - |X[t-1, k]|)
+```
+
+where `X[t, k]` is the STFT magnitude at time frame `t`, frequency bin
+`k`. Only positive differences contribute, so decreasing energy
+(decay tails) doesn't add to the onset signal.
+
+### Log-compression
+
+Perceptual loudness is roughly logarithmic, so raw spectral flux
+over-weights high-energy passages and under-weights quiet onsets.
+librosa's default applies `log(1 + X)` compression before the flux
+computation, equalizing the dynamic range.
+
+### Mel weighting
+
+librosa uses a mel-scaled filter bank rather than linear frequency
+bins. This concentrates resolution where human hearing is most
+sensitive (roughly 500 Hz - 4 kHz) and gives less weight to extreme
+lows (where fundamentals live) and extreme highs (where cymbal wash
+lives). For beat tracking, this emphasizes the mid-range where most
+rhythmic information actually sits.
+
+### The final envelope
+
+After the above, `librosa.onset.onset_strength(y=y, sr=sr)` returns a
+one-dimensional float array sampled at the hop rate (default
+hop_length=512 at sr=44100 gives 86.13 Hz, so ~11.6ms per sample).
+
+Peaks in this envelope correspond to perceptual onsets. Troughs are
+gaps between events.
+
+---
+
+## Step 2: autocorrelation for tempo
+
+Given the onset envelope, how do we extract a BPM?
+
+### The autocorrelation approach
+
+Autocorrelation at lag `τ` measures how similar the envelope is to a
+version of itself shifted by `τ`:
+
+```
+    R[τ] = sum over t of F[t] * F[t + τ]
+```
+
+If the envelope has a periodic component with period `τ_0`, then `R[τ]`
+will peak at `τ_0`, `2·τ_0`, `3·τ_0`, etc. The fundamental peak is the
+inter-beat interval. Convert to BPM:
+
+```
+    BPM = 60 * frame_rate / τ_peak
+```
+
+where `frame_rate = sr / hop_length`.
+
+### The tempogram
+
+Rather than a single autocorrelation, librosa computes a **tempogram**:
+autocorrelation of the onset envelope within a sliding analysis window,
+giving a 2D (tempo, time) matrix. This allows for tempo changes over
+time and produces robust estimates even when parts of the signal
+violate the beat grid (fills, breaks, silence).
+
+`librosa.beat.tempo` aggregates the tempogram into a single BPM
+estimate (or a per-frame array). By default it uses a prior that
+favors tempos near 120 BPM to break ties between octave multiples.
+
+### Octave ambiguity
+
+The autocorrelation has peaks at every integer multiple of the true
+inter-beat interval. If the true tempo is 128 BPM, there are peaks at:
+
+```
+    128 BPM (every beat)
+     64 BPM (every 2 beats)
+     32 BPM (every 4 beats)
+    256 BPM (every half-beat, subdivision)
+```
+
+Deciding which peak is the "real" tempo is the hard part. Octave
+errors are the #1 failure mode of beat trackers. More on this below.
+
+---
+
+## Step 3: beat tracking
+
+With a tempo estimate in hand, beat tracking places individual beats
+at consistent intervals aligned to the onset envelope. This is a
+constrained optimization: pick the set of time points that maximize
+onset strength at those points while maintaining near-uniform spacing
+matching the tempo estimate.
+
+`librosa.beat.beat_track` uses dynamic programming to solve this. The
+output is a list of frame indices at which beats fall, convertible to
+seconds via `librosa.frames_to_time`.
+
+For acidcat's current use this is mostly interesting as a count
+(`beat_count` in the feature vector). Per-beat timing gets important
+only for future loop-alignment features.
+
+---
+
+## acidcat's implementation
+
+In `core/detect.py`:
+
+```python
+detected_bpm = None
+try:
+    onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+    tempos_1 = librosa.beat.tempo(onset_envelope=onset_env, sr=sr, aggregate=None)
+    tempos_2 = librosa.beat.tempo(y=y, sr=sr, aggregate=None)
+    all_tempos = []
+    if tempos_1.size > 0:
+        all_tempos.extend(tempos_1)
+    if tempos_2.size > 0:
+        all_tempos.extend(tempos_2)
+    if all_tempos:
+        detected_bpm = round(float(np.median(all_tempos)), 2)
+except Exception:
+    pass
+```
+
+Two observations worth explaining:
+
+### Why two calls to `librosa.beat.tempo`
+
+`tempos_1` uses the pre-computed onset envelope. `tempos_2` re-runs
+the default onset detection internally. These two paths produce
+slightly different estimates because librosa's default onset detector
+has evolved over versions and the internal path applies additional
+smoothing the explicit path doesn't.
+
+Taking the median of both hedges against either one being off. For
+clearly-tempoed material they agree closely; for ambiguous material
+the median damps out outliers.
+
+`aggregate=None` asks for the full per-frame tempo array rather than
+a single summary. We then feed all values into one big median.
+
+### Why median of arrays, not means
+
+Same reasoning as chroma: median is robust to outlier frames where
+the tempo estimator briefly goes haywire (breaks, silence, fills).
+Mean pulls toward those outliers.
+
+In `core/features.py` the approach is different:
+
+```python
+onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+tempo, beats = librosa.beat.beat_track(onset_envelope=onset_env, sr=sr)
+features['tempo_librosa'] = float(np.atleast_1d(tempo)[0])
+features['beat_count'] = len(beats)
+```
+
+Here we use `beat_track` instead of `tempo`, and take the scalar tempo
+output. This is used for ML feature vectors where a single number is
+needed, not for final BPM estimation.
+
+---
+
+## The octave-error problem in detail
+
+Beat trackers often report half-time or double-time relative to the
+perceptual tempo. Why this happens:
+
+### Emphasis of subdivision vs beat
+
+In a 120 BPM hip-hop track, the kick hits on beats 1, 2, 3, 4 but the
+hi-hat often hits on every eighth (240 hits per minute). A beat tracker
+that weights onset energy across the full frequency range can lock
+onto the hi-hat rate, reporting 240 BPM.
+
+### Emphasis of the backbeat
+
+In rock and pop, the snare backbeat on beats 2 and 4 is often the
+loudest onset. A tracker can lock onto those two hits as the
+fundamental period (every 2 beats), reporting 60 BPM for a 120 BPM
+track.
+
+### Triplet feel
+
+In swung or triplet material (jazz, shuffle, dilla beats), the
+subdivision is three per beat, not two. A tracker can lock onto the
+triplet, reporting 3/2 or 2/3 of the correct tempo.
+
+### Ambient / drone / minimal percussion
+
+With few or no percussive onsets, the tempogram becomes noisy and the
+estimate unreliable. Results can be anywhere.
+
+---
+
+## The validation pipeline
+
+Given the known failure modes, acidcat doesn't trust librosa's output
+naively. In `core/detect.py`:
+
+```python
+def validate_and_improve_bpm(detected_bpm, filename_bpm, confidence_threshold=20):
+    if filename_bpm is None:
+        return detected_bpm, 'detected'
+    if detected_bpm is None:
+        return filename_bpm, 'filename'
+    if not (60 <= detected_bpm <= 200):
+        return filename_bpm, 'filename'
+
+    diff = abs(detected_bpm - filename_bpm)
+
+    if diff <= confidence_threshold:
+        return detected_bpm, 'detected'
+    if abs(detected_bpm * 2   - filename_bpm) <= confidence_threshold:
+        return detected_bpm * 2, 'corrected'
+    if abs(detected_bpm / 2   - filename_bpm) <= confidence_threshold:
+        return detected_bpm / 2, 'corrected'
+    if abs(detected_bpm * 1.5 - filename_bpm) <= confidence_threshold:
+        return detected_bpm * 1.5, 'corrected'
+    if abs(detected_bpm / 1.5 - filename_bpm) <= confidence_threshold:
+        return detected_bpm / 1.5, 'corrected'
+
+    return filename_bpm, 'filename'
+```
+
+The logic walks through candidate corrections in order of likelihood.
+
+### Example: 140 BPM track that librosa reports as 70
+
+```
+detected_bpm = 70
+filename_bpm = 140
+confidence_threshold = 20
+
+diff = |70 - 140| = 70           not within 20
+|70*2 - 140| = 0                 within 20! use 70*2 = 140
+```
+
+Result: `(140, 'corrected')`. The octave error is caught.
+
+### Example: 120 BPM track that librosa reports as 240
+
+```
+detected_bpm = 240
+filename_bpm = 120
+
+240 is outside [60, 200]  -> reject, use filename
+```
+
+Result: `(120, 'filename')`. Range check catches the hi-hat lock.
+
+### Example: 90 BPM track that librosa reports as 60
+
+```
+detected_bpm = 60
+filename_bpm = 90
+
+diff = 30                          not within 20
+|60*2 - 90| = 30                   not within 20
+|60/2 - 90| = 60                   not
+|60*1.5 - 90| = 0                  within 20! use 60*1.5 = 90
+```
+
+Result: `(90, 'corrected')`. Triplet-style error caught.
+
+### Example: librosa reports 124 on a 125 BPM track
+
+```
+detected_bpm = 124
+filename_bpm = 125
+
+diff = 1                           within 20, accept detected
+```
+
+Result: `(124, 'detected')`. Small normal disagreement accepted.
+
+### The thresholds
+
+`confidence_threshold = 20` is a deliberate choice:
+
+- Large enough to accept small tracking jitter (a few BPM either way)
+- Small enough that a truly different tempo (say 120 vs 140)
+  triggers the octave corrections rather than blindly accepting
+- Tight enough that a filename BPM of 125 and detected BPM of 150
+  fails to fit any of the ratios (150-125 = 25 > 20, and no ratio
+  lands within 20 either) and falls back to filename
+
+The `(60, 200)` range bounds the detected BPM to musically plausible
+values. Anything outside is treated as a failure mode.
+
+### Source tag
+
+Every outcome carries a source label: `detected` (librosa agreed or
+no filename present), `filename` (filename used), `corrected`
+(filename + octave-ratio adjustment), `oneshot` (too short to
+analyze). The label gets written to the DB via the future
+`bpm_source` column so later queries can filter by confidence.
+
+---
+
+## What the ranges catch and what they don't
+
+### Caught
+
+- **Octave errors**: 2x, 0.5x, 1.5x, 0.67x ratios.
+- **Extreme librosa outputs**: anything below 60 or above 200 BPM.
+- **Small tracking jitter**: ±20 BPM from filename.
+
+### Not caught (yet)
+
+- **3x errors**: librosa reporting 40 on a 120 track because it locked
+  onto quarter-bars. Could add `abs(detected*3 - filename) <= threshold`
+  and `abs(detected/3 - filename) <= threshold`.
+- **No-filename cases**: if the user renames a file, deleting the BPM
+  from the filename, we lose the validation signal and must trust
+  librosa blindly.
+- **Perceptual disagreements**: sometimes a 170 BPM filename and 85
+  detected is the intended tempo (half-time feel). No way to
+  disambiguate without musical context.
+
+### Future improvement: chunk-authored BPM
+
+ACID chunks and smpl chunks carry producer-authored BPM in many cases.
+When a `bpm` value comes from `core/riff.py:parse_riff` (an ACID chunk),
+it should be treated as ground truth and used to validate librosa the
+same way filename_bpm currently does. Source label `chunk` beats
+`filename` which beats `detected`.
+
+---
+
+## Edge cases and their handling
+
+### One-shots
+
+Samples shorter than 256 samples (about 6ms at 44.1k) get marked as
+one-shots with no tempo. In `detect.py`:
+
+```python
+if len(y) < 256:
+    return {
+        "estimated_bpm": "oneshot",
+        "estimated_key": None,
+        "duration_sec": duration_sec,
+        "bpm_source": "oneshot",
+        "key_source": None,
+    }
+```
+
+This is aggressive (some legitimate one-shot hits are longer than
+256 samples), but it prevents librosa from running beat tracking on
+material where the output is guaranteed meaningless.
+
+A smarter heuristic would use duration AND `acid_beats`: if the file
+is under ~1 second and has no ACID beats, it's almost certainly a
+one-shot. The current threshold could be raised to ~0.5 seconds
+(22050 samples at 44.1k) without introducing false positives.
+
+### Silence or near-silence
+
+librosa's beat tracker on a silent buffer typically returns 0 or
+NaN. The outer try/except catches this and falls through to the
+filename-only path. Nothing special needed.
+
+### Constant drone
+
+Sustained tonal content with no attack events produces an onset
+envelope that's essentially zero. Beat tracker picks arbitrary
+intervals. Same handling as silence: range check or validation
+catches it.
+
+### Time-varying tempo
+
+Tracks that accelerando or rallentando within a single file confuse
+single-number tempo estimates. librosa's `aggregate=None` path
+returns a per-frame array; acidcat medians over that, which
+produces a reasonable "middle" tempo for mildly-varying material.
+Severely-varying material gets a noisy estimate.
+
+### Very fast or very slow tempos
+
+The `[60, 200]` range cuts off legitimate extremes. Drum-and-bass at
+170-180 BPM fits; gabber at 200+ BPM doesn't. Ambient or classical
+at 40-50 BPM doesn't. Raising the bounds introduces more false
+positives from hi-hat lock (on the high end) and long-interval
+errors (on the low end), so the tradeoff isn't obvious.
+
+A future refinement: auto-widen the range when the filename BPM
+falls outside, since then we have corroborating evidence for the
+unusual value.
+
+---
+
+## Feature vector: `tempo_librosa` and `beat_count`
+
+In `core/features.py` these are used for ML similarity, not for the
+canonical BPM of the indexed row:
+
+```python
+onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+tempo, beats = librosa.beat.beat_track(onset_envelope=onset_env, sr=sr)
+features['tempo_librosa'] = float(np.atleast_1d(tempo)[0])
+features['beat_count'] = len(beats)
+```
+
+The canonical BPM (the `bpm` column in the `samples` table) goes
+through the validation pipeline. `tempo_librosa` does not; it's the
+raw librosa output. These two values can disagree and that's fine for
+their respective purposes:
+
+- `bpm`: what you search by, correctness matters
+- `tempo_librosa`: a feature for ML comparison, internal consistency
+  matters more than correctness (as long as the same extractor
+  produced all values)
+
+`beat_count` is useful as a loop-vs-one-shot signal in combination
+with `duration`. A 4-second clip with `beat_count=8` is almost
+certainly a 2-bar loop at 120 BPM. A 4-second clip with `beat_count=0`
+or `1` is probably a pad, drone, or one-shot.
+
+---
+
+## Gotchas
+
+### Onset detection in distorted / heavy material
+
+Heavy distortion or saturation can blur onset transients. Rock guitar
+power-chord strums with long sustain and overdrive often have weak
+onset signatures. Beat tracking suffers accordingly.
+
+Fix: use harmonic-percussive separation first. `librosa.effects.hpss`
+splits the signal into a harmonic and a percussive component; running
+onset detection on just the percussive part improves results for
+heavy material.
+
+### Very clean sine-wave content
+
+A continuous sine wave has no onsets. If the material is a single
+sustained tone or a slow sine sweep, beat tracking returns nothing
+useful. Pipeline falls back to filename.
+
+### Swing and microtiming
+
+Heavy swing (jazz shuffle, late-period Dilla drum programming) pushes
+onsets off the grid. Beat tracker still works in the aggregate but
+the inter-beat intervals are uneven. BPM estimate is still
+meaningful; beat positions are approximate.
+
+### Tempo-multiplexed material
+
+A track that layers patterns at different rates (e.g. a 128 BPM house
+beat with a 96 BPM melodic part on top) produces a bimodal
+autocorrelation. Result is often a tempo that's a compromise between
+the two.
+
+### Librosa version differences
+
+`librosa.beat.tempo` behavior changed between 0.8 and 0.10. The
+`aggregate=None` parameter we pass returns a per-frame array in 0.10
+but returned a different shape in earlier versions. If upgrading
+librosa, re-test on a known-tempo corpus.
+
+---
+
+## Interpretation
+
+A BPM value rounded to 2 decimal places. Common clean values:
+
+```
+60.0          very slow (ballad, dub)
+80.0 - 100    mid-tempo
+120.0 - 128   house, techno
+140.0         common dubstep, trap
+150.0 - 160   footwork, juke
+170.0 - 180   drum and bass
+```
+
+Values with non-integer precision often indicate a live-recorded or
+time-stretched source where the tempo isn't locked to a grid.
+Sample-pack content tends to report round integers because producers
+sequence to a fixed grid.
+
+`beat_count` interpretation:
+
+```
+0 or 1        no detectable beats -> one-shot or drone
+4             one bar of 4/4 or half-bar of 8/4
+8             two bars of 4/4 (classic 1-bar loop in a 2-bar sample)
+16            four bars of 4/4 (typical loop length in modern production)
+32+           long loop, phrase, or full track
+```
+
+Combined with `duration` this gives implied tempo via
+`beat_count / (duration / 60)`, which should match the canonical
+`bpm`. Disagreements indicate the beat tracker lost count.
+
+---
+
+## References
+
+- Bello, J. P., Daudet, L., Abdallah, S., Duxbury, C., Davies, M., &
+  Sandler, M. B. (2005). "A tutorial on onset detection in music
+  signals." *IEEE Transactions on Speech and Audio Processing*
+  13(5): 1035-1047. Canonical survey of onset detection methods.
+- Ellis, D. P. W. (2007). "Beat tracking by dynamic programming."
+  *Journal of New Music Research* 36(1): 51-60. The algorithm
+  librosa's beat tracker is based on.
+- Grosche, P., & Müller, M. (2011). "Extracting predominant local
+  pulse information from music recordings." *IEEE Transactions on
+  Audio, Speech, and Language Processing* 19(6): 1688-1701.
+  Introduces the PLP (predominant local pulse) method used in
+  newer librosa versions.
+- Schreiber, H., & Müller, M. (2018). "A single-step approach to
+  musical tempo estimation using a convolutional neural network."
+  *ISMIR 2018*. CNN-based tempo estimation, often more accurate
+  than autocorrelation-based methods. Not currently used in
+  acidcat but a possible future upgrade.
+- librosa documentation: <https://librosa.org/doc/latest/>
+- See `chroma_and_key.md` for the tonal side of the analysis
+  pipeline.
+- See `camelot_wheel.md` for how key output feeds harmonic matching.

--- a/docs/dsp/similarity.md
+++ b/docs/dsp/similarity.md
@@ -1,0 +1,567 @@
+# Similarity and Clustering
+
+How acidcat finds "samples that sound like this one" and groups
+libraries into clusters. Covers cosine distance over feature
+vectors, k-means and related clustering algorithms, and the design
+tradeoffs behind the current and proposed implementations.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+**Similarity search**: given a reference sample, return the N
+closest other samples by some distance measure. Implemented in
+`commands/similar.py` and exposed via the MCP `find_similar`
+tool.
+
+**Clustering**: given the full feature matrix, partition samples
+into groups of perceptually similar content. Exposed via
+`acidcat similar CSV cluster`.
+
+Both tasks operate on the feature vectors described in
+`feature_pipeline.md`. The math is standard unsupervised machine
+learning; the interesting choices are in which features to use,
+how to weight them, and how to present results.
+
+---
+
+## The distance question
+
+Given two feature vectors `a` and `b`, each 50-dim, what distance
+metric correlates best with "these samples sound alike"?
+
+### Euclidean distance
+
+```
+    d(a, b) = sqrt( sum of (a[i] - b[i])^2 )
+```
+
+Simple, interpretable, fails when features have different scales.
+A 44100 vs 48000 sample rate contributes 3900² to the squared
+distance, while a 0.5 vs 0.8 zcr_mean contributes 0.09². The
+distance is dominated by whichever features happen to have the
+biggest magnitude.
+
+Not used directly. Would require normalization first.
+
+### Cosine similarity
+
+```
+    cos(a, b) = (a · b) / (||a|| * ||b||)
+```
+
+Angle between the vectors, ignoring magnitude. Scale-invariant per
+vector but not per dimension. Still biased toward high-magnitude
+dimensions because they dominate both the dot product and the norm.
+
+Currently used. Better than Euclidean without normalization, but
+not optimal.
+
+### Standardized cosine
+
+Apply z-score normalization per feature (subtract mean, divide by
+std across the indexed population), then cosine.
+
+```
+    normalized[i] = (raw[i] - mean[i]) / std[i]
+    sim = cos(normalized_a, normalized_b)
+```
+
+Each feature contributes equally to the angle. This is what
+`acidcat features --ml-ready` outputs. The MCP `find_similar`
+tool does NOT currently do this, which is a known gap.
+
+### Weighted distance
+
+Multiply each feature by a weight chosen for the query intent:
+
+```
+    weighted[i] = w[i] * normalized[i]
+    sim = cos(weighted_a, weighted_b)
+```
+
+Allows callers to express "timbre matters more than rhythm" or
+"ignore duration." Not currently exposed.
+
+### Mahalanobis distance
+
+```
+    d(a, b) = sqrt( (a - b)^T * Σ^-1 * (a - b) )
+```
+
+Where `Σ` is the covariance matrix of the feature population. This
+accounts for correlations between features (e.g. centroid and
+rolloff are highly correlated; Mahalanobis de-emphasizes their
+double-count contribution).
+
+Conceptually ideal but computationally expensive. Computing `Σ^-1`
+on 50 features with a ~1000 sample library is fine; on a 10000
+sample library or a 100-field vector, less so. Could be added as an
+opt-in mode.
+
+### Learned embedding distance
+
+Use a pretrained audio model (CLAP, encodec, etc.) to produce an
+embedding per sample, then cosine on those. Modern approach, often
+superior to hand-crafted features for "sounds like" queries. Adds
+large model dependencies and is out of scope for current acidcat.
+
+---
+
+## Current implementation
+
+In `commands/similar.py` (uses sklearn):
+
+```python
+from sklearn.metrics.pairwise import cosine_similarity
+
+similarities = cosine_similarity(target_vector.reshape(1, -1), all_vectors)
+top_indices = np.argsort(similarities[0])[::-1][:n+1]
+# skip index 0 if it's the target itself
+results = top_indices[1:n+1] if top_indices[0] == target_index else top_indices[:n]
+```
+
+Straightforward:
+
+1. Compute cosine similarity from target to all samples.
+2. Sort descending.
+3. Return top N (excluding the target itself, which trivially has
+   similarity 1).
+
+### What this does well
+
+- Fast even on thousands of samples (matrix multiply is
+  well-optimized in numpy/sklearn).
+- Returns a clean ranked list.
+- Handles missing features by the CSV reader's NaN filling.
+
+### What this does poorly
+
+- No per-feature normalization, so high-magnitude features dominate.
+- No weighting, so the caller can't express intent.
+- No prefilter by metadata (can return drum hits when searching
+  from a tonal loop).
+- No magnitude/confidence reporting (top result has similarity 0.99
+  vs 0.65, and the caller has to check the value themselves).
+
+---
+
+## Proposed improvements to similarity
+
+### 1. Normalization before scoring
+
+Implementation:
+
+```python
+# once per index
+vectors = load_feature_matrix()
+scaler = StandardScaler().fit(vectors)
+# cache scaler parameters in a metadata row
+
+# per query
+target_normalized = scaler.transform(target.reshape(1, -1))
+all_normalized = scaler.transform(vectors)
+sim = cosine_similarity(target_normalized, all_normalized)[0]
+```
+
+The scaler can be cached in the `meta` table or in a dedicated
+`features_scaler` table so every query doesn't refit. Incremental
+updates when new samples are indexed require rerunning fit or
+using an incremental scaler.
+
+Expected accuracy improvement: large for heterogeneous libraries
+with samples across wildly different durations, sample rates, or
+mix levels.
+
+### 2. Kind prefilter
+
+Before computing similarity, filter to samples of compatible kind:
+
+```python
+def find_similar_with_kind(target, kind=None, ...):
+    target_kind = infer_kind(target)
+    kind_filter = kind or target_kind
+    candidates = samples.filter(kind=kind_filter)
+    sim = cosine_similarity(target, candidates)
+    ...
+```
+
+See `dsp/kind_inference.md` for the loop/one-shot/ambiguous
+taxonomy. When searching from a loop, return only loops. When
+searching from a one-shot, return only one-shots. Drops the
+"tonal loop returned drum hits" failure mode.
+
+### 3. Weighted similarity
+
+Expose per-family weights:
+
+```python
+find_similar(target,
+             weights={
+                 'timbre': 2.0,      # mfcc, contrast
+                 'spectrum': 1.0,    # centroid, rolloff, bandwidth
+                 'rhythm': 0.0,      # tempo, beat_count
+                 'tonal': 0.0,       # chroma, tonnetz, key
+             })
+```
+
+The agent or user picks weights based on intent:
+
+| query intent | weights |
+|--------------|---------|
+| "sounds like this" | timbre=2, spectrum=1, rhythm=0, tonal=0 |
+| "would fit this groove" | rhythm=2, timbre=1, spectrum=0, tonal=0 |
+| "layers harmonically" | tonal=2, rhythm=1, timbre=0.5, spectrum=0 |
+
+Implementation: multiply feature vectors by a weight vector before
+cosine. Zero-weight features are effectively removed from the
+metric.
+
+### 4. Confidence reporting
+
+Along with each result, include the similarity score AND a
+confidence estimate. A similarity of 0.95 with a standard deviation
+of 0.05 across the top 10 is a strong match. A similarity of 0.65
+with the top 20 all at 0.64-0.66 is essentially noise.
+
+A simple confidence metric:
+
+```python
+top_score = similarities[top_index]
+top_10_mean = np.mean(similarities[top_indices[:10]])
+top_10_std = np.std(similarities[top_indices[:10]])
+confidence = (top_score - top_10_mean) / (top_10_std + 1e-9)
+```
+
+High confidence: top match clearly separates from the rest. Low:
+flat similarity landscape, results are ambiguous.
+
+---
+
+## Clustering
+
+Clustering partitions the library into groups of similar samples.
+Uses the same feature vectors, but applies a grouping algorithm
+instead of pairwise comparison.
+
+### k-means
+
+Currently implemented via sklearn:
+
+```python
+from sklearn.cluster import KMeans
+km = KMeans(n_clusters=k, random_state=42, n_init=10)
+labels = km.fit_predict(vectors)
+```
+
+Properties:
+
+- Fast: O(N * k * iterations) per fit.
+- Requires k as input: caller must pick cluster count.
+- Sensitive to initialization: `n_init=10` mitigates this by
+  running from 10 starts and picking the best.
+- Produces convex clusters: won't find elongated or crescent-shaped
+  groups.
+- Sensitive to feature scaling: same normalization concerns as
+  similarity.
+
+### Choosing k
+
+Common heuristics:
+
+- **Elbow method**: plot inertia (within-cluster variance) vs k.
+  Look for the point where the curve flattens. `acidcat` doesn't
+  currently automate this but could output a silhouette or elbow
+  metric with cluster results.
+- **Silhouette analysis**: for each sample, compute how well it fits
+  its assigned cluster vs the next-best cluster. Higher average
+  silhouette means better clustering.
+- **Rule of thumb**: sqrt(N / 2) for libraries without obvious
+  structure.
+
+For sample libraries, k in the range of 5-20 tends to produce
+musically meaningful clusters (percussion vs tonal vs ambient vs
+sustained vs whatever).
+
+### Alternatives to k-means
+
+- **DBSCAN**: density-based, finds arbitrary-shaped clusters, no k
+  required. Needs an `eps` distance parameter instead. Handles
+  outliers (doesn't force them into a cluster). Good for libraries
+  with a few distinct types and a lot of singleton oddities.
+- **Agglomerative / hierarchical**: builds a dendrogram, can cut at
+  any level to produce different cluster counts. Useful for
+  exploratory work where you want to see the structure at multiple
+  scales.
+- **Spectral clustering**: builds a similarity graph, uses its
+  eigenvectors to partition. Can find non-convex clusters. More
+  expensive but often produces more musically-meaningful groupings.
+- **HDBSCAN**: like DBSCAN but varies density automatically. State
+  of the art for unsupervised clustering of heterogeneous data.
+
+For acidcat, k-means is the reasonable default because it's fast,
+well-understood, and produces consistent results. HDBSCAN would
+be worth adding for libraries where the user wants the algorithm
+to determine cluster count.
+
+---
+
+## Cluster interpretation
+
+After clustering, each cluster is a set of sample paths with a
+centroid (mean feature vector). Interpretation requires inspecting
+what's in each cluster.
+
+### Per-cluster summary
+
+Useful statistics per cluster:
+
+```python
+for cluster_id, samples in clusters.items():
+    centroid = mean feature vector
+    size = len(samples)
+    avg_duration = mean duration of cluster members
+    avg_centroid_khz = mean spectral centroid / 1000
+    avg_bpm = mean tempo
+    common_tags = most frequent tags across members
+    sample_filenames = first few filenames for scanning
+```
+
+Let the agent (or user) eyeball the clusters to name them. Good
+names are descriptive:
+
+```
+cluster 0: "dark percussive loops"   (low centroid, high bpm, high rms, short)
+cluster 1: "bright synth stabs"      (high centroid, short duration)
+cluster 2: "sustained pads"          (low zcr, low beat_count, long)
+cluster 3: "drum hits"               (very short, high variance mfcc)
+cluster 4: "tonal loops"             (moderate duration, stable tonnetz)
+```
+
+### LLM-driven cluster naming
+
+An agent can take cluster summaries and propose human-readable tag
+names. This is exactly the "tag taxonomy learning" workflow
+described in the direction doc:
+
+```
+agent:
+  1. reindex_features to populate vectors
+  2. cluster_samples(k=10) to get partition
+  3. for each cluster: request_cluster_summary, then propose a name
+  4. on user approval: tag_sample all members with the name
+```
+
+None of this is workflow logic in the server. The server exposes
+primitives (`reindex_features`, hypothetical `cluster_samples`,
+`tag_sample`). The agent composes them.
+
+A `cluster_samples` primitive is on the potential-future-tool list.
+Current workflow requires going through `acidcat features ... CSV`
+then `acidcat similar CSV cluster`, which is CSV-mediated and not
+ideal for agent use.
+
+---
+
+## Performance characteristics
+
+### Similarity
+
+- Feature matrix load: O(N) where N is indexed samples.
+- Cosine computation: O(N * D) where D is feature dim.
+- Sort: O(N log N).
+- Total: O(N * D + N log N).
+
+For N=1000, D=50, a query takes milliseconds. For N=100000 it's
+still under a second. The bottleneck is loading the feature matrix
+from SQLite/JSON, not the math.
+
+Optimization: keep the feature matrix in memory for a long-lived
+server process. The MCP server doesn't currently do this because
+of the fresh-connection-per-call pattern. A small cache would help.
+
+### Clustering
+
+- k-means: O(N * k * D * iterations).
+- For N=1000, k=10, D=50, iterations~=100: ~50 million ops.
+  Sub-second on modern hardware.
+- For N=100000, k=20, D=50: still tractable, few seconds.
+
+For libraries past ~1M samples, mini-batch k-means becomes
+preferable.
+
+---
+
+## Integration with the rest of the system
+
+### Similarity as a secondary filter
+
+Most useful similarity queries combine metadata filter + similarity
+ranking:
+
+```
+1. search_samples({bpm: [118, 128], kind: 'loop'}) -> 200 candidates
+2. find_similar among those candidates -> 10 best matches
+```
+
+Metadata filter narrows the candidate set cheaply; similarity scores
+the remaining few hundred. Currently `find_similar` operates over
+the full index, which is wasteful for intent queries. A future
+version should accept a pre-filtered candidate list.
+
+### Chaining with compatibility
+
+```
+1. find_compatible(target) -> 50 harmonically compatible samples
+2. find_similar within that 50 -> best timbral matches that also
+   harmonically fit
+```
+
+This is the kind of compound workflow the agent composes, not
+something the server should bake in.
+
+### Clustering for tag generation
+
+```
+1. cluster the library into 10-20 groups
+2. agent proposes names for each
+3. agent tags every sample with its cluster's name
+```
+
+Now the library has a descriptive tag namespace generated from its
+own content, not imposed from outside. Search queries using those
+tags hit clusters.
+
+---
+
+## Gotchas
+
+### Similarity is not transitive
+
+If A is similar to B, and B is similar to C, A may not be similar
+to C. Feature space distance isn't an equivalence relation.
+
+Practical consequence: recommending "samples like the samples you
+liked" naively can drift. If the user liked sample A, and we
+surface B (similar to A), and then they click B, surfacing
+"similar to B" can wander far from A's character.
+
+Mitigation: anchor recommendations to the original query, not to
+the user's click history.
+
+### Cluster membership is hard at the boundary
+
+k-means assigns every sample to exactly one cluster. Samples near
+cluster boundaries get arbitrary assignments. A kick drum that's a
+little tonal might end up in the "drum hits" cluster or the "tonal
+short samples" cluster depending on initialization.
+
+Mitigation: use soft clustering (Gaussian mixture models) that
+assign probabilities instead of hard labels. More expressive but
+more expensive, and users need to know the scores to interpret.
+
+### Feature importance depends on the library
+
+A library of mostly drum samples has low variance in tonal
+features. In that library, tonal features add nothing to
+similarity (because everyone is similar on those axes). A library
+of mostly pads has low variance in rhythm features.
+
+Mitigation: compute feature importance (variance) per library and
+surface it. Low-variance features shouldn't dominate distance
+metrics. Could be automated via variance-weighted similarity.
+
+### Cold-start for new samples
+
+A newly-indexed sample has no feature vector until `reindex_features`
+runs. It can't be compared by `find_similar` until then.
+
+Mitigation: make feature extraction part of the normal `index`
+flow (opt-in via `--features` flag, which already exists). For
+agent-driven workflows, add a `get_or_compute_features` helper.
+
+### Normalization drifts as library grows
+
+If scaler parameters are cached, adding new samples to the library
+means the cached scaler is slightly stale. For small additions
+this doesn't matter. For large additions (doubling library size),
+recomputing the scaler is worth it.
+
+Mitigation: track scaler freshness via a row count, recompute when
+it drifts past a threshold (e.g. 20% growth since last fit).
+
+---
+
+## A small worked example
+
+Library of 500 samples. User queries find_similar on a specific
+kick drum. Trace:
+
+```
+1. target = kick_808_heavy.wav
+   feature_vector = [0.6 s, 44100, ..., -1.2, 0.8, ..., 0.4, 0.01]
+                    dur    sr         mfcc     chroma    zcr  ...
+
+2. load all 500 feature vectors into a 500x50 matrix V
+
+3. compute cosine(target, V) -> 500-dim similarity vector
+   target is trivially 1.0
+
+4. sort descending, take top 10 (skipping target)
+   results:
+     kick_sub_long.wav           0.94  # dark, long, similar mfcc
+     kick_808_hipass.wav         0.89  # similar timbre, brighter
+     sub_bass_pluck.wav          0.87  # not a kick but similar feature profile
+     808_tail_short.wav          0.83
+     low_tom.wav                 0.78
+     dark_snare.wav              0.71  # borderline
+     noise_hit_low.wav           0.65  # starting to diverge
+     ...
+
+5. agent sees top 3 are very close (0.94, 0.89, 0.87) then a drop;
+   reports the top 3 with high confidence, mentions the rest with
+   lower confidence
+```
+
+If normalization and kind filtering were applied:
+
+```
+with kind='one_shot' prefilter:
+  candidates reduce to ~150 one-shots
+
+with StandardScaler normalization:
+  the "sub_bass_pluck.wav" sample (0.87 raw) may drop to 0.79
+  because its feature spread differs from a kick
+  the "kick_sub_long.wav" (0.94 raw) stays high because its shape
+  really does match
+
+final result: tighter, more kick-specific top 5
+```
+
+---
+
+## References
+
+- Aggarwal, C. C., et al. (2001). "On the surprising behavior of
+  distance metrics in high dimensional space." *International
+  Conference on Database Theory*. Why cosine beats Euclidean in
+  high dimensions.
+- Pedregosa, F., et al. (2011). "Scikit-learn: Machine learning in
+  Python." *JMLR* 12: 2825-2830. The similarity and clustering
+  library acidcat uses.
+- Lloyd, S. (1982). "Least squares quantization in PCM." *IEEE
+  Transactions on Information Theory* 28(2): 129-137. The
+  k-means algorithm.
+- Campello, R. J., Moulavi, D., & Sander, J. (2013).
+  "Density-based clustering based on hierarchical density
+  estimates." *PAKDD*. The HDBSCAN algorithm worth adding.
+- Rousseeuw, P. J. (1987). "Silhouettes: a graphical aid to the
+  interpretation and validation of cluster analysis." *Journal of
+  Computational and Applied Mathematics* 20: 53-65. For evaluating
+  cluster quality.
+- See `dsp/feature_pipeline.md` for the feature vector this
+  operates over.
+- See `dsp/kind_inference.md` for the loop/one-shot heuristic that
+  can prefilter candidates.

--- a/docs/dsp/spectral_features.md
+++ b/docs/dsp/spectral_features.md
@@ -1,0 +1,647 @@
+# Spectral and Energy Features
+
+Single-number and two-number (mean + std) descriptors of timbre and
+dynamics: spectral centroid, rolloff, bandwidth, contrast, plus the
+time-domain companions zero-crossing rate and RMS energy. These are
+the "what does this sample sound like" primitives that feed
+similarity scoring and ML clustering.
+
+Last updated: 2026-04-23
+
+---
+
+## What they are
+
+Where chroma and beat tracking answer "what notes, at what times,"
+spectral features answer "what does each moment of this sample
+actually sound like." They collapse a short audio frame's full
+spectrum into a small number of interpretable scalars.
+
+Each feature is computed per STFT frame (usually ~11ms windows) and
+aggregated over the clip with mean and standard deviation. The two
+numbers give a rough (location, spread) summary of the feature's
+trajectory over time. A drum hit with a bright attack and a dull
+tail has a high centroid-std because the value swings widely between
+frames.
+
+acidcat stores the mean and std of each feature. In `features.py`:
+
+```python
+spectral_centroids = librosa.feature.spectral_centroid(y=y, sr=sr)[0]
+features['spectral_centroid_mean'] = np.mean(spectral_centroids)
+features['spectral_centroid_std']  = np.std(spectral_centroids)
+```
+
+Same pattern for rolloff, bandwidth, contrast, ZCR, RMS. This gives
+the feature vector (roughly) 2 fields per extractor, plus the
+per-band arrays for contrast and the per-coefficient arrays for
+MFCC, totaling the advertised 50+ features.
+
+---
+
+## Spectral centroid
+
+Perceptual correlate: **brightness**. How much of the energy is in
+high frequencies.
+
+### Math
+
+The spectral centroid is the first moment (center of mass) of the
+magnitude spectrum:
+
+```
+    C = sum over k of (f[k] * |X[k]|)  /  sum over k of |X[k]|
+```
+
+where `f[k]` is the frequency of bin `k` in Hz, and `|X[k]|` is the
+magnitude at that bin. The denominator normalizes by total energy so
+the output is independent of overall loudness.
+
+Units: hertz. Values typically range from ~100 Hz (extreme bass) to
+~10,000 Hz (hissy / cymbal-heavy).
+
+### librosa implementation
+
+```python
+librosa.feature.spectral_centroid(y=y, sr=sr,
+                                   n_fft=2048,
+                                   hop_length=512,
+                                   freq=None)
+```
+
+Returns array of shape `(1, T)` where `T` is number of frames. The
+`freq=None` default uses the STFT bin frequencies directly. Can pass
+a custom frequency array for alternative bandings.
+
+### Interpretation
+
+| centroid (Hz) | typical content |
+|---------------|-----------------|
+| < 500 | sub-bass, pure bass tones, muddy content |
+| 500 - 1500 | bass-heavy but complete (kick, deep pad, vocal chest) |
+| 1500 - 3000 | mid-forward, voice, most guitar |
+| 3000 - 5000 | bright: hi-hats, snare top end, cutting synths |
+| > 5000 | hissy, cymbal wash, noise, very bright transients |
+
+Common rule of thumb: a dark pad has centroid < 1500 Hz. A bright
+lead has centroid > 3000 Hz. A full mix sits around 2000-3000 Hz.
+
+### acidcat usage
+
+Stored as `spectral_centroid_mean` and `spectral_centroid_std` in
+the feature JSON blob. Used in similarity scoring: two samples with
+similar centroids likely have similar brightness. A high centroid-std
+suggests dynamic timbre (changes over the clip); low std suggests
+static timbre (same character throughout).
+
+### Gotchas
+
+- **DC offset**: A signal with DC offset (nonzero mean) has a spurious
+  spike at 0 Hz that pulls the centroid down. librosa normally
+  handles this, but cheap converters or badly-edited audio can leak
+  DC.
+- **Narrow-band content**: a pure sine at 440 Hz has centroid =
+  440 Hz with near-zero std (trivially). Useful for sanity checks.
+- **Inaudible high content**: 20 kHz content still contributes to the
+  centroid even though it's inaudible. Some ultrasonic noise or
+  digital artifacts can inflate the centroid without affecting how
+  the sample actually sounds. Pre-filtering with a low-pass at
+  ~16 kHz is sometimes worth doing for perceptually-anchored
+  centroid estimates.
+
+---
+
+## Spectral rolloff
+
+Perceptual correlate: **high-frequency cutoff**. The frequency below
+which a specified fraction of total spectral energy lies.
+
+### Math
+
+For threshold `r` (typically 0.85), rolloff is the smallest frequency
+`f_R` such that:
+
+```
+    sum over k where f[k] <= f_R  of  |X[k]|^2   >=   r * total_energy
+```
+
+where `total_energy = sum of |X[k]|^2`.
+
+Intuitively: "where does 85% of the energy stop?" A track with most
+of its energy below 2000 Hz has rolloff around 2000 Hz. A bright mix
+with lots of high content has rolloff at 8000+ Hz.
+
+### librosa implementation
+
+```python
+librosa.feature.spectral_rolloff(y=y, sr=sr, roll_percent=0.85)
+```
+
+Default `roll_percent=0.85` is the standard MPEG-7 definition.
+`roll_percent=0.5` gives the spectral median (half the energy below,
+half above). Setting the percent lower makes it more sensitive to
+energy concentration; higher makes it more sensitive to noise in the
+tail.
+
+### Interpretation
+
+| rolloff (Hz) | typical content |
+|--------------|-----------------|
+| < 1000 | telephone-quality audio, bass-heavy filtered sounds |
+| 1000 - 3000 | AM-radio quality, heavily filtered or muted |
+| 3000 - 7000 | typical lo-fi or tape-saturated content |
+| 7000 - 12000 | modern clean mix, full-frequency response |
+| > 12000 | very bright or hissy, cymbal-wash, noise-heavy |
+
+### centroid vs rolloff
+
+They correlate but aren't redundant:
+
+- **Centroid** is a weighted average; a single very bright transient
+  mixed with a lot of bass produces a moderate centroid.
+- **Rolloff** is a percentile; the same signal produces a high
+  rolloff because the high transient by itself represents a
+  significant fraction of total energy.
+
+For distinguishing "consistently bright" from "mostly dark with
+occasional brightness," having both features is useful.
+
+### acidcat usage
+
+`spectral_rolloff_mean` and `spectral_rolloff_std`. Same pattern as
+centroid.
+
+### Gotchas
+
+- **Sensitive to `roll_percent` choice**: comparing across extractors
+  with different percentages produces meaningless comparisons. We
+  use librosa's default 0.85 everywhere.
+- **Noise tail inflation**: a clean mix with 30 seconds of noisy
+  silence at the end has an artificially high rolloff because the
+  noise dominates the high-frequency tail. Trim silence before
+  analysis for accurate rolloff.
+
+---
+
+## Spectral bandwidth
+
+Perceptual correlate: **spectral spread**. How wide the frequency
+distribution is around the centroid.
+
+### Math
+
+Bandwidth is the p-th central moment of the spectrum, usually p=2
+(variance-analogue):
+
+```
+    B = sqrt( sum over k of (f[k] - C)^2 * |X[k]|^2  /  sum of |X[k]|^2 )
+```
+
+where `C` is the spectral centroid. Units: hertz. This is the
+standard deviation of the frequency distribution weighted by
+magnitude.
+
+Intuitively: a narrow sine wave has low bandwidth; white noise has
+high bandwidth; a mix sits in between.
+
+### librosa implementation
+
+```python
+librosa.feature.spectral_bandwidth(y=y, sr=sr, p=2)
+```
+
+Default `p=2` gives the RMS-style spread. `p=1` gives mean absolute
+deviation; higher `p` weights outliers more.
+
+### Interpretation
+
+| bandwidth (Hz) | typical content |
+|----------------|-----------------|
+| < 500 | pure tone, simple sine, isolated note |
+| 500 - 1500 | clean harmonic tone, mono instrument |
+| 1500 - 3000 | ensemble content, mixed source |
+| 3000 - 6000 | full mix, broadband material |
+| > 6000 | noisy, wide-band, distorted |
+
+### acidcat usage
+
+`spectral_bandwidth_mean` and `spectral_bandwidth_std`. Useful for
+distinguishing focused tonal content from broadband textures in
+similarity searches.
+
+### Gotchas
+
+- **Correlates with noise-floor level**: a quiet recording with
+  audible noise has higher bandwidth than a silent one. Mostly an
+  issue for very quiet source material.
+- **Not a great mono-vs-stereo indicator**: two mono sources
+  summed produce similar bandwidth to one mono source. For
+  stereo-width analysis, use L/R channel comparisons directly.
+
+---
+
+## Spectral contrast
+
+Perceptual correlate: **tonal vs noise character, per frequency
+band**. Measures how peaky the spectrum is within each of several
+octave-wide bands.
+
+### Math
+
+Divide the spectrum into octave-wide bands (typically 6 bands, e.g.
+~0-200 Hz, 200-400, 400-800, 800-1600, 1600-3200, 3200+). Within
+each band, take the ratio (or log-difference) between the top
+percentile of magnitudes and the bottom percentile:
+
+```
+    contrast[b] = log(mean of top  alpha fraction of |X| in band b)
+                - log(mean of bot  alpha fraction of |X| in band b)
+```
+
+where `alpha` is typically 0.02 (top and bottom 2%).
+
+High contrast in a band means distinct peaks (tonal content, sharp
+harmonics). Low contrast means even distribution (noisy content).
+
+### librosa implementation
+
+```python
+librosa.feature.spectral_contrast(y=y, sr=sr, n_bands=6, fmin=200)
+```
+
+Returns array of shape `(n_bands + 1, T)`. The extra band is the
+sub-fmin band (below 200 Hz by default). Six bands gives one per
+octave roughly from 200 Hz to 12.8 kHz.
+
+### Interpretation
+
+Per-band values. Reading a contrast vector:
+
+```
+[3.2, 2.8, 3.1, 2.5, 1.9, 1.5, 0.8]
+ sub  200  400  800  1.6k 3.2k 6.4k
+
+tonal bass, mid-heavy, dull top
+```
+
+vs
+
+```
+[0.5, 0.4, 0.3, 0.3, 0.4, 0.5, 0.6]
+near-uniform = noisy / percussive / inharmonic
+```
+
+### acidcat usage
+
+`spectral_contrast_mean` and `spectral_contrast_std`. librosa returns
+a per-band array; acidcat currently flattens to mean/std across all
+bands. This loses the per-band information, which is a known
+simplification worth revisiting for similarity work.
+
+A better storage scheme would preserve each band as its own mean/std
+pair, giving 14 features (7 bands x 2 stats) instead of 2. The
+feature vector would be larger but more discriminating.
+
+### Gotchas
+
+- **Band definitions matter**: the 200 Hz `fmin` default cuts off
+  sub-bass. For bass-heavy content (house, dubstep) lowering fmin
+  to 50 or even 20 Hz gives better discrimination.
+- **Silence handling**: contrast in a band with no energy is
+  ill-defined. librosa returns 0 which is a reasonable convention
+  but shouldn't be averaged in without care.
+
+---
+
+## Zero-crossing rate
+
+Technically time-domain, not spectral, but grouped with spectral
+features because it's a cheap proxy for high-frequency content.
+
+### What it is
+
+Count of sign changes in the waveform per unit time. A signal that
+oscillates quickly crosses zero often; a signal with slow variations
+crosses zero rarely.
+
+### Math
+
+For a frame of samples `y[0..N-1]`:
+
+```
+    ZCR = (1 / (N-1)) * sum over n in [1, N-1] of  [sign(y[n]) != sign(y[n-1])]
+```
+
+Dimensionless (fraction per sample). Multiply by `sr` to get crossings
+per second.
+
+### Interpretation
+
+| ZCR | typical content |
+|-----|-----------------|
+| < 0.01 | very low frequency content, sub-bass, DC-heavy |
+| 0.01 - 0.05 | bass, kick drums, sustained low tones |
+| 0.05 - 0.15 | mid-range tonal content, voice, melody |
+| 0.15 - 0.35 | bright / percussive, hi-hat, snare, noise-adjacent |
+| > 0.35 | white noise, cymbal wash, heavy saturation |
+
+Relationship to centroid: high-ZCR signals usually have high
+centroids (both are sensitive to fast oscillation). But they can
+disagree: a signal with equal energy at 50 Hz and 2000 Hz has
+moderate centroid but very low ZCR (dominated by the 50 Hz
+oscillation).
+
+### Voiced vs unvoiced speech
+
+Classical use case: in speech analysis, voiced segments (vowels)
+have low ZCR and high energy; unvoiced segments (fricatives like
+"s", "f") have high ZCR. A ZCR vs energy 2D plot cleanly separates
+voiced from unvoiced frames.
+
+For sample libraries this is less directly useful but the same
+principle applies: tonal sustained content has low ZCR, noisy
+transient content has high ZCR.
+
+### librosa implementation
+
+```python
+librosa.feature.zero_crossing_rate(y, frame_length=2048, hop_length=512)
+```
+
+### acidcat usage
+
+`zcr_mean` and `zcr_std`. Cheap to compute, good for distinguishing
+bass-heavy samples from hat-heavy samples in similarity queries.
+
+### Gotchas
+
+- **Sample-rate dependent if unnormalized**: the same signal at
+  44.1k vs 48k has different raw crossing counts per frame. librosa
+  returns the normalized fraction (per sample) so this is handled,
+  but be aware when computing ZCR manually.
+- **DC offset matters**: a signal with DC offset crosses zero only
+  when oscillation amplitude exceeds the offset magnitude, which
+  suppresses the ZCR. Unlikely in clean recordings but common in
+  cheap converters.
+
+---
+
+## RMS energy
+
+Root mean square of the waveform. Perceptual correlate: **loudness**
+in a rough sense (true loudness requires perceptual weighting).
+
+### Math
+
+For a frame of samples `y[0..N-1]`:
+
+```
+    RMS = sqrt( (1/N) * sum of y[n]^2 )
+```
+
+Dimensionless (if samples are in [-1, 1]). Interpretable as an
+"average amplitude."
+
+### Relationship to perceived loudness
+
+RMS is not true loudness. True loudness (LUFS, ITU-R BS.1770)
+applies K-weighting (pre-emphasis of mid frequencies) and gating
+(ignoring silent sections). RMS ignores both.
+
+For sample-library purposes RMS is a useful relative measure:
+samples with higher RMS are louder on average. Two different
+samples at the same RMS can have very different perceived
+loudnesses if their frequency content differs significantly.
+
+### Interpretation
+
+Values depend on normalization. For a signal in [-1, 1]:
+
+| RMS | dBFS approx | typical content |
+|-----|-------------|-----------------|
+| 0.001 | -60 dB | very quiet, near-silence |
+| 0.01 | -40 dB | background music, ambient |
+| 0.1 | -20 dB | normal program material |
+| 0.3 | -10 dB | loud mix, heavy compression |
+| 0.5+ | -6 dB+ | brickwalled, clipped, or very hot |
+
+### librosa implementation
+
+```python
+librosa.feature.rms(y=y, frame_length=2048, hop_length=512)
+```
+
+Returns per-frame RMS. Array shape `(1, T)`.
+
+### acidcat usage
+
+`rms_mean` and `rms_std`. The mean gives average loudness; the std
+indicates dynamic range (high std = highly dynamic, low std = heavily
+compressed or sustained).
+
+### Gotchas
+
+- **Normalization assumption**: acidcat loads audio with
+  `librosa.load(sr=None, mono=True)` which applies a default
+  normalization (max absolute amplitude ≈ 1). This means RMS
+  values are comparable across files of different original
+  levels. If you want pre-normalization RMS for mastering checks,
+  use `librosa.load(normalize=False)` instead.
+- **Silence padding**: trailing silence in a file pulls down RMS
+  because it adds zero-energy frames to the average. For a loop
+  with 1 second of audio and 3 seconds of silence, the RMS is
+  roughly 1/4 what it would be without the silence.
+- **Not a clipping indicator**: a brickwalled signal has RMS close
+  to 0.5 but clipping (hard limit at 1.0) doesn't show up in RMS.
+  Peak-to-RMS ratio (crest factor) is the right metric for that.
+
+---
+
+## Mel spectrogram
+
+Used inside MFCC extraction; separately exposed by acidcat as
+`mel_mean` and `mel_std`. Deep-dive math lives in `dsp/mfcc.md`;
+this is a brief overview.
+
+### What it is
+
+A spectrogram whose frequency axis is warped to the mel scale, which
+approximates human pitch perception. The mel scale is roughly linear
+below 1 kHz and logarithmic above.
+
+### Formula (Hz to mel)
+
+```
+    m = 2595 * log10(1 + f / 700)
+```
+
+and inverse:
+
+```
+    f = 700 * (10^(m / 2595) - 1)
+```
+
+A 128-band mel filterbank is standard. Each band is a triangular
+filter centered at a mel-spaced frequency, width tapering linearly.
+
+### librosa implementation
+
+```python
+librosa.feature.melspectrogram(y=y, sr=sr,
+                                n_fft=2048,
+                                hop_length=512,
+                                n_mels=128)
+```
+
+Returns array shape `(n_mels, T)`. Units: power (not amplitude) by
+default.
+
+### acidcat usage
+
+Stored as `mel_mean` and `mel_std` across the full mel spectrogram.
+Loses per-band information, similar to the spectral contrast
+collapse. Used for rough "energy in perceptual bands" similarity.
+
+MFCC is the more discriminating feature derived from this; see the
+MFCC doc.
+
+---
+
+## Feature vector summary
+
+The complete list of "single-number" features stored in acidcat's
+feature vector, grouped by type:
+
+### Time domain
+
+```
+duration_sec                          length in seconds
+sample_rate                           Hz (not really a feature, stored for provenance)
+audio_length_samples                  raw frame count
+zcr_mean / zcr_std                    zero-crossing rate statistics
+rms_mean / rms_std                    RMS energy statistics
+```
+
+### Spectrum
+
+```
+spectral_centroid_mean / std          brightness
+spectral_rolloff_mean / std           high-frequency cutoff
+spectral_bandwidth_mean / std         spectral spread
+spectral_contrast_mean / std          peak-to-valley ratio (collapsed across bands)
+chroma_mean / std                     pitch class energy (collapsed across bins)
+mel_mean / std                        mel-band energy (collapsed across bands)
+```
+
+### Cepstrum
+
+```
+mfcc_1_mean / std ... mfcc_13_mean / std    (13 coefficients x 2 stats = 26 fields)
+```
+
+### Rhythm
+
+```
+tempo_librosa                         raw librosa tempo estimate
+beat_count                            detected beat count
+```
+
+### Tonal space
+
+```
+tonnetz_mean / std                    tonal centroid coordinates (collapsed)
+```
+
+Total: roughly 50 features, depending on exact count. Most are stored
+as float32; the MFCC group dominates the vector by count (26 of ~50).
+
+The "collapsed" features (contrast, mel, chroma, tonnetz) lose per-band
+information by taking global mean and std. Preserving per-band stats
+would multiply the feature count significantly but improve similarity
+discrimination. See `feature_pipeline.md` for the discussion of
+current vs ideal feature shapes.
+
+---
+
+## Cross-feature correlations worth knowing
+
+Some pairs of features carry mostly redundant information. Knowing
+which ones helps when interpreting similarity results or designing
+scoring weights.
+
+| feature pair | correlation | why |
+|--------------|-------------|-----|
+| centroid, rolloff | high | both track high-frequency presence |
+| centroid, ZCR | moderate | both reflect fast-oscillation energy |
+| bandwidth, spectral_contrast | low | measure different properties of the same spectrum |
+| RMS, tempo | none | amplitude vs rate, independent |
+| chroma, mfcc | low | pitch class vs timbre, mostly independent |
+
+For similarity scoring a cosine distance over the full feature vector
+implicitly weights each feature equally, which means redundant
+features (centroid + rolloff) effectively double-count brightness.
+Addressing this properly requires either feature weighting or
+dimensionality reduction (PCA) before the distance metric. Neither
+is currently done.
+
+---
+
+## Gotchas common to all spectral features
+
+### Window length
+
+Default `n_fft=2048` at sr=44100 gives 46ms analysis windows.
+
+- Too short: insufficient frequency resolution, bass gets smeared.
+- Too long: poor time resolution, transient details washed out.
+- Default is a reasonable compromise for general-purpose use.
+
+For sub-bass-specific analysis, doubling to `n_fft=4096` improves low
+resolution at the cost of doubled compute and some latency. For
+transient detail analysis, `n_fft=512` or `1024` is better.
+
+### Silence and very short clips
+
+All of these features assume a signal with actual audio content. On a
+pure-silence clip they return 0 or undefined values. acidcat's
+extractor guards against the zero-audio case but not against near-
+silence (very quiet but nonzero content), where features can be
+dominated by noise floor rather than intended signal.
+
+### Loudness normalization
+
+acidcat uses librosa's default normalization. If you compare feature
+vectors between unnormalized and normalized source material, the RMS
+values will obviously differ but the centroid / rolloff / bandwidth
+should not (they're ratio-based and level-invariant).
+
+### Sample rate mismatches
+
+A 22 kHz WAV and a 44.1 kHz WAV of the same source produce identical
+centroids, rolloffs, etc. because these are frequency-based and
+frequency is intrinsic to the content, not the sample rate. Sample
+rate bounds the maximum measurable frequency (Nyquist = sr/2), so
+files at lower sample rates have less high-frequency information to
+work with.
+
+---
+
+## References
+
+- Peeters, G. (2004). "A large set of audio features for sound
+  description (similarity and classification) in the CUIDADO
+  project." *IRCAM technical report*. Canonical reference for audio
+  feature definitions.
+- Tzanetakis, G., & Cook, P. (2002). "Musical genre classification of
+  audio signals." *IEEE Transactions on Speech and Audio Processing*
+  10(5): 293-302. Seminal paper using many of these features for
+  classification.
+- Fastl, H., & Zwicker, E. (2007). *Psychoacoustics: Facts and
+  Models*. Springer. Background on perceptual frequency scales (mel,
+  Bark).
+- librosa feature documentation:
+  <https://librosa.org/doc/latest/feature.html>
+- See `dsp/mfcc.md` for the cepstral features that build on the mel
+  spectrogram.
+- See `dsp/feature_pipeline.md` for how all of these are assembled
+  into the final feature vector.

--- a/docs/dsp/tonnetz.md
+++ b/docs/dsp/tonnetz.md
@@ -1,0 +1,475 @@
+# Tonnetz (Tonal Centroid Features)
+
+A 6-dimensional geometric representation of harmonic content derived
+from chroma vectors. Captures tonal relationships that are
+music-theoretically meaningful but hidden in the raw 12-dimensional
+pitch-class representation. Useful for distinguishing harmonic
+content from non-harmonic content, and for measuring harmonic
+similarity.
+
+Last updated: 2026-04-23
+
+---
+
+## What it is
+
+The Tonnetz (German for "tone network") is a geometric space whose
+points represent tonal content of a short audio frame. It has 6
+dimensions organized into three 2D coordinate planes, each capturing
+a different harmonic interval:
+
+- dimensions 0-1: **perfect fifth** circle (C-G-D-A-E-B-F#-...)
+- dimensions 2-3: **minor third** circle (C-Eb-Gb-A-C)
+- dimensions 4-5: **major third** circle (C-E-G#-C)
+
+A chroma vector (12-dim) gets projected into this 6-dim tonal space
+by weighted summation along each circle. Points close together in
+the Tonnetz represent keys or chords that are harmonically close in
+Western tonal music.
+
+The name and construction come from Euler's 1739 tuning network,
+formalized for signal processing by Harte, Sandler, and Gasser in
+the 2000s.
+
+---
+
+## Why not just use chroma
+
+Chroma is 12-dimensional. Tonnetz is 6-dimensional. Both represent
+pitch content. What does Tonnetz give you that chroma doesn't?
+
+### Interval relationships are linear in Tonnetz
+
+In chroma space, the relationship between two notes is encoded in
+*which* pitch classes are active, not *how they relate*. Moving from
+C (pc 0) to G (pc 7) requires rotating the chroma vector by 7
+positions, which is a non-obvious operation in 12-D vector space.
+
+In Tonnetz space, the same move is a simple rotation in the
+fifths plane. Harmonic relationships become linear-algebraic
+operations instead of combinatorial pattern matching.
+
+### Harmonic similarity has a natural metric
+
+Two keys like C major and G major are harmonically close (one step
+apart on the circle of fifths). In raw chroma, the C-major chroma
+vector and the G-major chroma vector aren't particularly similar by
+cosine distance (they share 6 of 7 notes, but the histogram
+distributions differ).
+
+In Tonnetz, C major and G major are literally adjacent points in
+the fifths plane. Euclidean distance in Tonnetz space approximates
+harmonic distance.
+
+### Tonal vs non-tonal content is easier to separate
+
+A chord produces a clustered point in Tonnetz. Noise or inharmonic
+content produces a diffuse spread. The difference between a clean
+chord and a dissonance or noise cluster is visually and numerically
+obvious.
+
+### Dimensionality reduction with musical meaning
+
+PCA would reduce chroma to 6 dimensions mathematically. Tonnetz
+does the same reduction but the resulting axes have music-theoretic
+meaning. When you inspect a feature vector row, you can reason
+about it.
+
+---
+
+## The math
+
+### The three circle projections
+
+Each of the 12 pitch classes has a unique position on each of three
+circles, corresponding to stepping through the pitch classes by 7,
+3, and 4 semitones respectively:
+
+**Perfect fifth circle** (step by 7 semitones, mod 12):
+
+```
+    C -> G -> D -> A -> E -> B -> F# -> C# -> G# -> D# -> A# -> F -> C
+    pc  0    7    2    9    4    11   6     1     8     3     10    5    0
+```
+
+**Minor third circle** (step by 3 semitones):
+
+```
+    C -> D# -> F# -> A -> C
+    pc  0     3     6    9    0
+```
+
+**Major third circle** (step by 4 semitones):
+
+```
+    C -> E -> G# -> C
+    pc  0    4    8     0
+```
+
+The minor-third and major-third circles are shorter because 12 /
+gcd(12, 3) = 4 and 12 / gcd(12, 4) = 3. Each has only 4 or 3 unique
+pitch classes before returning to start.
+
+### The 6D projection matrix
+
+Each pitch class gets assigned 6 coordinates: two per circle. The
+position of pitch class `n` on each circle is given by mapping the
+circle step to an angle:
+
+For the fifths circle (12 positions around a full circle):
+
+```
+    angle_fifth[n] = 2π * position_on_fifth_circle(n) / 12
+    x_fifth[n]     = cos(angle_fifth[n])
+    y_fifth[n]     = sin(angle_fifth[n])
+```
+
+Similarly for minor thirds (angle = 2π * position / 4) and major
+thirds (angle = 2π * position / 3).
+
+Arranging these into a 6x12 matrix `T` where each column is one
+pitch class's 6D Tonnetz coordinate, the projection of a chroma
+vector `c` (length 12) into Tonnetz space is:
+
+```
+    tonnetz_vector = T @ c
+```
+
+One matrix-vector multiply. The output is a 6-vector.
+
+### Geometric interpretation
+
+Each pair (fifth, minor third, major third) spans a 2D plane. The
+projected chroma is a point in each of three 2D planes.
+
+**Fifths plane**:
+- C is at (1, 0)
+- G is at (cos(30°), sin(30°))
+- D is at (cos(60°), sin(60°))
+- ...and so on around the unit circle
+
+A pure C chroma (all energy at pc 0) projects to (1, 0) in the
+fifths plane. A pure G projects to (cos 30°, sin 30°). A chord of
+C and G projects to the midpoint, which has smaller magnitude but
+lies on the line between them.
+
+The angle of the point indicates the "position" in fifths space;
+the magnitude indicates "how tonal" the content is (bigger = more
+concentrated around a specific fifth).
+
+Same geometric intuition for minor thirds (4 equally-spaced points
+on a circle) and major thirds (3 equally-spaced points).
+
+### Why these specific intervals
+
+- **Perfect fifth**: most consonant interval, defines tonal center.
+- **Major third**: defines major tonality.
+- **Minor third**: defines minor tonality.
+
+Together they span all the relationships needed to place a chord or
+key in tonal space. Other intervals (seconds, sevenths, tritones)
+are derivable from combinations of these three.
+
+### Neo-Riemannian theory connection
+
+The 2D minor-third and major-third planes correspond to Riemannian
+transformations (P, L, R) that map triads to related triads. This
+is a deep connection to 19th-century music theory that formalizes
+"smooth" chord progressions.
+
+Not directly needed for acidcat's current use, but notable because
+the Tonnetz representation is why some modern music-theory tools
+can reason about chord progressions computationally.
+
+---
+
+## librosa implementation
+
+```python
+tonnetz = librosa.feature.tonnetz(y=y, sr=sr, chroma=None)
+```
+
+Returns shape `(6, T)` where `T` is the number of frames.
+
+If `chroma=None`, librosa computes chroma internally using
+`chroma_cqt`. You can pass a pre-computed chroma matrix if you've
+already done it for other purposes (saves compute).
+
+The projection matrix is hardcoded in librosa according to
+Harte, Sandler, and Gasser's definition.
+
+---
+
+## acidcat implementation
+
+In `core/features.py`:
+
+```python
+tonnetz = librosa.feature.tonnetz(y=y, sr=sr)
+features['tonnetz_mean'] = np.mean(tonnetz)
+features['tonnetz_std']  = np.std(tonnetz)
+```
+
+The full tonnetz matrix is 6x T, but acidcat collapses to a single
+mean and std across all 6 dimensions and all frames. This loses
+most of the interesting information: a point in fifths space is
+different from a point in major-thirds space, but the collapse
+conflates them.
+
+**This is the same collapse problem noted in `spectral_features.md`
+for contrast, mel, and chroma.** The proper storage would be 12
+values (6 dimensions x 2 stats), giving per-plane position and
+spread.
+
+Fixing this would improve similarity discrimination meaningfully
+for harmonic content. Not fixing it means two chords with similar
+overall tonal magnitude but different tonal positions can't be
+distinguished.
+
+Future improvement plan:
+
+```python
+# proposed: preserve per-dimension stats
+for i, dim in enumerate(['fifth_x', 'fifth_y', 'minor3_x', 'minor3_y', 'major3_x', 'major3_y']):
+    features[f'tonnetz_{dim}_mean'] = np.mean(tonnetz[i])
+    features[f'tonnetz_{dim}_std']  = np.std(tonnetz[i])
+```
+
+Adds 10 fields to the feature vector, makes Tonnetz actually useful.
+
+---
+
+## Interpretation
+
+A 6D Tonnetz vector can be read as three 2D points. For a single
+frame, each point indicates:
+
+- **Angle**: which key or chord region the frame sits in for that
+  interval type.
+- **Magnitude**: how concentrated the tonal content is. Close to 0
+  means diffuse (multiple chords sounding, or noise). Close to 1
+  means a single clear tonality.
+
+### Example vectors
+
+```
+C major chord (C-E-G), sustained:
+fifth plane:  (0.7, 0.2)    # points toward C direction
+minor3 plane: (0.4, 0.1)    # weak, C and E are far apart on m3 circle
+major3 plane: (0.8, 0.0)    # strong, C and E are adjacent on M3 circle
+
+G major chord (G-B-D), sustained:
+fifth plane:  (0.6, 0.4)    # rotated from C position (G is 1 step away on fifths)
+minor3 plane: (0.3, 0.2)
+major3 plane: (0.2, 0.7)
+
+C major going to G major:
+fifth plane: trajectory rotates by 30° between frames
+```
+
+Distance between C major and G major in Tonnetz space is smaller
+than distance between C major and F# major (because F# is 6 steps
+away on the fifths circle, the maximum distance).
+
+---
+
+## What Tonnetz is good for
+
+### Chord change detection
+
+A consistent Tonnetz vector across frames = same chord. A large
+jump between frames = chord change. This is the basis for
+automatic chord recognition systems. acidcat doesn't currently do
+chord segmentation, but the feature is available if we ever add it.
+
+### Key similarity
+
+Two clips in the same key produce clustered Tonnetz positions. Two
+clips in adjacent keys (fifth-related) are close. Two clips in
+distant keys (tritone apart) are far.
+
+This is a more nuanced version of Camelot compatibility: Camelot
+is a discrete 24-class categorization; Tonnetz is a continuous
+space. Combining both gives you the discrete "are these
+compatible" answer plus a continuous "how similar are they"
+score.
+
+### Harmonic vs inharmonic discrimination
+
+A drum loop has essentially random Tonnetz values per frame (no
+stable tonal center). The mean across frames is near zero; the std
+is high. A harmonic loop has a stable mean and low std.
+
+Even without the per-dimension breakdown, the current
+`tonnetz_mean` and `tonnetz_std` features can flag "this sample
+has tonal character" vs "this sample doesn't."
+
+### Style differentiation
+
+Different genres have different characteristic Tonnetz
+trajectories. A blues progression (I-IV-V) traces a specific shape
+in fifths space. A jazz ii-V-I traces a different shape. Pop
+diatonic progressions cluster in a compact region. Extended
+harmonies (maj9, sus4 stacks) spread out differently.
+
+For sample-library purposes this is mostly unused, but the
+information is there.
+
+---
+
+## What Tonnetz is not good for
+
+### Timbre similarity
+
+Tonnetz says nothing about timbre. Two different instruments
+playing the same chord have identical Tonnetz profiles. That's a
+feature, not a bug, because it means Tonnetz gives you a clean
+harmonic representation independent of timbre. But if you want to
+find "sounds similar" matches, use MFCC.
+
+### Key detection (on its own)
+
+Tonnetz is derived from chroma. It encodes the same pitch
+information, just in a different geometry. For the specific task
+of key estimation, chroma with Krumhansl-Schmuckler correlation
+(see `chroma_and_key.md`) is more direct. Tonnetz adds geometric
+interpretability but doesn't uniquely determine a key unless you
+combine it with mode information.
+
+### Modal or non-Western content
+
+Tonnetz is built around Western tonal assumptions: diatonic scales,
+triadic harmony, equal temperament. Modal jazz, non-Western scales,
+just-intonation material, microtonal content, and atonal music
+can all produce Tonnetz vectors, but the geometric interpretation
+breaks down.
+
+A piece in Phrygian mode projects to Tonnetz points that don't
+match either the parallel major or parallel minor's typical
+location. The interpretation "tonal center at this angle" is
+misleading for modal content.
+
+### Short samples
+
+A one-shot (drum hit, pluck) is too short to have stable Tonnetz
+content across frames. The vector reflects whatever transient
+spectral content is present, which isn't necessarily the
+"tonal center" of the sample.
+
+---
+
+## Gotchas
+
+### Magnitude vs angle aren't independent
+
+A frame with diffuse chroma has small Tonnetz magnitude in all
+three planes. A frame with clear tonality has large magnitude in
+whichever plane best captures it. When aggregating mean and std
+across frames, both components contribute.
+
+Currently acidcat's single mean+std loses this nuance. Fixing the
+collapse (see implementation section) would separate "how tonal"
+from "what tonal direction."
+
+### Percussive onsets inflate variance
+
+A sample with tonal sustain plus drum hits has high Tonnetz std
+because the percussive frames don't fit the tonal geometry. This
+is actually useful information (it tells you the sample mixes
+tonal and percussive content) but could be misinterpreted as
+"harmonically unstable."
+
+### Frame size matters
+
+With `hop_length=512`, frames are ~11.6ms. Chord changes faster
+than ~80ms (less than 7 frames) can blur together. For detecting
+fast chord changes, shorter hop lengths help; for sample-library
+classification where we aggregate across the whole clip, the
+default is fine.
+
+### Pre-chroma artifacts propagate
+
+Anything that affects chroma affects Tonnetz downstream. Material
+tuned to A4 ≠ 440 Hz produces systematically wrong chroma, which
+then produces systematically wrong Tonnetz. Same mitigation:
+`librosa.estimate_tuning` for non-standard tunings.
+
+---
+
+## Proposed storage enhancement
+
+Current (loses geometry):
+
+```
+tonnetz_mean     single scalar, mean across all 6 dims and T frames
+tonnetz_std      single scalar, std across all 6 dims and T frames
+```
+
+Proposed (preserves geometry):
+
+```
+tonnetz_fifth_x_mean, tonnetz_fifth_x_std
+tonnetz_fifth_y_mean, tonnetz_fifth_y_std
+tonnetz_minor3_x_mean, tonnetz_minor3_x_std
+tonnetz_minor3_y_mean, tonnetz_minor3_y_std
+tonnetz_major3_x_mean, tonnetz_major3_x_std
+tonnetz_major3_y_mean, tonnetz_major3_y_std
+```
+
+Twelve fields instead of two. Dataset size grows by roughly 0.5%.
+Discrimination for harmonic similarity improves noticeably.
+
+Even better: add derived features:
+
+```
+tonnetz_fifth_magnitude_mean  = mean over T of  sqrt(x^2 + y^2)
+tonnetz_fifth_angle_mean       = circular mean of  atan2(y, x)
+```
+
+The magnitude/angle decomposition is how Tonnetz is typically
+reported in the literature. Implementing circular mean correctly
+is a little fiddly (can't just average angles that wrap around),
+so stick with x/y components unless the downstream task explicitly
+benefits from polar form.
+
+This is near-term work on the roadmap under "feature vector
+versioning" since it's a schema change.
+
+---
+
+## Comparison with other tonal features
+
+| feature | dim | encodes | pros | cons |
+|---------|-----|---------|------|------|
+| chroma | 12 | pitch-class histogram | direct interpretation, standard | high-dim, not octave-invariant geometry |
+| tonnetz | 6 | tonal geometry | harmonic distance is metric | needs good chroma input, Western-centric |
+| key estimate | 1 (discrete) | best-fit key | compact, compatible with Camelot | lossy, discrete |
+| MFCC | 13 | timbral envelope | robust, decorrelated | no harmonic content |
+
+For acidcat, Tonnetz complements chroma and key estimate by
+providing a continuous harmonic-similarity metric that neither of
+the others offers.
+
+---
+
+## References
+
+- Harte, C., Sandler, M., & Gasser, M. (2006). "Detecting harmonic
+  change in musical audio." *Proceedings of the 1st ACM workshop
+  on Audio and music computing multimedia*: 21-26. The paper that
+  introduced the 6D Tonnetz representation for signal processing.
+- Cohn, R. (1997). "Neo-Riemannian operations, parsimonious
+  trichords, and their Tonnetz representations." *Journal of Music
+  Theory* 41(1): 1-66. The music-theoretic background; formalizes
+  triadic transformations on the Tonnetz.
+- Euler, L. (1739). *Tentamen novae theoriae musicae*. The original
+  tone network concept, centuries before digital signal processing.
+- Chew, E. (2014). *Mathematical and Computational Modeling of
+  Tonality*. Springer. Detailed treatment of tonal spaces including
+  Tonnetz.
+- librosa tonnetz documentation:
+  <https://librosa.org/doc/latest/generated/librosa.feature.tonnetz.html>
+- See `dsp/chroma_and_key.md` for the chroma vectors that feed
+  Tonnetz.
+- See `dsp/camelot_wheel.md` for the discrete harmonic compatibility
+  space that complements continuous Tonnetz.

--- a/docs/signal_processing.md
+++ b/docs/signal_processing.md
@@ -1,0 +1,172 @@
+# Signal Processing Internals
+
+Math, DSP, and music-theory reference for acidcat's analysis and
+harmonic-matching subsystems. Each topic has a dedicated deep-dive
+document in `dsp/`.
+
+Last updated: 2026-04-23
+
+---
+
+## Document index
+
+### Harmonic matching
+
+| topic | file | status | covers |
+|-------|------|--------|--------|
+| [Camelot Wheel](dsp/camelot_wheel.md) | `dsp/camelot_wheel.md` | Complete | pitch-class math, Camelot code lookup, compatibility rules, enharmonic normalization policy |
+
+### Audio analysis
+
+| topic | file | status | covers |
+|-------|------|--------|--------|
+| [Chroma and key detection](dsp/chroma_and_key.md) | `dsp/chroma_and_key.md` | Complete | chroma_stft vs chroma_cqt, argmax key estimation, Krumhansl-Schmuckler proposal |
+| [Rhythm and BPM](dsp/rhythm_and_bpm.md) | `dsp/rhythm_and_bpm.md` | Complete | onset strength envelope, autocorrelation, beat tracking, octave-error correction |
+| [Onset detection](dsp/onset_detection.md) | `dsp/onset_detection.md` | Complete | spectral flux variants, peak picking, parameter tuning, alternative methods |
+| [Spectral features](dsp/spectral_features.md) | `dsp/spectral_features.md` | Complete | centroid, rolloff, bandwidth, contrast, ZCR, RMS, mel spectrogram |
+| [MFCC](dsp/mfcc.md) | `dsp/mfcc.md` | Complete | mel scale, log-mel spectrogram, cepstral DCT, coefficient interpretation |
+| [Tonnetz](dsp/tonnetz.md) | `dsp/tonnetz.md` | Complete | tonal centroid geometry, fifths/minor-3rd/major-3rd planes, harmonic distance |
+| [Feature pipeline](dsp/feature_pipeline.md) | `dsp/feature_pipeline.md` | Complete | how features.py composes all of the above into the 50-field vector |
+
+### Preprocessing
+
+| topic | file | status | covers |
+|-------|------|--------|--------|
+| [HPR (harmonic-percussive separation)](dsp/hpr.md) | `dsp/hpr.md` | Complete | median-filter separation, soft masks, use cases for chroma/onset cleanup |
+
+### Classification and similarity
+
+| topic | file | status | covers |
+|-------|------|--------|--------|
+| [Similarity scoring](dsp/similarity.md) | `dsp/similarity.md` | Complete | cosine over feature vectors, normalization, weighting, clustering |
+| [Loop vs one-shot](dsp/kind_inference.md) | `dsp/kind_inference.md` | Complete | duration + acid_beats heuristic, edge cases, proposed augmentations |
+
+---
+
+## Extraction flow
+
+```
+    audio file
+        │
+        ▼
+    librosa.load  →  y (float32 array), sr (sample rate)
+        │
+        ├────────────────┬────────────────┬────────────────┐
+        ▼                ▼                ▼                ▼
+    onset_strength   chroma_cqt      spectral_*       mfcc
+        │                │                │                │
+        ▼                ▼                ▼                ▼
+    beat.tempo       argmax median   mean / std        mean / std
+        │                │                │                │
+        ▼                ▼                ▼                ▼
+       BPM              key          brightness       timbre
+                                     proxies          signature
+```
+
+The pipeline never holds references to the audio buffer longer than it
+has to. `features.py` loads, computes, returns a dict; `detect.py` does
+the same for bpm+key only. No warm caches beyond librosa's internal
+numba JIT, which is a process-lifetime concern and not a design choice.
+
+---
+
+## Provenance and confidence
+
+Every field that can come from multiple origins carries a source tag.
+Canonical ordering, best to worst:
+
+1. **chunk**: producer-authored metadata embedded in the file (ACID,
+   SMPL, ID3 BPM, mutagen `tmpo`). Treated as ground truth unless
+   flagrantly wrong.
+2. **corrected**: detected value that agreed with a filename value
+   after an octave-ratio adjustment (see
+   `dsp/rhythm_and_bpm.md`).
+3. **detected**: librosa analysis output, no corroborating source.
+4. **filename**: regex-extracted from the filename. Usually accurate
+   but prone to false positives if the parsing rules are too loose.
+5. **oneshot**: file too short for meaningful analysis.
+6. **failed**: extraction errored. Fall back to null.
+
+The `source` fields are currently computed in `core/detect.py` but not
+yet plumbed into the `samples` table columns. Adding `bpm_source`,
+`key_source`, and a numerical `confidence` column is on the near-term
+work list.
+
+---
+
+## Why separate chunk-authored from analyzed
+
+The two sources answer different questions:
+
+- **Chunk metadata encodes intent**. The producer set 125 BPM because
+  that's what they tracked to. The producer set root note D3 because
+  that's the key center of the sample. This is what they meant.
+- **Analyzed metadata encodes observation**. librosa ran a beat tracker
+  on the waveform and found periodicity at 125 BPM. The chroma vector
+  peaked at pitch class 2. This is what the audio is.
+
+Usually these agree. When they disagree, the disagreement is the
+signal: the file may have been re-pitched, re-timed, re-purposed, or
+mislabeled. A future `compare_metadata(path)` tool would surface this
+as a first-class result.
+
+acidcat currently resolves the disagreement by preferring the chunk
+value if present, using the analyzed value otherwise, and running a
+validation pass on the analyzed BPM to catch librosa's common
+octave-doubling failure mode. See `core/detect.py:validate_and_improve_bpm`.
+
+---
+
+## Optional dependencies
+
+All DSP functionality is behind the `[analysis]` extra:
+
+```
+pip install acidcat[analysis]
+```
+
+This pulls in `librosa`, `numpy`, and `scipy`. Without these, `acidcat
+detect`, `acidcat features`, and the MCP `analyze_sample` /
+`detect_bpm_key` / `find_similar` tools return a structured error
+pointing to the install step.
+
+See `architecture.md` for the full optional-dependency matrix.
+
+---
+
+## Reading order for new contributors
+
+If you're coming to the DSP code fresh:
+
+1. **`camelot_wheel.md`** first. It's closed-form math with no audio
+   processing involved. Gives you the musical-theory vocabulary for
+   reading the rest.
+2. **`chroma_and_key.md`** next (once written). Introduces the
+   pitch-class vector representation that feeds into Camelot.
+3. **`rhythm_and_bpm.md`** (once written). Onset detection and beat
+   tracking as the other half of the "when does a sample play what"
+   question.
+4. **`spectral_features.md`**, **`mfcc.md`**, **`tonnetz.md`** in any
+   order. These are the feature extractors used for similarity work.
+5. **`feature_pipeline.md`** last, because it depends on understanding
+   every feature type individually.
+
+---
+
+## Conventions
+
+Every `dsp/*.md` document follows the same structure:
+
+1. **What it is**: one paragraph, plain language.
+2. **The math**: equations, derivations, motivations.
+3. **librosa implementation**: what the library actually computes,
+   parameter defaults, edge cases.
+4. **acidcat usage**: where in the codebase, what we do with it.
+5. **Interpretation**: how to read the numbers.
+6. **Gotchas**: pitfalls and alternatives considered.
+7. **References**: further reading when applicable.
+
+Equations are rendered in plaintext or simple LaTeX-style markup. No
+MathJax dependency. Diagrams are ASCII. Code snippets are Python or
+pseudocode, never runnable scripts unless the section specifically
+illustrates an implementation.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -247,6 +247,28 @@ def test_find_compatible_infer_kind_helper():
     assert mcp_server.infer_kind(1.5, 0) == "any"
 
 
+@pytest.mark.parametrize("duration,acid_beats,expected", [
+    # Producer Loops Hypnotize pack: ACID chunk present but beats=0,
+    # durations are exact bar counts. Must classify as loops via duration.
+    (7.619, 0, "loop"),         # 2 bars at 126 BPM
+    (15.238, 0, "loop"),        # 4 bars at 126 BPM
+    # equivalence: None and 0 must behave identically for every duration band
+    (7.619, None, "loop"),
+    (15.238, None, "loop"),
+    (0.3, 0, "one_shot"),
+    (0.3, None, "one_shot"),
+    (1.5, 0, "any"),
+    (1.5, None, "any"),
+])
+def test_infer_kind_zero_beats_equivalent_to_null(duration, acid_beats, expected):
+    # regression guard: acid_beats == 0 must be treated as uninformative
+    # (equivalent to NULL), never as a one-shot signal on its own.
+    # some commercial packs (Producer Loops Hypnotize) write ACID chunks
+    # with beats=0 on legitimate loops, so inference must fall through to
+    # duration-based classification.
+    assert mcp_server.infer_kind(duration, acid_beats) == expected
+
+
 def test_tag_sample(seeded_db):
     r = mcp_server.dispatch("tag_sample", {
         "path": P_HAT, "add_tags": ["bright", "tight"],


### PR DESCRIPTION
- new docs/architecture.md: layer diagram, SQLite schema walk, CLI/MCP symmetry, BPM validation pipeline, known perf characteristics, extension points
- new docs/signal_processing.md: top-level index for the DSP deep-dives, provenance and confidence source ordering, reading order for new contributors
- new docs/dsp/ tree (11 files): camelot_wheel (pitch-class math + compatibility rules), chroma_and_key (chroma_cqt key estimation + proposed Krumhansl-Schmuckler upgrade), rhythm_and_bpm (onset strength, autocorrelation, octave-error correction), onset_detection (spectral flux variants, peak picking, alternative methods), spectral_features (centroid/rolloff/bandwidth/contrast/ZCR/RMS), mfcc (mel scale, log-mel, DCT, coefficient interpretation), tonnetz (6D tonal geometry, fifths/minor-3rd/major-3rd planes), feature_pipeline (how features.py composes the 50-field vector, normalization gaps), hpr (harmonic-percussive separation for cleaner analysis), similarity (cosine distance, weighted scoring, clustering), kind_inference (loop vs one-shot heuristic, edge cases)
- add regression test for acid_beats=0 classification: Producer Loops Hypnotize pack writes ACID chunks with beats=0 on legitimate loops (126 BPM, exact 2-bar and 4-bar durations). Lock in behavior that acid_beats=0 is uninformative, equivalent to NULL, falls through to duration. Prevents future refactor from treating 0 as a one-shot signal
- expand docs/dsp/kind_inference.md to document the finding and rule

All docs follow the seven-section convention established in docs/format_internals.md 