### PR TITLE
fix info C-1 phantom key, make -v meaningful, add dump json, propagat…

### DIFF
--- a/src/acidcat/__main__.py
+++ b/src/acidcat/__main__.py
@@ -1,5 +1,6 @@
 """Allow running as `python -m acidcat`."""
+import sys
 from acidcat.cli import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main() or 0)

--- a/src/acidcat/commands/chunks.py
+++ b/src/acidcat/commands/chunks.py
@@ -16,7 +16,14 @@ def register(subparsers):
                    help="Output format (default: table).")
     p.add_argument("-o", "--output", help="Write output to file.")
     p.add_argument("-q", "--quiet", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Diagnostic lines on stderr (container size, walk summary).")
     p.set_defaults(func=run)
+
+
+def _vlog(args, msg):
+    if getattr(args, "verbose", False) and not getattr(args, "quiet", False):
+        print(msg, file=sys.stderr)
 
 
 def run(args):
@@ -29,6 +36,9 @@ def run(args):
         return 1
 
     fmt_name = getattr(args, 'format', 'table')
+
+    _vlog(args, f"[chunks] file={os.path.basename(filepath)} "
+                f"size={os.path.getsize(filepath)}")
 
     # Get RIFF container info
     riff_info = get_riff_info(filepath)
@@ -44,9 +54,13 @@ def run(args):
             "offset": offset,
             "size": size,
         })
+    _vlog(args, f"[chunks] walked {len(chunk_list)} chunks in "
+                f"RIFF {riff_info['type']}")
 
     # Also get parsed fields
     results, meta, seen = parse_riff(filepath, enumerate_all=True)
+    _vlog(args, f"[chunks] parsed {len(results)} fields from "
+                f"{len(seen)} unique chunk types")
 
     if fmt_name == "table":
         stream = sys.stdout

--- a/src/acidcat/commands/dump.py
+++ b/src/acidcat/commands/dump.py
@@ -1,8 +1,12 @@
 """
 acidcat dump -- hex-dump a specific RIFF chunk from a WAV file.
+
+Default output is a human-friendly hex preview. `-f json` emits a machine
+readable list that composes with jq and other tools.
 """
 
 import binascii
+import json
 import os
 import sys
 
@@ -15,9 +19,18 @@ def register(subparsers):
     p.add_argument("chunks", nargs="+",
                    help="Chunk IDs to dump (e.g. acid smpl LIST). Case-insensitive.")
     p.add_argument("-b", "--bytes", type=int, default=64, help="Hex preview length in bytes.")
+    p.add_argument("-f", "--format", default="hex", choices=["hex", "json"],
+                   help="Output format (default: hex). json emits full hex payloads.")
     p.add_argument("--write", help="Write raw chunk payloads to this directory.")
     p.add_argument("-q", "--quiet", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Diagnostic lines on stderr (wanted/found/skipped).")
     p.set_defaults(func=run)
+
+
+def _vlog(args, msg):
+    if getattr(args, "verbose", False) and not getattr(args, "quiet", False):
+        print(msg, file=sys.stderr)
 
 
 def run(args):
@@ -30,11 +43,15 @@ def run(args):
     wanted = {c.upper().ljust(4)[:4] for c in args.chunks}
     preview_len = getattr(args, 'bytes', 64)
     outdir = getattr(args, 'write', None)
+    fmt_name = getattr(args, 'format', 'hex')
     base = os.path.basename(filepath)
+
+    _vlog(args, f"[dump] wanted={sorted(wanted)} preview={preview_len}B fmt={fmt_name}")
 
     if outdir:
         os.makedirs(outdir, exist_ok=True)
 
+    collected = []
     found = False
     for cid, offset, size in iter_chunks(filepath):
         if cid.upper() not in wanted:
@@ -45,22 +62,45 @@ def run(args):
             f.seek(offset + 8)  # skip chunk header
             payload = f.read(size)
 
-        preview = binascii.hexlify(payload[:preview_len]).decode()
-        hex_str = " ".join(preview[i:i+2] for i in range(0, len(preview), 2))
+        entry = {
+            "chunk": cid,
+            "offset": offset,
+            "size": size,
+        }
 
-        print(f"[{cid}] @ offset {offset}, {size} bytes")
-        print(f"  {hex_str}")
-
-        if outdir:
-            outname = f"{os.path.splitext(base)[0]}_{cid}_{offset}.bin"
-            outpath = os.path.join(outdir, outname)
-            with open(outpath, "wb") as g:
-                g.write(payload)
-            print(f"  → {outpath}")
-        print()
+        if fmt_name == "hex":
+            preview = binascii.hexlify(payload[:preview_len]).decode()
+            hex_str = " ".join(preview[i:i + 2] for i in range(0, len(preview), 2))
+            print(f"[{cid}] @ offset {offset}, {size} bytes")
+            print(f"  {hex_str}")
+            if outdir:
+                outname = f"{os.path.splitext(base)[0]}_{cid}_{offset}.bin"
+                outpath = os.path.join(outdir, outname)
+                with open(outpath, "wb") as g:
+                    g.write(payload)
+                print(f"  -> {outpath}")
+                _vlog(args, f"[dump] wrote {size}B to {outpath}")
+            print()
+        else:
+            # json: include the full payload as a hex string so it survives
+            # serialization cleanly. Truncation here would surprise callers.
+            entry["hex"] = binascii.hexlify(payload).decode()
+            if outdir:
+                outname = f"{os.path.splitext(base)[0]}_{cid}_{offset}.bin"
+                outpath = os.path.join(outdir, outname)
+                with open(outpath, "wb") as g:
+                    g.write(payload)
+                entry["written_to"] = outpath
+                _vlog(args, f"[dump] wrote {size}B to {outpath}")
+            collected.append(entry)
 
     if not found:
         print(f"None of the requested chunks ({', '.join(args.chunks)}) found.", file=sys.stderr)
         return 1
 
+    if fmt_name == "json":
+        json.dump(collected, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+
+    _vlog(args, f"[dump] matched {len(collected) if fmt_name == 'json' else 'N/A'} chunks")
     return 0

--- a/src/acidcat/commands/info.py
+++ b/src/acidcat/commands/info.py
@@ -16,8 +16,17 @@ from acidcat.core.tagged import is_tagged_format
 from acidcat.core.detect import estimate_librosa_metadata
 from acidcat.core.features import extract_audio_features
 from acidcat.core.formats import output
-from acidcat.util.midi import midi_note_to_name
+from acidcat.util.midi import midi_note_to_name, midi_note_to_pitch_class
 from acidcat.util.stdin import is_stdin_target, stdin_to_tempfile
+
+
+def _vlog(args, msg):
+    """Emit a diagnostic line to stderr when -v is set and -q is not.
+
+    Keeps stdout clean so `acidcat info ... -f json | jq` stays pipe-friendly.
+    """
+    if getattr(args, "verbose", False) and not getattr(args, "quiet", False):
+        print(msg, file=sys.stderr)
 
 
 def register(subparsers):
@@ -59,6 +68,17 @@ def _info_wav(filepath, args):
     duration = get_duration(filepath)
     fmt = get_fmt_info(filepath)
 
+    # SMPL/ACID root_note of 0 is the default-unset sentinel (MIDI C-1),
+    # not a legitimate musical root. Treat as missing.
+    smpl_root = meta.get("smpl_root_key")
+    if not smpl_root:
+        smpl_root = None
+    acid_root = meta.get("acid_root_note")
+    if not acid_root:
+        acid_root = None
+
+    _vlog(args, "[detect] fmt=wav")
+
     rec = {}
     rec["File"] = os.path.basename(filepath)
 
@@ -75,8 +95,8 @@ def _info_wav(filepath, args):
         rec["BPM"] = meta["bpm"]
         if meta["acid_beats"]:
             rec["Beats"] = meta["acid_beats"]
-        if meta["acid_root_note"] is not None:
-            rec["ACID Root"] = midi_note_to_name(meta["acid_root_note"])
+        if acid_root is not None:
+            rec["ACID Root"] = midi_note_to_name(acid_root)
         if meta["acid_beats"] and meta["bpm"]:
             expected = round((meta["acid_beats"] / meta["bpm"]) * 60, 4)
             rec["Expected Duration"] = f"{expected}s"
@@ -86,18 +106,20 @@ def _info_wav(filepath, args):
     else:
         rec["BPM"] = "-"
 
-    if meta["smpl_root_key"] is not None:
-        rec["Key"] = f"{midi_note_to_name(meta['smpl_root_key'])} (from SMPL)"
-    elif meta["acid_root_note"] is not None:
-        rec["Key"] = f"{midi_note_to_name(meta['acid_root_note'])} (from ACID)"
+    if smpl_root is not None:
+        rec["Key"] = f"{midi_note_to_pitch_class(smpl_root)} (from SMPL)"
+        _vlog(args, f"[key] smpl_root={smpl_root} -> {midi_note_to_pitch_class(smpl_root)}")
+    elif acid_root is not None:
+        rec["Key"] = f"{midi_note_to_pitch_class(acid_root)} (from ACID)"
+        _vlog(args, f"[key] acid_root={acid_root} -> {midi_note_to_pitch_class(acid_root)}")
     else:
         rec["Key"] = "-"
+        _vlog(args, "[key] no SMPL/ACID root, unset")
 
     rec["ACID"] = "yes" if meta["bpm"] is not None else "no"
 
-    has_smpl = meta["smpl_root_key"] is not None
-    if has_smpl:
-        smpl_parts = [f"root={midi_note_to_name(meta['smpl_root_key'])}"]
+    if smpl_root is not None:
+        smpl_parts = [f"root={midi_note_to_name(smpl_root)}"]
         if meta["smpl_loop_start"] is not None:
             smpl_parts.append(f"loop={meta['smpl_loop_start']}-{meta['smpl_loop_end']}")
         else:
@@ -117,6 +139,7 @@ def _info_wav(filepath, args):
 
 def _info_aiff(filepath, args):
     """Build info record for an AIFF/AIFC file."""
+    _vlog(args, "[detect] fmt=aiff")
     _, meta, seen = parse_aiff(filepath, enumerate_all=False)
 
     rec = {}
@@ -160,6 +183,7 @@ def _info_aiff(filepath, args):
 
 def _info_midi(filepath, args):
     """Build info record for a MIDI file."""
+    _vlog(args, "[detect] fmt=midi")
     meta = parse_midi(filepath)
 
     rec = {}
@@ -205,6 +229,7 @@ def _info_midi(filepath, args):
 
 def _info_serum(filepath, args):
     """Build info record for a Serum preset."""
+    _vlog(args, "[detect] fmt=serum")
     meta = parse_serum_preset(filepath)
 
     rec = {}
@@ -239,6 +264,7 @@ def _info_tagged(filepath, args):
     """Build info record for tagged audio (MP3, FLAC, OGG, M4A)."""
     from acidcat.core.tagged import parse_tagged
 
+    _vlog(args, "[detect] fmt=tagged (via mutagen)")
     meta = parse_tagged(filepath)
     if meta is None:
         return {"File": os.path.basename(filepath), "Format": "unknown (mutagen failed)"}
@@ -307,10 +333,15 @@ def _info_tagged(filepath, args):
 
 def _add_deep_analysis(filepath, rec, args):
     """Append librosa deep analysis fields to an existing record."""
+    import time as _time
+
     if not getattr(args, 'quiet', False):
         print("  [deep] Running librosa analysis...", file=sys.stderr)
 
+    t0 = _time.perf_counter()
     estimates = estimate_librosa_metadata(filepath)
+    _vlog(args, f"[librosa] estimate_librosa_metadata: "
+                f"{(_time.perf_counter() - t0) * 1000:.0f}ms")
     if estimates:
         if estimates.get("estimated_bpm") and rec.get("BPM") in (None, "-"):
             bpm_val = estimates["estimated_bpm"]
@@ -321,7 +352,10 @@ def _add_deep_analysis(filepath, rec, args):
             src = estimates.get("key_source", "")
             rec["Key"] = f"{key_val} ({src})" if src else key_val
 
+    t1 = _time.perf_counter()
     feats = extract_audio_features(filepath)
+    _vlog(args, f"[librosa] extract_audio_features: "
+                f"{(_time.perf_counter() - t1) * 1000:.0f}ms")
     if feats:
         rec["Spectral Centroid"] = f"{float(feats.get('spectral_centroid_mean', 0)):.1f} Hz"
         rec["RMS Energy"] = f"{float(feats.get('rms_mean', 0)):.6f}"

--- a/src/acidcat/commands/scan.py
+++ b/src/acidcat/commands/scan.py
@@ -124,10 +124,18 @@ def run(args):
         wanted = set(w.strip().upper() for w in has_val.split(",") if w.strip())
 
     quiet = getattr(args, 'quiet', False)
+    verbose = getattr(args, 'verbose', False) and not quiet
     do_fallback = getattr(args, 'fallback', False)
     do_features = getattr(args, 'features', False)
     do_ml_ready = getattr(args, 'ml_ready', False)
     num = getattr(args, 'num', 500)
+
+    def _vlog(msg):
+        if verbose:
+            print(msg, file=sys.stderr)
+
+    _vlog(f"[scan] dir={directory} num={num} fallback={do_fallback} "
+          f"features={do_features}")
 
     rows = []
     count = 0
@@ -186,6 +194,10 @@ def run(args):
             if not quiet:
                 bpm_str = row.get("bpm") or "-"
                 print(f"  {os.path.basename(filepath):40s} BPM={bpm_str}", file=sys.stderr)
+            if verbose:
+                _vlog(f"    format={row.get('format')} "
+                      f"key={row.get('key') or '-'} "
+                      f"dur={row.get('duration_sec') or '-'}")
 
             rows.append(row)
             count += 1

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,9 +3,36 @@
 import os
 import csv
 import json
+import struct
 import pytest
 
 from acidcat.cli import main as cli_main
+
+
+def _riff_wav_with_smpl(path, smpl_root_key=None, num_samples=4):
+    """Write a minimal PCM WAV to path, optionally with a SMPL chunk.
+
+    Used by the C-1 regression tests for the info command.
+    """
+    sample_rate, channels, bits = 44100, 1, 16
+    block_align = channels * bits // 8
+    byte_rate = sample_rate * block_align
+    audio_data = b"\x00" * (num_samples * block_align)
+    fmt = struct.pack(
+        "<HHIIHH", 1, channels, sample_rate, byte_rate, block_align, bits,
+    )
+    fmt_chunk = b"fmt " + struct.pack("<I", 16) + fmt
+    data_chunk = b"data" + struct.pack("<I", len(audio_data)) + audio_data
+    smpl_chunk = b""
+    if smpl_root_key is not None:
+        smpl_body = struct.pack(
+            "<IIIIIIiiI",
+            0, 0, 0, smpl_root_key, 0, 0, 0, 0, 0,
+        )
+        smpl_chunk = b"smpl" + struct.pack("<I", len(smpl_body)) + smpl_body
+    riff_body = b"WAVE" + fmt_chunk + data_chunk + smpl_chunk
+    path.write_bytes(b"RIFF" + struct.pack("<I", len(riff_body)) + riff_body)
+    return str(path)
 
 
 def run_cli(*args):
@@ -197,6 +224,112 @@ class TestSurveyCommand:
         assert code == 0 or code is None
         assert "fmt" in out
         assert "data" in out
+
+
+class TestInfoSmplKeyDisplay:
+    """Regression tests: info should no longer display the bogus C-1 key
+    when SMPL/ACID root_key is 0, and should show pitch class (C) not C4."""
+
+    def test_smpl_root_zero_renders_as_unset(self, tmp_path):
+        path = _riff_wav_with_smpl(tmp_path / "zero.wav", smpl_root_key=0)
+        code, out, err = run_cli(path)
+        assert code == 0 or code is None
+        assert "C-1" not in out
+        # JSON form is unambiguous for the assertion
+        code_j, out_j, _ = run_cli(path, "-f", "json")
+        data = json.loads(out_j)
+        assert data["Key"] == "-"
+
+    def test_smpl_root_60_renders_as_pitch_class(self, tmp_path):
+        path = _riff_wav_with_smpl(tmp_path / "c4.wav", smpl_root_key=60)
+        code, out, err = run_cli(path)
+        assert code == 0 or code is None
+        # pitch class only in the Key line; octave suffix must not appear there
+        assert "C (from SMPL)" in out
+        assert "C4 (from SMPL)" not in out
+
+    def test_smpl_root_60_json_has_pitch_class(self, tmp_path):
+        path = _riff_wav_with_smpl(tmp_path / "c4.wav", smpl_root_key=60)
+        code, out, err = run_cli(path, "-f", "json")
+        assert code == 0 or code is None
+        data = json.loads(out)
+        assert data["Key"].startswith("C ")
+        assert "C4" not in data["Key"]
+
+    def test_no_smpl_no_acid_renders_as_unset(self, tmp_path):
+        path = _riff_wav_with_smpl(tmp_path / "nokey.wav", smpl_root_key=None)
+        code, out, err = run_cli(path)
+        assert code == 0 or code is None
+        assert "C-1" not in out
+
+
+class TestVerboseStderr:
+    """-v should add stderr diagnostics without changing stdout."""
+
+    def test_info_verbose_stdout_unchanged(self, minimal_wav):
+        _, out_quiet, _ = run_cli(minimal_wav, "-f", "json")
+        _, out_verbose, err = run_cli(minimal_wav, "-f", "json", "-v")
+        assert out_quiet == out_verbose
+        assert "[detect]" in err
+
+    def test_info_quiet_overrides_verbose(self, minimal_wav):
+        _, out, err = run_cli(minimal_wav, "-f", "json", "-v", "-q")
+        # -q wins: no verbose lines on stderr
+        assert "[detect]" not in err
+
+    def test_chunks_verbose_stdout_unchanged(self, minimal_wav):
+        _, out_plain, _ = run_cli("chunks", minimal_wav, "-f", "json")
+        _, out_verbose, err = run_cli("chunks", minimal_wav, "-f", "json", "-v")
+        assert out_plain == out_verbose
+        assert "[chunks]" in err
+
+    def test_dump_verbose_stdout_unchanged(self, minimal_wav):
+        _, out_plain, _ = run_cli("dump", minimal_wav, "fmt", "-f", "json")
+        _, out_verbose, err = run_cli("dump", minimal_wav, "fmt", "-f", "json", "-v")
+        assert out_plain == out_verbose
+        assert "[dump]" in err
+
+
+class TestDumpJson:
+    """dump -f json should emit a machine-readable list of chunks."""
+
+    def test_json_structure(self, minimal_wav):
+        code, out, err = run_cli("dump", minimal_wav, "fmt", "-f", "json")
+        assert code == 0 or code is None
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        entry = data[0]
+        for k in ("chunk", "offset", "size", "hex"):
+            assert k in entry
+        assert entry["chunk"].upper().startswith("FMT")
+        assert isinstance(entry["offset"], int)
+        assert isinstance(entry["size"], int)
+        # full payload in hex, not a preview
+        assert len(entry["hex"]) == entry["size"] * 2
+
+    def test_json_multiple_chunks(self, minimal_wav):
+        code, out, err = run_cli("dump", minimal_wav, "fmt", "data", "-f", "json")
+        assert code == 0 or code is None
+        data = json.loads(out)
+        chunks_returned = {e["chunk"].upper().strip() for e in data}
+        assert {"FMT", "DATA"}.issubset(chunks_returned)
+
+    def test_json_missing_chunk_returns_error(self, minimal_wav):
+        code, out, err = run_cli("dump", minimal_wav, "acid", "-f", "json")
+        assert code == 1
+        # no stdout emitted on error
+        assert out.strip() == ""
+
+    def test_hex_still_default(self, minimal_wav):
+        code, out, err = run_cli("dump", minimal_wav, "fmt")
+        assert code == 0 or code is None
+        # default hex output is not valid JSON
+        try:
+            json.loads(out)
+            assert False, "hex default should not be valid JSON"
+        except (json.JSONDecodeError, ValueError):
+            pass
 
     def test_survey_empty_directory(self, tmp_path):
         code, out, err = run_cli("survey", str(tmp_path), "-q")


### PR DESCRIPTION
…e exit codes

- info: when SMPL/ACID root_note is 0 (the default-unset MIDI sentinel), show "Key: -" instead of the bogus "C-1 (from ACID)". Use pitch-class display (e.g. "C") rather than full note name with octave (e.g. "C4") for the Key field; ACID Root keeps the octave since it is technical metadata. Brings info in line with the index command's behavior
- -v across info/chunks/scan/dump: now produces diagnostic lines on stderr only, leaving stdout byte-identical for pipes. Useful for debugging without breaking `acidcat ... -f json | jq`. Examples: `[detect] fmt=wav`, `[key] no SMPL/ACID root, unset`, `[librosa] estimate_librosa_metadata: 3854ms`, `[chunks] walked 7 chunks in RIFF WAVE`. -q still squelches
- dump -f json: new format alongside the default hex preview. Each chunk emits {chunk, offset, size, hex} with the full payload (not a preview) so callers can decode without re-reading the file. Pipes cleanly into Python/jq for chunk inspection
- __main__.py: propagate main()'s return value through sys.exit so `python -m acidcat info missing.wav` actually exits 1. Was silently exiting 0 on every error
- 12 new tests covering all of the above (TestInfoSmplKeyDisplay, TestVerboseStderr, TestDumpJson)