### PR TITLE
move to per-library SQLite indexes + global registry, bump to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Reads BPM, key, duration, tags, and format info from WAV, AIFF, MP3, FLAC,
 OGG, Opus, M4A, MIDI, and Serum presets. Zero dependencies for core metadata.
 Optional librosa analysis for BPM/key detection and ML feature extraction.
 
-Also ships a persistent SQLite index (`acidcat index`) and an MCP server
-(`acidcat-mcp`) so an LLM can query your whole sample library by bpm, key,
-tags, or full-text.
+Also ships per-library SQLite indexes (`acidcat index`) tracked in a
+small global registry, plus an MCP server (`acidcat-mcp`) so an LLM can
+query your whole collection across libraries by bpm, key, tags, or
+full-text.
 
 ## Install
 
@@ -139,50 +140,74 @@ tags, or full-text.
     # k-means clustering
     acidcat similar features.csv cluster -k 10 -o clustered.csv
 
-## Global Index
+## Libraries (per-directory indexes)
 
-`acidcat scan` writes a one-off CSV. `acidcat index` maintains a single
-persistent SQLite database at `~/.acidcat/index.db` that aggregates every
-directory you point it at. Re-running skips unchanged files and prunes
-missing ones. Query it without rescanning.
+`acidcat scan` writes a one-off CSV. `acidcat index` is the persistent
+path: each directory you index becomes a *library* with its own SQLite
+file, and a small global registry at `~/.acidcat/registry.db` lets reads
+fan out across every library you have registered.
 
-    # add a library (repeat for as many folders as you want)
-    acidcat index ~/Samples/Loops
-    acidcat index ~/Samples/OneShots
+By default the per-library DB lives centrally at
+`~/.acidcat/libraries/<label>_<hash>.db`. Pass `--in-tree` if you'd
+rather have the DB travel with the data at
+`<library>/.acidcat/index.db`.
 
-    # show what has been indexed
-    acidcat index --list-roots
-    acidcat index --stats
+    # register and index a library (label defaults to basename of DIR)
+    acidcat index ~/Samples/Loops --label loops
+    acidcat index ~/Samples/OneShots --label oneshots
 
-    # optional: include librosa features (slower, enables similarity)
-    acidcat index ~/Samples/Loops --features
+    # show every registered library
+    acidcat index --list
 
-    # optional: import legacy <name>_tags.json into the index
-    acidcat index ~/Samples --import-tags old_tags.json
+    # per-library stats
+    acidcat index --stats loops
 
-    # drop everything under a root
-    acidcat index --remove-root ~/Samples/Loops
+    # extract librosa features during indexing (slower, enables similarity)
+    acidcat index ~/Samples/Loops --label loops --features
+
+    # rebuild a library's DB from scratch
+    acidcat index ~/Samples/Loops --label loops --rebuild
+
+    # forget a library (registry only) vs remove it (deletes the DB file)
+    acidcat index --forget loops
+    acidcat index --remove loops
+
+    # list registered libraries whose DB file is missing on disk
+    acidcat index --orphans
+
+    # import a legacy <name>_tags.json into a library
+    acidcat index ~/Samples --label samples --import-tags old_tags.json
+
+Nested libraries are rejected at registration time: if you've registered
+`~/Samples`, you can't also register `~/Samples/Loops` until you forget
+the parent.
 
 ### Querying
+
+By default `acidcat query` fans out across every registered library and
+merges the results.
 
     acidcat query --bpm 120:130 --key Am
     acidcat query --tag drums --tag punchy --duration :1
     acidcat query --text "dusty lofi" --limit 20
-    acidcat query --format mp3 --root ~/Samples/Loops
+    acidcat query --format mp3 --root loops
+    acidcat query --root loops,oneshots --bpm 128
     acidcat query --bpm 128 --paths-only | xargs -I {} cp {} out/
 
-Override the DB on any command with `--db PATH` or the `ACIDCAT_DB`
-environment variable.
+`--root` accepts a label, an absolute path, or a comma-separated list.
+Override the registry on any command with `--registry PATH` or the
+`ACIDCAT_REGISTRY` environment variable.
 
 ## MCP Server
 
-`acidcat-mcp` is a stdio MCP server that exposes the global index as
-structured tools. An LLM can search your library by metadata, find
-compatible keys via Camelot, or (with `[analysis]` installed) find
-similar samples by librosa feature cosine.
+`acidcat-mcp` is a stdio MCP server that exposes the registered libraries
+as structured tools. An LLM can ask "what libraries do I have?",
+search across them by metadata, find compatible keys via Camelot, or
+(with `[analysis]` installed) find similar samples by librosa feature
+cosine.
 
-    pip install -e .[tags,mcp]        # minimum for discovery + writes
-    pip install -e .[tags,analysis,mcp]  # unlock find_similar/analyze_*
+    pip install -e .[tags,mcp]            # minimum for discovery + writes
+    pip install -e .[tags,analysis,mcp]   # unlock find_similar / analyze_*
 
 Claude Desktop / Claude Code config:
 
@@ -194,19 +219,20 @@ Claude Desktop / Claude Code config:
       }
     }
 
-Optional: pass `--db` or set `ACIDCAT_DB` on the server process if your
-index lives outside the default path.
+Optional: pass `--registry PATH` on the server process or set
+`ACIDCAT_REGISTRY` if your registry lives outside the default location.
 
 Tool tiers (each tool description starts with `Fast.`, `SLOW.`, or
 `VERY SLOW.` so the model self-selects):
 
 - **Fast (SQLite only)**: `search_samples`, `get_sample`, `locate_sample`,
-  `list_roots`, `list_tags`, `list_keys`, `list_formats`, `index_stats`,
-  `find_compatible`
+  `list_libraries`, `list_tags`, `list_keys`, `list_formats`,
+  `index_stats`, `find_compatible`
 - **Slow analysis** (needs `[analysis]`): `find_similar`, `analyze_sample`,
   `detect_bpm_key`
 - **Index management**: `reindex`, `reindex_features`
-- **Write**: `tag_sample`, `describe_sample` (marked destructive)
+- **Write** (marked destructive): `register_library`, `forget_library`,
+  `tag_sample`, `describe_sample`
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.4.0"
+version = "0.5.0"
 description = "Audio metadata explorer and analysis tool -- like exiftool, but for audio"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/acidcat/commands/index.py
+++ b/src/acidcat/commands/index.py
@@ -1,6 +1,20 @@
 """
-acidcat index -- walk a directory and upsert samples into the global
-SQLite index at ~/.acidcat/index.db.
+acidcat index -- build and manage per-library sample indexes.
+
+A library is a directory you have registered for indexing. Each library
+gets its own SQLite file (default: ~/.acidcat/libraries/<label>_<hash>.db,
+or `<library>/.acidcat/index.db` with --in-tree). The global registry at
+~/.acidcat/registry.db tracks every library so reads can fan out across
+your whole collection without scanning disk.
+
+Usage:
+    acidcat index DIR [--label NAME] [--in-tree] [--features] [--deep]
+                      [--rebuild] [--import-tags FILE] [--registry PATH]
+    acidcat index --list   [--registry PATH]
+    acidcat index --orphans [--registry PATH]
+    acidcat index --stats LABEL_OR_PATH [--registry PATH]
+    acidcat index --forget LABEL_OR_PATH [--registry PATH]
+    acidcat index --remove LABEL_OR_PATH [--registry PATH]
 """
 
 import json
@@ -9,6 +23,8 @@ import sys
 import time
 
 from acidcat.core import index as idx
+from acidcat.core import paths as acidpaths
+from acidcat.core import registry as reg
 from acidcat.core.riff import parse_riff, get_duration, get_fmt_info
 from acidcat.core.aiff import is_aiff, parse_aiff
 from acidcat.core.midi import is_midi, parse_midi
@@ -37,60 +53,123 @@ def _is_junk(name):
 def register(subparsers):
     p = subparsers.add_parser(
         "index",
-        help="Build/update the global sample index at ~/.acidcat/index.db.",
+        help="Build/update a per-library sample index.",
     )
     p.add_argument("target", nargs="?", help="Directory to index.")
-    p.add_argument("--db", help="Override DB path (default: ~/.acidcat/index.db).")
+    p.add_argument("--label",
+                   help="Friendly label for the library "
+                        "(default: basename of DIR).")
+    p.add_argument("--in-tree", dest="in_tree", action="store_true",
+                   help="Store the DB inside <DIR>/.acidcat/index.db instead "
+                        "of ~/.acidcat/libraries/<label>_<hash>.db.")
+    p.add_argument("--rebuild", action="store_true",
+                   help="Delete the existing per-library DB before indexing.")
     p.add_argument("--features", action="store_true",
                    help="Extract librosa audio features during indexing.")
     p.add_argument("--deep", action="store_true",
                    help="Use librosa for BPM/key when metadata is absent.")
     p.add_argument("--import-tags", dest="import_tags",
-                   help="Import a legacy <name>_tags.json into the index.")
-    p.add_argument("--list-roots", action="store_true",
-                   help="Print known scan roots and exit.")
-    p.add_argument("--remove-root", dest="remove_root",
-                   help="Delete all samples under this root and exit.")
-    p.add_argument("--stats", action="store_true",
-                   help="Print index summary and exit.")
+                   help="Import a legacy <name>_tags.json into the library.")
+    p.add_argument("--registry",
+                   help="Override registry DB path "
+                        "(default: ~/.acidcat/registry.db).")
+    # registry-management subcommands (target-less)
+    p.add_argument("--list", dest="list_libs", action="store_true",
+                   help="List all registered libraries.")
+    p.add_argument("--orphans", action="store_true",
+                   help="List registered libraries whose DB file is missing.")
+    p.add_argument("--stats", dest="stats_target",
+                   help="Print stats for one library (by label or path).")
+    p.add_argument("--forget", dest="forget",
+                   help="Remove a library from the registry. Does NOT delete "
+                        "its DB file.")
+    p.add_argument("--remove", dest="remove",
+                   help="Forget a library AND delete its DB file.")
     p.add_argument("-q", "--quiet", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Diagnostic lines on stderr.")
     p.set_defaults(func=run)
 
 
+def _vlog(args, msg):
+    if getattr(args, "verbose", False) and not getattr(args, "quiet", False):
+        print(msg, file=sys.stderr)
+
+
+def _warn_legacy_db(args):
+    """One-line stderr warning if v0.4 single-DB sits at ~/.acidcat/index.db."""
+    legacy = acidpaths.legacy_global_db_path()
+    if os.path.isfile(legacy) and not getattr(args, "quiet", False):
+        print(f"[INFO] legacy v0.4 DB at {legacy} is ignored. "
+              f"Remove with: rm {legacy}*", file=sys.stderr)
+
+
 def run(args):
-    db_path = idx.resolve_db_path(getattr(args, "db", None))
-    conn = idx.open_db(db_path)
     quiet = getattr(args, "quiet", False)
+    registry_path = getattr(args, "registry", None)
 
+    # registry-management modes (no target required)
+    if args.list_libs:
+        return _cmd_list(registry_path)
+    if args.orphans:
+        return _cmd_orphans(registry_path)
+    if args.stats_target:
+        return _cmd_stats(args.stats_target, registry_path)
+    if args.forget:
+        return _cmd_forget(args.forget, registry_path, quiet=quiet)
+    if args.remove:
+        return _cmd_remove(args.remove, registry_path, quiet=quiet)
+
+    # main index mode requires a target dir
+    if not args.target:
+        print("acidcat index: missing target directory (or use "
+              "--list/--orphans/--stats/--forget/--remove)", file=sys.stderr)
+        return 1
+
+    target = args.target
+    if not os.path.isdir(target):
+        print(f"acidcat index: {target}: Not a directory", file=sys.stderr)
+        return 1
+
+    _warn_legacy_db(args)
+
+    scan_root = acidpaths.normalize(target)
+    label = args.label or os.path.basename(scan_root) or "library"
+    in_tree = bool(args.in_tree)
+    db_path = (
+        acidpaths.in_tree_db_path_for(scan_root) if in_tree
+        else acidpaths.central_db_path_for(scan_root, label)
+    )
+
+    # open registry first to validate non-overlap before we touch any disk state
+    rconn = reg.open_registry(registry_path)
     try:
-        if args.list_roots:
-            _print_roots(conn, db_path)
-            return 0
-
-        if args.remove_root:
-            root = idx.normalize_path(args.remove_root)
-            removed = idx.remove_root(conn, root)
-            conn.commit()
-            if not quiet:
-                print(f"[INFO] removed {removed} sample(s) under {root}",
-                      file=sys.stderr)
-            return 0
-
-        if args.stats:
-            _print_stats(conn, db_path)
-            return 0
-
-        if not args.target:
-            print("acidcat index: missing target directory (or use "
-                  "--list-roots/--remove-root/--stats)", file=sys.stderr)
+        try:
+            reg.register_library(
+                rconn, scan_root, label=label, db_path=db_path,
+                in_tree=in_tree, schema_version=idx.SCHEMA_VERSION,
+            )
+        except reg.OverlapError as e:
+            print(f"acidcat index: {e}", file=sys.stderr)
             return 1
+    finally:
+        rconn.close()
 
-        target = args.target
-        if not os.path.isdir(target):
-            print(f"acidcat index: {target}: Not a directory", file=sys.stderr)
+    if args.rebuild and os.path.isfile(db_path):
+        try:
+            os.remove(db_path)
+            for ext in (".db-shm", ".db-wal"):
+                sidecar = db_path[:-3] + ext if db_path.endswith(".db") else db_path + ext
+                if os.path.isfile(sidecar):
+                    os.remove(sidecar)
+        except OSError as e:
+            print(f"acidcat index: --rebuild could not remove {db_path}: {e}",
+                  file=sys.stderr)
             return 1
+        _vlog(args, f"[index] removed existing DB at {db_path}")
 
-        scan_root = idx.normalize_path(target)
+    conn = idx.open_db(db_path)
+    try:
         if not quiet:
             print(f"[INFO] indexing {scan_root} -> {db_path}", file=sys.stderr)
 
@@ -110,16 +189,147 @@ def run(args):
 
         conn.commit()
 
-        if not quiet:
-            print(
-                f"[INFO] {counts['added']} added, {counts['updated']} updated, "
-                f"{counts['skipped']} skipped, {counts['pruned']} pruned, "
-                f"{counts['failed']} failed",
-                file=sys.stderr,
-            )
-        return 0
+        # post-walk: refresh registry stats
+        sample_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM samples"
+        ).fetchone()["c"]
+        feature_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM features"
+        ).fetchone()["c"]
     finally:
         conn.close()
+
+    rconn = reg.open_registry(registry_path)
+    try:
+        reg.update_stats(
+            rconn, scan_root,
+            sample_count=sample_count,
+            feature_count=feature_count,
+            last_indexed_at=time.time(),
+            schema_version=idx.SCHEMA_VERSION,
+        )
+    finally:
+        rconn.close()
+
+    if not quiet:
+        print(
+            f"[INFO] [{label}] {counts['added']} added, {counts['updated']} updated, "
+            f"{counts['skipped']} skipped, {counts['pruned']} pruned, "
+            f"{counts['failed']} failed",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def _cmd_list(registry_path):
+    rconn = reg.open_registry(registry_path)
+    try:
+        rows = reg.list_libraries(rconn)
+        if not rows:
+            print("(no libraries registered)")
+            return 0
+        for r in rows:
+            existing = "  " if os.path.isfile(r["db_path"]) else "! "
+            count = r["sample_count"] if r["sample_count"] is not None else "?"
+            mode = "in-tree" if r["in_tree"] else "central"
+            print(f"{existing}{r['label']:<24s} {count:>7}  [{mode}]  {r['root_path']}")
+        return 0
+    finally:
+        rconn.close()
+
+
+def _cmd_orphans(registry_path):
+    rconn = reg.open_registry(registry_path)
+    try:
+        orphans = reg.find_orphans(rconn)
+        if not orphans:
+            print("(no orphans)")
+            return 0
+        for r in orphans:
+            print(f"{r['label']:<24s}  {r['root_path']}  -> missing {r['db_path']}")
+        return 0
+    finally:
+        rconn.close()
+
+
+def _cmd_stats(target, registry_path):
+    rconn = reg.open_registry(registry_path)
+    try:
+        row = reg.get_library(rconn, target)
+        if row is None:
+            print(f"acidcat index: no library matches '{target}'", file=sys.stderr)
+            return 1
+    finally:
+        rconn.close()
+
+    if not os.path.isfile(row["db_path"]):
+        print(f"Library:      {row['label']}")
+        print(f"Root:         {row['root_path']}")
+        print(f"DB:           {row['db_path']}  (MISSING)")
+        return 1
+
+    conn = idx.open_db(row["db_path"])
+    try:
+        stats = idx.index_stats(conn)
+    finally:
+        conn.close()
+
+    print(f"Library:      {row['label']}")
+    print(f"Root:         {row['root_path']}")
+    print(f"DB:           {row['db_path']}")
+    print(f"Mode:         {'in-tree' if row['in_tree'] else 'central'}")
+    print(f"Total:        {stats['total_samples']}")
+    print(f"With features:{stats['with_features']:>6}")
+    print(f"Unique tags:  {stats['unique_tags']}")
+    print(f"Descriptions: {stats['with_descriptions']}")
+    if stats["by_format"]:
+        print("By format:")
+        for fmt in stats["by_format"]:
+            print(f"  {fmt['format']:<10s} {fmt['count']}")
+    return 0
+
+
+def _cmd_forget(target, registry_path, quiet=False):
+    rconn = reg.open_registry(registry_path)
+    try:
+        n = reg.forget_library(rconn, target)
+    finally:
+        rconn.close()
+    if n == 0:
+        print(f"acidcat index: no library matches '{target}'", file=sys.stderr)
+        return 1
+    if not quiet:
+        print(f"[INFO] forgot library '{target}' "
+              f"(DB file untouched)", file=sys.stderr)
+    return 0
+
+
+def _cmd_remove(target, registry_path, quiet=False):
+    rconn = reg.open_registry(registry_path)
+    try:
+        row = reg.get_library(rconn, target)
+        if row is None:
+            print(f"acidcat index: no library matches '{target}'",
+                  file=sys.stderr)
+            return 1
+        db_path = row["db_path"]
+        reg.forget_library(rconn, target)
+    finally:
+        rconn.close()
+
+    removed_files = []
+    for suffix in ("", "-shm", "-wal"):
+        cand = db_path + suffix
+        if os.path.isfile(cand):
+            try:
+                os.remove(cand)
+                removed_files.append(cand)
+            except OSError as e:
+                print(f"[WARN] could not remove {cand}: {e}", file=sys.stderr)
+    if not quiet:
+        print(f"[INFO] removed library '{target}' "
+              f"({len(removed_files)} file(s) deleted)", file=sys.stderr)
+    return 0
 
 
 def _walk_and_upsert(conn, scan_root, do_features=False, do_deep=False, quiet=False):
@@ -432,27 +642,3 @@ def _import_tags(conn, import_file):
     return imported
 
 
-def _print_roots(conn, db_path):
-    roots = idx.list_roots(conn)
-    if not roots:
-        print(f"(no scan roots in {db_path})")
-        return
-    for r in roots:
-        print(f"{r['file_count']:>6}  {r['path']}")
-
-
-def _print_stats(conn, db_path):
-    stats = idx.index_stats(conn)
-    print(f"DB: {db_path}")
-    print(f"Total samples: {stats['total_samples']}")
-    print(f"With features: {stats['with_features']}")
-    print(f"With descriptions: {stats['with_descriptions']}")
-    print(f"Unique tags: {stats['unique_tags']}")
-    if stats["by_format"]:
-        print("By format:")
-        for row in stats["by_format"]:
-            print(f"  {row['format']:<10s} {row['count']}")
-    if stats["roots"]:
-        print("Scan roots:")
-        for r in stats["roots"]:
-            print(f"  {r['file_count']:>6}  {r['path']}")

--- a/src/acidcat/commands/query.py
+++ b/src/acidcat/commands/query.py
@@ -1,11 +1,18 @@
 """
-acidcat query -- filter samples from the global SQLite index.
+acidcat query -- filter samples across all registered libraries.
+
+Default behavior is to fan out across every library in the registry,
+merge results, dedup by path, and apply a final LIMIT. Use --root to
+scope to one or more libraries by label or path. Override the registry
+location with --registry or the ACIDCAT_REGISTRY env var.
 """
 
 import os
 import sys
 
 from acidcat.core import index as idx
+from acidcat.core import paths as acidpaths
+from acidcat.core import registry as reg
 from acidcat.core.formats import output
 
 
@@ -18,9 +25,11 @@ DEFAULT_FIELDS = [
 def register(subparsers):
     p = subparsers.add_parser(
         "query",
-        help="Filter the global sample index.",
+        help="Filter samples across all registered libraries.",
     )
-    p.add_argument("--db", help="Override DB path (default: ~/.acidcat/index.db).")
+    p.add_argument("--registry",
+                   help="Override registry DB path "
+                        "(default: ~/.acidcat/registry.db).")
     p.add_argument("--bpm", help="BPM filter. Exact (128) or range (120:130).")
     p.add_argument("--key", help="Key filter (exact match, e.g. Am, C#).")
     p.add_argument("--duration", help="Duration filter in seconds. "
@@ -31,7 +40,9 @@ def register(subparsers):
                    help="File format filter (wav, mp3, flac, midi, ...).")
     p.add_argument("--text", help="Full-text search across title/artist/album/"
                    "genre/comment/description/tags/path.")
-    p.add_argument("--root", help="Scope results to samples under this scan root.")
+    p.add_argument("--root",
+                   help="Scope results to one or more libraries (label or "
+                        "path). Comma-separate to query multiple libraries.")
     p.add_argument("--limit", type=int, default=50, help="Max rows (default 50).")
     p.add_argument("-f", "--output-format", dest="output_format",
                    default="table", choices=["table", "json", "csv"],
@@ -39,21 +50,41 @@ def register(subparsers):
     p.add_argument("-o", "--output", help="Write output to file.")
     p.add_argument("--paths-only", action="store_true",
                    help="Print bare paths, one per line.")
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Diagnostic lines on stderr (per-library row counts).")
     p.set_defaults(func=run)
 
 
+def _vlog(args, msg):
+    if getattr(args, "verbose", False):
+        print(msg, file=sys.stderr)
+
+
 def run(args):
-    db_path = idx.resolve_db_path(getattr(args, "db", None))
-    if not os.path.isfile(db_path):
-        print(f"acidcat query: no index at {db_path}. "
-              f"Run `acidcat index DIR` first.", file=sys.stderr)
+    registry_path = getattr(args, "registry", None)
+    rconn = reg.open_registry(registry_path)
+    try:
+        libs = reg.list_libraries(rconn, only_existing=True)
+    finally:
+        rconn.close()
+
+    if not libs:
+        print("acidcat query: no libraries registered. "
+              "Run `acidcat index DIR --label NAME` first.", file=sys.stderr)
         return 1
 
-    conn = idx.open_db(db_path)
-    try:
-        rows = _run_query(conn, args)
-    finally:
-        conn.close()
+    scopes = None
+    if args.root:
+        scopes = [s.strip() for s in args.root.split(",") if s.strip()]
+        libs = _scope_libraries(libs, scopes)
+        if not libs:
+            print(f"acidcat query: no library matches --root {args.root!r}",
+                  file=sys.stderr)
+            return 1
+
+    rows = _fan_out(libs, args)
+    rows.sort(key=lambda r: r.get("path") or "")
+    rows = rows[: args.limit]
 
     if not rows:
         if not getattr(args, "paths_only", False):
@@ -76,7 +107,62 @@ def run(args):
     return 0
 
 
-def _run_query(conn, args):
+def _scope_libraries(libs, scopes):
+    """Filter libs to those matching any scope (by label or path)."""
+    out = []
+    for lib in libs:
+        for s in scopes:
+            if lib["label"] == s:
+                out.append(lib)
+                break
+            if os.path.exists(s):
+                norm = acidpaths.normalize(s)
+                root = lib["root_path"]
+                if root == norm or root.startswith(norm + "/") \
+                        or norm.startswith(root + "/"):
+                    out.append(lib)
+                    break
+    return out
+
+
+def _fan_out(libs, args):
+    """Open each library's DB, run the query, accumulate rows, dedup."""
+    sql, params = _build_sql(args)
+    per_db_sql = sql + " LIMIT ?"
+    per_db_limit = args.limit
+
+    accumulated = []
+    seen_paths = set()
+    for lib in libs:
+        try:
+            conn = idx.open_db(lib["db_path"])
+        except Exception as e:
+            _vlog(args, f"[query] {lib['label']} skipped: {e}")
+            continue
+        try:
+            rows = conn.execute(per_db_sql, params + [per_db_limit]).fetchall()
+        except Exception as e:
+            _vlog(args, f"[query] {lib['label']} query failed: {e}")
+            conn.close()
+            continue
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        _vlog(args, f"[query] {lib['label']:<20s} {len(rows)} rows")
+        for r in rows:
+            d = dict(r)
+            p = d.get("path")
+            if p in seen_paths:
+                continue
+            seen_paths.add(p)
+            accumulated.append(_shape_row(d))
+    return accumulated
+
+
+def _build_sql(args):
+    """Build the WHERE clause shared across every library DB."""
     where = []
     params = []
     joins = []
@@ -107,12 +193,6 @@ def _run_query(conn, args):
         where.append("LOWER(s.format) = LOWER(?)")
         params.append(args.file_format)
 
-    if args.root:
-        root = idx.normalize_path(args.root)
-        where.append("(s.scan_root = ? OR s.path LIKE ?)")
-        params.append(root)
-        params.append(root.rstrip("/") + "/%")
-
     tags = [t for t in (args.tag or []) if t]
     if tags:
         placeholders = ",".join("?" for _ in tags)
@@ -133,15 +213,12 @@ def _run_query(conn, args):
     sql = "SELECT s.* FROM samples s " + " ".join(joins)
     if where:
         sql += " WHERE " + " AND ".join(where)
-    sql += " ORDER BY s.path LIMIT ?"
-    params.append(args.limit)
-
-    rows = conn.execute(sql, params).fetchall()
-    return [_shape_row(dict(r)) for r in rows]
+    sql += " ORDER BY s.path"
+    return sql, params
 
 
 def _shape_row(row):
-    """Project to the default display columns, keeping key data."""
+    """Project to the default display columns, keeping non-null values only."""
     out = {}
     for k in DEFAULT_FIELDS:
         if k in row and row[k] is not None:

--- a/src/acidcat/core/paths.py
+++ b/src/acidcat/core/paths.py
@@ -1,0 +1,145 @@
+"""Path layout helpers for acidcat v0.5+ per-library storage.
+
+acidcat tracks a sample collection as a set of libraries. Each library
+has its own SQLite index. By default the index lives centrally:
+
+    ~/.acidcat/
+        registry.db                          global registry of libraries
+        libraries/
+            <safe_label>_<hash>.db           per-library index, one per registered root
+
+A user who would rather have the DB travel with the data passes
+`--in-tree` at registration time, which puts the DB at
+`<library_root>/.acidcat/index.db` instead. Either way the registry
+records the canonical db_path so callers do not need to care which
+mode any given library uses.
+
+Everything here is stdlib-only.
+"""
+
+import hashlib
+import os
+import re
+
+
+ACIDCAT_DIR_NAME = ".acidcat"
+INDEX_DB_NAME = "index.db"
+REGISTRY_DB_NAME = "registry.db"
+LIBRARIES_DIR_NAME = "libraries"
+
+
+def normalize(p):
+    """Canonical absolute path with forward slashes (cross-platform stable).
+
+    Used for every persisted path so we do not get equivalent rows differing
+    only by separator or relative form.
+    """
+    return os.path.abspath(p).replace("\\", "/")
+
+
+def acidcat_home():
+    """`~/.acidcat/`. Created on demand by callers that write into it."""
+    return os.path.join(os.path.expanduser("~"), ACIDCAT_DIR_NAME).replace("\\", "/")
+
+
+def central_libraries_dir():
+    """`~/.acidcat/libraries/`, where central-mode per-lib DBs live."""
+    return os.path.join(acidcat_home(), LIBRARIES_DIR_NAME).replace("\\", "/")
+
+
+def registry_db_path():
+    """Default registry DB path: `~/.acidcat/registry.db`."""
+    return os.path.join(acidcat_home(), REGISTRY_DB_NAME).replace("\\", "/")
+
+
+def resolve_registry_path(cli_value=None):
+    """Resolve registry path from --registry, ACIDCAT_REGISTRY env, or default."""
+    if cli_value:
+        return cli_value
+    env = os.environ.get("ACIDCAT_REGISTRY")
+    if env:
+        return env
+    return registry_db_path()
+
+
+def legacy_global_db_path():
+    """`~/.acidcat/index.db`, the v0.4 single-DB location.
+
+    v0.5 does not read or write this file. We only check for its existence
+    so we can surface a one-line stderr warning when it is encountered.
+    """
+    return os.path.join(acidcat_home(), INDEX_DB_NAME).replace("\\", "/")
+
+
+_LABEL_SAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def safe_label(label):
+    """Return a filename-safe version of a label.
+
+    Replaces any run of non-alphanumeric/underscore/dot/dash characters with
+    a single underscore, trims surrounding underscores, and falls back to
+    "library" if the result is empty.
+    """
+    if label is None:
+        return "library"
+    s = _LABEL_SAFE_RE.sub("_", str(label)).strip("_")
+    return s or "library"
+
+
+def path_hash(root):
+    """8-character sha1 hex of the normalized root path.
+
+    Stable across runs and across label changes. Used as a disambiguating
+    suffix in central-mode DB filenames so two libraries with the same
+    label slug never collide on disk.
+    """
+    return hashlib.sha1(normalize(root).encode("utf-8")).hexdigest()[:8]
+
+
+def central_db_path_for(root, label):
+    """Compute the central-mode DB path for a given root + label.
+
+    Example:
+        central_db_path_for("/foo/Hypnotize 03", "hypnotize")
+        -> "~/.acidcat/libraries/hypnotize_a3f9c2d1.db"
+    """
+    name = f"{safe_label(label)}_{path_hash(root)}.db"
+    return os.path.join(central_libraries_dir(), name).replace("\\", "/")
+
+
+def in_tree_db_path_for(root):
+    """Compute the in-tree DB path for a given root.
+
+    Example:
+        in_tree_db_path_for("/foo/Hypnotize 03")
+        -> "/foo/Hypnotize 03/.acidcat/index.db"
+    """
+    return os.path.join(
+        normalize(root), ACIDCAT_DIR_NAME, INDEX_DB_NAME
+    ).replace("\\", "/")
+
+
+def find_library_root_above(path):
+    """Walk upward from `path` looking for a directory containing
+    `.acidcat/index.db`. Returns the directory or None.
+
+    Useful for detecting in-tree libraries when a caller has only a
+    sample path. The registry is the source of truth; this is a fallback
+    for the in-tree case.
+
+    Skips `~` itself: a `.acidcat/index.db` at the user's home directory
+    is the legacy v0.4 global DB, not an in-tree library root.
+    """
+    home = normalize(os.path.expanduser("~"))
+    current = normalize(path)
+    if os.path.isfile(current):
+        current = os.path.dirname(current)
+    while current and current != os.path.dirname(current):
+        if current == home:
+            return None
+        candidate = os.path.join(current, ACIDCAT_DIR_NAME, INDEX_DB_NAME)
+        if os.path.isfile(candidate):
+            return current
+        current = os.path.dirname(current)
+    return None

--- a/src/acidcat/core/registry.py
+++ b/src/acidcat/core/registry.py
@@ -1,0 +1,287 @@
+"""Global registry of acidcat libraries.
+
+The registry is a small SQLite at `~/.acidcat/registry.db` (overridable
+via `--registry` or `ACIDCAT_REGISTRY`). It tracks every known library:
+its root path, its db path, a human label, the storage mode (in-tree or
+central), and cached counts so `acidcat index --list` is fast without
+opening every per-lib DB.
+
+Policy decisions baked into this module:
+
+- `label` is mandatory. Auto-derive from `os.path.basename(root)` at the
+  caller; this module enforces NOT NULL.
+- No nested libraries. `register_library` rejects a root that is `==`,
+  parent of, or child of any already-registered root. Avoids dedup
+  ambiguity at query time.
+- The registry never writes to a per-lib DB. It only stores pointers and
+  cached counts. Callers update counts via `update_stats` after each
+  index walk.
+"""
+
+import os
+import sqlite3
+import time
+
+from acidcat.core import paths
+
+
+REGISTRY_SCHEMA_VERSION = 1
+
+
+def open_registry(registry_path=None):
+    """Open (or create) the registry DB. Applies schema if new."""
+    path = paths.resolve_registry_path(registry_path)
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent, exist_ok=True)
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+    except sqlite3.DatabaseError:
+        pass
+
+    _apply_schema(conn)
+    return conn
+
+
+def _apply_schema(conn):
+    cur = conn.cursor()
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS meta (
+            k TEXT PRIMARY KEY,
+            v TEXT
+        )
+    """)
+
+    row = cur.execute("SELECT v FROM meta WHERE k = 'schema_version'").fetchone()
+    if row is None:
+        _create_tables(cur)
+        cur.execute(
+            "INSERT INTO meta (k, v) VALUES ('schema_version', ?)",
+            (str(REGISTRY_SCHEMA_VERSION),),
+        )
+        conn.commit()
+        return
+    # future: handle migrations when REGISTRY_SCHEMA_VERSION bumps
+
+
+def _create_tables(cur):
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS libraries (
+            db_path           TEXT PRIMARY KEY,
+            root_path         TEXT UNIQUE NOT NULL,
+            label             TEXT NOT NULL,
+            in_tree           INTEGER NOT NULL DEFAULT 0,
+            sample_count      INTEGER,
+            feature_count     INTEGER,
+            last_indexed_at   REAL,
+            last_seen_at      REAL,
+            schema_version    INTEGER,
+            created_at        REAL NOT NULL
+        )
+    """)
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_libraries_root ON libraries(root_path)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_libraries_label ON libraries(label)")
+
+
+class OverlapError(ValueError):
+    """Raised when a register call would overlap an existing registered root.
+
+    Carries the conflicting library row so the caller can surface a useful
+    message ("path already covered by library X").
+    """
+
+    def __init__(self, message, conflict_row):
+        super().__init__(message)
+        self.conflict = conflict_row
+
+
+def _assert_no_overlap(conn, root):
+    """Reject roots that overlap any registered library.
+
+    Three failure modes (all rejected):
+        a) root is already registered
+        b) some registered library is a parent of root
+        c) some registered library is a child of root
+
+    Re-registering the exact same root is not an overlap; callers that
+    want idempotent re-register pass through register_library which
+    handles that path via UPSERT.
+    """
+    norm = paths.normalize(root)
+    rows = conn.execute(
+        "SELECT db_path, root_path, label FROM libraries"
+    ).fetchall()
+    for r in rows:
+        other = r["root_path"]
+        if other == norm:
+            # exact match: not an overlap (re-register is allowed)
+            continue
+        if norm.startswith(other + "/"):
+            raise OverlapError(
+                f"path is already covered by library '{r['label']}' at {other}; "
+                f"forget that library first if you want to split",
+                conflict_row=r,
+            )
+        if other.startswith(norm + "/"):
+            raise OverlapError(
+                f"library '{r['label']}' at {other} sits inside this path; "
+                f"forget it first if you want to register a parent",
+                conflict_row=r,
+            )
+
+
+def register_library(conn, root, label, db_path, in_tree=False,
+                     schema_version=None):
+    """Register (or refresh) a library.
+
+    Idempotent on re-register: same `root` upserts metadata, preserves
+    `created_at`. Overlapping (but non-equal) roots raise OverlapError.
+    Returns the canonical db_path stored in the registry.
+    """
+    if not label:
+        raise ValueError("label is required")
+    norm_root = paths.normalize(root)
+    norm_db = paths.normalize(db_path)
+    now = time.time()
+
+    _assert_no_overlap(conn, norm_root)
+
+    existing = conn.execute(
+        "SELECT created_at FROM libraries WHERE root_path = ?", (norm_root,)
+    ).fetchone()
+    created_at = existing["created_at"] if existing else now
+
+    conn.execute(
+        """
+        INSERT INTO libraries (
+            db_path, root_path, label, in_tree,
+            schema_version, created_at, last_seen_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(db_path) DO UPDATE SET
+            root_path     = excluded.root_path,
+            label         = excluded.label,
+            in_tree       = excluded.in_tree,
+            schema_version= COALESCE(excluded.schema_version, libraries.schema_version),
+            last_seen_at  = excluded.last_seen_at
+        """,
+        (norm_db, norm_root, label, 1 if in_tree else 0,
+         schema_version, created_at, now),
+    )
+    conn.commit()
+    return norm_db
+
+
+def update_stats(conn, root, sample_count=None, feature_count=None,
+                 last_indexed_at=None, schema_version=None):
+    """Refresh cached counts and timestamps for a library by root path.
+
+    All numeric args are optional; only provided fields are updated.
+    Always bumps last_seen_at to now.
+    """
+    norm = paths.normalize(root)
+    fields = ["last_seen_at = ?"]
+    values = [time.time()]
+    if sample_count is not None:
+        fields.append("sample_count = ?")
+        values.append(sample_count)
+    if feature_count is not None:
+        fields.append("feature_count = ?")
+        values.append(feature_count)
+    if last_indexed_at is not None:
+        fields.append("last_indexed_at = ?")
+        values.append(last_indexed_at)
+    if schema_version is not None:
+        fields.append("schema_version = ?")
+        values.append(schema_version)
+    values.append(norm)
+    conn.execute(
+        f"UPDATE libraries SET {', '.join(fields)} WHERE root_path = ?",
+        values,
+    )
+    conn.commit()
+
+
+def forget_library(conn, label_or_root):
+    """Remove a library from the registry. Does NOT touch the per-lib DB.
+
+    Accepts either a label or a root path. Returns the number of rows
+    removed (0 if the library was not registered).
+    """
+    norm = paths.normalize(label_or_root) if os.path.exists(label_or_root) else None
+    cur = conn.cursor()
+    if norm:
+        cur.execute(
+            "DELETE FROM libraries WHERE root_path = ? OR db_path = ?",
+            (norm, norm),
+        )
+        if cur.rowcount > 0:
+            conn.commit()
+            return cur.rowcount
+    cur.execute("DELETE FROM libraries WHERE label = ?", (label_or_root,))
+    conn.commit()
+    return cur.rowcount
+
+
+def get_library(conn, label_or_root):
+    """Look up a single library by label or by absolute root path. None on miss."""
+    if os.path.exists(label_or_root):
+        norm = paths.normalize(label_or_root)
+        row = conn.execute(
+            "SELECT * FROM libraries WHERE root_path = ? OR db_path = ?",
+            (norm, norm),
+        ).fetchone()
+        if row:
+            return row
+    return conn.execute(
+        "SELECT * FROM libraries WHERE label = ?", (label_or_root,)
+    ).fetchone()
+
+
+def list_libraries(conn, only_existing=False):
+    """All registered libraries, sorted by last_seen_at desc.
+
+    If `only_existing` is True, filters out libraries whose db_path is
+    no longer present on disk (drive unmounted, file deleted by hand).
+    Used by fan-out paths to silently skip orphans.
+    """
+    rows = conn.execute(
+        "SELECT * FROM libraries ORDER BY last_seen_at DESC, label"
+    ).fetchall()
+    if not only_existing:
+        return list(rows)
+    return [r for r in rows if os.path.isfile(r["db_path"])]
+
+
+def find_orphans(conn):
+    """Inverse of list_libraries(only_existing=True): rows whose DB is gone."""
+    return [
+        r for r in list_libraries(conn)
+        if not os.path.isfile(r["db_path"])
+    ]
+
+
+def find_library_for_path(conn, sample_path):
+    """Return the registered library that contains `sample_path`, or None.
+
+    Picks the longest matching root so a sample inside a nested layout
+    resolves to the most-specific library. (We forbid nested registration,
+    but a stale registry or a reorg could still produce overlapping rows
+    until the user runs --forget.)
+    """
+    p = paths.normalize(sample_path)
+    if os.path.isfile(p):
+        p = os.path.dirname(p)
+    rows = list_libraries(conn)
+    rows = sorted(rows, key=lambda r: -len(r["root_path"] or ""))
+    for r in rows:
+        root = r["root_path"]
+        if not root:
+            continue
+        if p == root or p.startswith(root + "/"):
+            return r
+    return None

--- a/src/acidcat/mcp_server.py
+++ b/src/acidcat/mcp_server.py
@@ -1,9 +1,15 @@
 """
-acidcat-mcp -- stdio MCP server over the global SQLite sample index.
+acidcat-mcp -- stdio MCP server over the per-library sample index layout.
 
-Register all tools up front even when optional deps (librosa) are missing;
-the slow ones return a structured error describing the install step. This
-way the LLM discovers what's possible and can surface the fix to the user.
+Default behavior fans out across every library registered in
+`~/.acidcat/registry.db` so the LLM sees one logical sample pool made up
+of many per-library DBs. Pass `--registry PATH` (or set
+ACIDCAT_REGISTRY) to use a different registry, e.g. for project
+isolation.
+
+Tools register up front even when optional deps are missing; the SLOW
+ones return a structured error describing the install step. Stdout is
+strictly the JSON-RPC channel; the server logs warnings to stderr.
 """
 
 import argparse
@@ -15,18 +21,155 @@ import sys
 import time
 
 from acidcat import __version__
-from acidcat.core import index as idx
 from acidcat.core import camelot
+from acidcat.core import index as idx
+from acidcat.core import paths as acidpaths
+from acidcat.core import registry as reg
 
 
 # ── server config ─────────────────────────────────────────────────
 
-_DB_PATH = None
+
+_REGISTRY_PATH = None  # None means: use default resolution rules
 
 
-def _get_conn():
-    """Open a fresh connection per tool call -- cheap for SQLite."""
-    return idx.open_db(_DB_PATH)
+# ── library access helpers ────────────────────────────────────────
+
+
+def _open_all_libraries():
+    """Return [(lib_row, conn), ...] for every existing registered library.
+
+    Sorted deepest-root-first so dedup-by-path consistently picks the
+    most-specific library when paths overlap (which we forbid at register
+    time, but a stale registry could still produce briefly).
+    """
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        libs = reg.list_libraries(rconn, only_existing=True)
+    finally:
+        rconn.close()
+    libs = sorted(libs, key=lambda r: -len(r["root_path"] or ""))
+    pairs = []
+    for lib in libs:
+        try:
+            pairs.append((lib, idx.open_db(lib["db_path"])))
+        except Exception:
+            # corrupt/locked DB: skip silently, the orphan check already
+            # filtered missing files
+            continue
+    return pairs
+
+
+def _close_all(pairs):
+    for _, c in pairs:
+        try:
+            c.close()
+        except Exception:
+            pass
+
+
+def _scope_libraries(pairs, scope_arg):
+    """Filter (lib, conn) pairs by --root-style scope arg.
+
+    `scope_arg` is None, a single label/path, or a comma-separated list.
+    Matches by exact label or by root-path prefix overlap.
+    """
+    if not scope_arg:
+        return pairs
+    scopes = [s.strip() for s in str(scope_arg).split(",") if s.strip()]
+    if not scopes:
+        return pairs
+    keep = []
+    for lib, conn in pairs:
+        for s in scopes:
+            if lib["label"] == s:
+                keep.append((lib, conn))
+                break
+            if os.path.exists(s):
+                norm = acidpaths.normalize(s)
+                root = lib["root_path"]
+                if root == norm or root.startswith(norm + "/") \
+                        or norm.startswith(root + "/"):
+                    keep.append((lib, conn))
+                    break
+    # close the libraries we are filtering out
+    keep_ids = {id(c) for _, c in keep}
+    for _, c in pairs:
+        if id(c) not in keep_ids:
+            try:
+                c.close()
+            except Exception:
+                pass
+    return keep
+
+
+def _open_owning_library(path):
+    """Return (lib_row, conn) for the library that contains `path`.
+
+    Walks the registry to find the registered root that contains `path`.
+    Falls back to scanning every library's samples table if the
+    canonical mapping misses (e.g. symlinks, normalization edge cases).
+    Returns (None, None) if the path is not indexed anywhere. The caller
+    must close the returned conn.
+    """
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        lib = reg.find_library_for_path(rconn, path)
+        all_libs = reg.list_libraries(rconn, only_existing=True)
+    finally:
+        rconn.close()
+
+    if lib is not None and os.path.isfile(lib["db_path"]):
+        try:
+            return lib, idx.open_db(lib["db_path"])
+        except Exception:
+            pass
+
+    # fallback: scan every library for this path (rare; covers symlinks
+    # and odd normalization mismatches)
+    norm = acidpaths.normalize(path)
+    for cand in all_libs:
+        try:
+            conn = idx.open_db(cand["db_path"])
+        except Exception:
+            continue
+        hit = conn.execute(
+            "SELECT 1 FROM samples WHERE path = ? LIMIT 1", (norm,)
+        ).fetchone()
+        if hit is None and norm != path:
+            hit = conn.execute(
+                "SELECT 1 FROM samples WHERE path = ? LIMIT 1", (path,)
+            ).fetchone()
+        if hit is not None:
+            return cand, conn
+        conn.close()
+    return None, None
+
+
+def _dedup_by_path(rows):
+    """Keep the first row per `path`. Used after fan-out merge."""
+    seen = set()
+    out = []
+    for r in rows:
+        p = r.get("path")
+        if p in seen:
+            continue
+        seen.add(p)
+        out.append(r)
+    return out
+
+
+def _resolve_stored_path(conn, user_path):
+    """Within a single library DB, resolve a user-supplied path to its
+    canonical stored form. Returns None if not present."""
+    norm = acidpaths.normalize(user_path)
+    for candidate in (norm, user_path):
+        row = conn.execute(
+            "SELECT path FROM samples WHERE path = ?", (candidate,)
+        ).fetchone()
+        if row is not None:
+            return row["path"]
+    return None
 
 
 # ── tool registry ─────────────────────────────────────────────────
@@ -49,9 +192,6 @@ def _tool(name, description, input_schema, handler, annotations):
     })
 
 
-# ── helpers ───────────────────────────────────────────────────────
-
-
 def _require_path(args, field="path"):
     v = args.get(field)
     if not v:
@@ -59,28 +199,11 @@ def _require_path(args, field="path"):
     return v
 
 
-def _resolve_stored_path(conn, user_path):
-    """Find the canonical stored path for a user-provided path.
-
-    Tries the normalized form first, then the raw form. Returns the stored
-    path, or None if the sample is not indexed.
-    """
-    norm = idx.normalize_path(user_path)
-    for candidate in (norm, user_path):
-        row = conn.execute(
-            "SELECT path FROM samples WHERE path = ?", (candidate,)
-        ).fetchone()
-        if row is not None:
-            return row["path"]
-    return None
-
-
 def _librosa_available():
     """Cheap check: does Python see librosa + numpy on the import path?
 
-    Uses find_spec so this never actually imports librosa (which would
-    cold-start the numba JIT chain and add tens of seconds to the first
-    call of any tool that probes availability).
+    Uses find_spec so this never imports librosa (which would cold-start
+    numba and add tens of seconds to the first call probing availability).
     """
     return (importlib.util.find_spec("librosa") is not None
             and importlib.util.find_spec("numpy") is not None)
@@ -97,65 +220,72 @@ def _analysis_unavailable():
 
 
 def search_samples(args):
-    conn = _get_conn()
+    where = []
+    params = []
+    joins = []
+
+    if args.get("bpm_min") is not None:
+        where.append("s.bpm >= ?")
+        params.append(float(args["bpm_min"]))
+    if args.get("bpm_max") is not None:
+        where.append("s.bpm <= ?")
+        params.append(float(args["bpm_max"]))
+    if args.get("duration_min") is not None:
+        where.append("s.duration >= ?")
+        params.append(float(args["duration_min"]))
+    if args.get("duration_max") is not None:
+        where.append("s.duration <= ?")
+        params.append(float(args["duration_max"]))
+    if args.get("key"):
+        where.append("LOWER(s.key) = LOWER(?)")
+        params.append(args["key"])
+    if args.get("format"):
+        where.append("LOWER(s.format) = LOWER(?)")
+        params.append(args["format"])
+
+    tags = args.get("tags") or []
+    if tags:
+        placeholders = ",".join("?" for _ in tags)
+        where.append(
+            f"s.path IN (SELECT path FROM tags WHERE tag IN ({placeholders}) "
+            f"GROUP BY path HAVING COUNT(DISTINCT tag) = ?)"
+        )
+        params.extend(tags)
+        params.append(len(tags))
+
+    if args.get("text"):
+        joins.append("JOIN samples_fts fts ON fts.path = s.path")
+        where.append("samples_fts MATCH ?")
+        params.append(args["text"])
+
+    limit = int(args.get("limit") or 50)
+    sql = "SELECT s.* FROM samples s " + " ".join(joins)
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY s.path LIMIT ?"
+
+    pairs = _scope_libraries(_open_all_libraries(), args.get("root"))
     try:
-        where, params, joins = [], [], []
-
-        if args.get("bpm_min") is not None:
-            where.append("s.bpm >= ?")
-            params.append(float(args["bpm_min"]))
-        if args.get("bpm_max") is not None:
-            where.append("s.bpm <= ?")
-            params.append(float(args["bpm_max"]))
-        if args.get("duration_min") is not None:
-            where.append("s.duration >= ?")
-            params.append(float(args["duration_min"]))
-        if args.get("duration_max") is not None:
-            where.append("s.duration <= ?")
-            params.append(float(args["duration_max"]))
-        if args.get("key"):
-            where.append("LOWER(s.key) = LOWER(?)")
-            params.append(args["key"])
-        if args.get("format"):
-            where.append("LOWER(s.format) = LOWER(?)")
-            params.append(args["format"])
-        if args.get("root"):
-            root = idx.normalize_path(args["root"])
-            where.append("(s.scan_root = ? OR s.path LIKE ?)")
-            params.append(root)
-            params.append(root.rstrip("/") + "/%")
-
-        tags = args.get("tags") or []
-        if tags:
-            placeholders = ",".join("?" for _ in tags)
-            where.append(
-                f"s.path IN (SELECT path FROM tags WHERE tag IN ({placeholders}) "
-                f"GROUP BY path HAVING COUNT(DISTINCT tag) = ?)"
-            )
-            params.extend(tags)
-            params.append(len(tags))
-
-        if args.get("text"):
-            joins.append("JOIN samples_fts fts ON fts.path = s.path")
-            where.append("samples_fts MATCH ?")
-            params.append(args["text"])
-
-        limit = int(args.get("limit") or 50)
-        sql = "SELECT s.* FROM samples s " + " ".join(joins)
-        if where:
-            sql += " WHERE " + " AND ".join(where)
-        sql += " ORDER BY s.path LIMIT ?"
-        params.append(limit)
-
-        rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
-        return {"count": len(rows), "samples": rows}
+        merged = []
+        for lib, conn in pairs:
+            for r in conn.execute(sql, params + [limit]).fetchall():
+                d = dict(r)
+                d["library_label"] = lib["label"]
+                merged.append(d)
     finally:
-        conn.close()
+        _close_all(pairs)
+
+    merged = _dedup_by_path(merged)
+    merged.sort(key=lambda r: r.get("path") or "")
+    merged = merged[:limit]
+    return {"count": len(merged), "samples": merged}
 
 
 def get_sample(args):
     path = _require_path(args)
-    conn = _get_conn()
+    lib, conn = _open_owning_library(path)
+    if conn is None:
+        raise ToolError(f"sample not indexed: {path}")
     try:
         resolved = _resolve_stored_path(conn, path)
         if resolved is None:
@@ -178,6 +308,9 @@ def get_sample(args):
                 "SELECT 1 FROM features WHERE path = ?", (resolved,)
             ).fetchone()
         )
+        if lib is not None:
+            out["library_label"] = lib["label"]
+            out["library_root"] = lib["root_path"]
         return out
     finally:
         conn.close()
@@ -188,80 +321,175 @@ def locate_sample(args):
     if not name:
         raise ToolError("name is required")
     limit = int(args.get("limit") or 10)
-    conn = _get_conn()
+    # substring match anywhere in the path. The previous "%/<name>%" pattern
+    # required `name` to start at a path-component boundary, which silently
+    # failed for searches that landed mid-filename (e.g. "Kick_Wet" inside
+    # "PL_Hypnotize_03_126_Kick_Wet.wav").
+    like = "%" + name + "%"
+
+    pairs = _open_all_libraries()
+    merged = []
     try:
-        like = "%/" + name + "%"
-        rows = conn.execute(
-            "SELECT path, scan_root, format, bpm, key, duration "
-            "FROM samples WHERE path LIKE ? ORDER BY path LIMIT ?",
-            (like, limit),
-        ).fetchall()
-        return {"count": len(rows), "samples": [dict(r) for r in rows]}
+        for lib, conn in pairs:
+            rows = conn.execute(
+                "SELECT path, scan_root, format, bpm, key, duration "
+                "FROM samples WHERE path LIKE ? ORDER BY path LIMIT ?",
+                (like, limit),
+            ).fetchall()
+            for r in rows:
+                d = dict(r)
+                d["library_label"] = lib["label"]
+                merged.append(d)
     finally:
-        conn.close()
+        _close_all(pairs)
+
+    merged = _dedup_by_path(merged)
+    merged.sort(key=lambda r: r.get("path") or "")
+    merged = merged[:limit]
+    return {"count": len(merged), "samples": merged}
 
 
-def list_roots(_args):
-    conn = _get_conn()
+def list_libraries(_args):
+    """Roll up the registry into a single response."""
+    rconn = reg.open_registry(_REGISTRY_PATH)
     try:
-        return {"roots": idx.list_roots(conn)}
+        rows = reg.list_libraries(rconn)
     finally:
-        conn.close()
+        rconn.close()
+    out = []
+    for r in rows:
+        d = dict(r)
+        d["available"] = bool(os.path.isfile(d["db_path"]))
+        out.append(d)
+    available = sum(1 for r in out if r["available"])
+    return {
+        "count": len(out),
+        "available": available,
+        "unavailable": len(out) - available,
+        "libraries": out,
+    }
 
 
 def list_tags(args):
-    conn = _get_conn()
+    prefix = args.get("prefix") or ""
+    pairs = _open_all_libraries()
+    counts = {}
     try:
-        prefix = args.get("prefix") or ""
         if prefix:
-            rows = conn.execute(
-                "SELECT tag, COUNT(*) AS count FROM tags "
-                "WHERE tag LIKE ? GROUP BY tag ORDER BY count DESC, tag",
-                (prefix + "%",),
-            ).fetchall()
+            sql = ("SELECT tag, COUNT(*) AS c FROM tags WHERE tag LIKE ? "
+                   "GROUP BY tag")
+            params = (prefix + "%",)
         else:
-            rows = conn.execute(
-                "SELECT tag, COUNT(*) AS count FROM tags "
-                "GROUP BY tag ORDER BY count DESC, tag"
-            ).fetchall()
-        return {"tags": [dict(r) for r in rows]}
+            sql = "SELECT tag, COUNT(*) AS c FROM tags GROUP BY tag"
+            params = ()
+        for _, conn in pairs:
+            for r in conn.execute(sql, params).fetchall():
+                counts[r["tag"]] = counts.get(r["tag"], 0) + r["c"]
     finally:
-        conn.close()
+        _close_all(pairs)
+    tags_out = sorted(
+        ({"tag": t, "count": c} for t, c in counts.items()),
+        key=lambda d: (-d["count"], d["tag"]),
+    )
+    return {"tags": tags_out}
 
 
 def list_keys(_args):
-    conn = _get_conn()
+    pairs = _open_all_libraries()
+    counts = {}
     try:
-        rows = conn.execute(
-            "SELECT key, COUNT(*) AS count FROM samples "
-            "WHERE key IS NOT NULL GROUP BY key ORDER BY count DESC, key"
-        ).fetchall()
-        return {"keys": [dict(r) for r in rows]}
+        for _, conn in pairs:
+            for r in conn.execute(
+                "SELECT key, COUNT(*) AS c FROM samples "
+                "WHERE key IS NOT NULL GROUP BY key"
+            ).fetchall():
+                counts[r["key"]] = counts.get(r["key"], 0) + r["c"]
     finally:
-        conn.close()
+        _close_all(pairs)
+    out = sorted(
+        ({"key": k, "count": c} for k, c in counts.items()),
+        key=lambda d: (-d["count"], d["key"]),
+    )
+    return {"keys": out}
 
 
 def list_formats(_args):
-    conn = _get_conn()
+    pairs = _open_all_libraries()
+    counts = {}
     try:
-        rows = conn.execute(
-            "SELECT format, COUNT(*) AS count FROM samples "
-            "WHERE format IS NOT NULL GROUP BY format ORDER BY count DESC"
-        ).fetchall()
-        return {"formats": [dict(r) for r in rows]}
+        for _, conn in pairs:
+            for r in conn.execute(
+                "SELECT format, COUNT(*) AS c FROM samples "
+                "WHERE format IS NOT NULL GROUP BY format"
+            ).fetchall():
+                counts[r["format"]] = counts.get(r["format"], 0) + r["c"]
     finally:
-        conn.close()
+        _close_all(pairs)
+    out = sorted(
+        ({"format": f, "count": c} for f, c in counts.items()),
+        key=lambda d: (-d["count"], d["format"]),
+    )
+    return {"formats": out}
 
 
 def index_stats(_args):
-    conn = _get_conn()
+    """Roll up stats across every library."""
+    rconn = reg.open_registry(_REGISTRY_PATH)
     try:
-        stats = idx.index_stats(conn)
-        stats["analysis_available"] = _librosa_available()
-        stats["db_path"] = _DB_PATH
-        return stats
+        all_rows = reg.list_libraries(rconn)
     finally:
-        conn.close()
+        rconn.close()
+
+    available = [r for r in all_rows if os.path.isfile(r["db_path"])]
+    unavailable = [r for r in all_rows if not os.path.isfile(r["db_path"])]
+
+    total_samples = 0
+    with_features = 0
+    with_descriptions = 0
+    by_format = {}
+    last_indexed_at = None
+
+    for lib in available:
+        try:
+            conn = idx.open_db(lib["db_path"])
+        except Exception:
+            continue
+        try:
+            total_samples += conn.execute(
+                "SELECT COUNT(*) AS c FROM samples"
+            ).fetchone()["c"]
+            with_features += conn.execute(
+                "SELECT COUNT(*) AS c FROM features"
+            ).fetchone()["c"]
+            with_descriptions += conn.execute(
+                "SELECT COUNT(*) AS c FROM descriptions"
+            ).fetchone()["c"]
+            for row in conn.execute(
+                "SELECT format, COUNT(*) AS c FROM samples "
+                "WHERE format IS NOT NULL GROUP BY format"
+            ).fetchall():
+                by_format[row["format"]] = by_format.get(row["format"], 0) \
+                    + row["c"]
+            li = lib["last_indexed_at"]
+            if li is not None and (last_indexed_at is None or li > last_indexed_at):
+                last_indexed_at = li
+        finally:
+            conn.close()
+
+    return {
+        "total_samples": total_samples,
+        "with_features": with_features,
+        "with_descriptions": with_descriptions,
+        "by_format": sorted(
+            ({"format": f, "count": c} for f, c in by_format.items()),
+            key=lambda d: -d["count"],
+        ),
+        "available_libraries": len(available),
+        "unavailable_libraries": len(unavailable),
+        "last_indexed_at": last_indexed_at,
+        "analysis_available": _librosa_available(),
+        "registry_path": acidpaths.resolve_registry_path(_REGISTRY_PATH),
+    }
 
 
 def infer_kind(duration, acid_beats):
@@ -288,94 +516,113 @@ def find_compatible(args):
     kind_arg = (args.get("kind") or "").lower() or None
     min_duration = args.get("min_duration")
 
-    conn = _get_conn()
+    # find target's metadata in its owning library
+    lib, conn = _open_owning_library(path)
+    if conn is None:
+        raise ToolError(f"sample not indexed: {path}")
     try:
         resolved = _resolve_stored_path(conn, path)
-        if resolved is None:
-            raise ToolError(f"sample not indexed: {path}")
         target = conn.execute(
             "SELECT * FROM samples WHERE path = ?", (resolved,)
         ).fetchone()
-
-        target_bpm = target["bpm"]
-        target_key = target["key"]
-        target_kind = infer_kind(target["duration"], target["acid_beats"])
-
-        # default kind: match the target's own classification (so loops return
-        # loops, one-shots return one-shots). 'any' skips kind filtering.
-        effective_kind = kind_arg or target_kind
-        if effective_kind not in ("loop", "one_shot", "any"):
-            raise ToolError(
-                f"kind must be loop, one_shot, or any (got {effective_kind!r})"
-            )
-
-        compat_keys = camelot.compatible_keys(target_key) if target_key else set()
-        if not include_relative and target_key:
-            base = camelot.key_to_camelot(target_key)
-            if base:
-                keep = {c for c in camelot.camelot_neighbors(base)
-                        if not c.endswith(("A",) if base.endswith("B") else ("B",))}
-                compat_keys = {
-                    k for k in compat_keys
-                    if camelot.key_to_camelot(k) in keep
-                }
-
-        # expand each compatible key to all enharmonic spellings so a DB row
-        # stored as "Cb" still matches when target implies "B", etc.
-        sql_keys = set()
-        for k in compat_keys:
-            sql_keys.update(camelot.enharmonic_spellings(k))
-
-        where = ["s.path != ?"]
-        params = [resolved]
-
-        if target_bpm is not None:
-            lo = target_bpm * (1 - tol)
-            hi = target_bpm * (1 + tol)
-            where.append("s.bpm BETWEEN ? AND ?")
-            params.extend([lo, hi])
-
-        if sql_keys:
-            placeholders = ",".join("?" for _ in sql_keys)
-            where.append(f"LOWER(s.key) IN ({placeholders})")
-            params.extend(k.lower() for k in sql_keys)
-
-        if effective_kind == "loop":
-            where.append("(s.acid_beats > 0 OR s.duration >= 2.0)")
-        elif effective_kind == "one_shot":
-            where.append(
-                "((s.acid_beats IS NULL OR s.acid_beats = 0) AND "
-                "(s.duration IS NULL OR s.duration < 1.0))"
-            )
-
-        if min_duration is not None:
-            where.append("s.duration >= ?")
-            params.append(float(min_duration))
-
-        sql = (
-            "SELECT s.* FROM samples s WHERE "
-            + " AND ".join(where)
-            + " ORDER BY s.bpm IS NULL, ABS(s.bpm - ?) LIMIT ?"
-        )
-        params.append(target_bpm or 0)
-        params.append(limit)
-
-        rows = [dict(r) for r in conn.execute(sql, params).fetchall()]
-        return {
-            "target": {
-                "path": resolved,
-                "bpm": target_bpm,
-                "key": target_key,
-                "camelot": camelot.key_to_camelot(target_key) if target_key else None,
-                "kind": target_kind,
-            },
-            "compatible_keys": sorted(compat_keys),
-            "filter_kind": effective_kind,
-            "count": len(rows),
-            "samples": rows,
-        }
     finally:
         conn.close()
+
+    target_bpm = target["bpm"]
+    target_key = target["key"]
+    target_kind = infer_kind(target["duration"], target["acid_beats"])
+
+    effective_kind = kind_arg or target_kind
+    if effective_kind not in ("loop", "one_shot", "any"):
+        raise ToolError(
+            f"kind must be loop, one_shot, or any (got {effective_kind!r})"
+        )
+
+    compat_keys = camelot.compatible_keys(target_key) if target_key else set()
+    if not include_relative and target_key:
+        base = camelot.key_to_camelot(target_key)
+        if base:
+            keep = {c for c in camelot.camelot_neighbors(base)
+                    if not c.endswith(("A",) if base.endswith("B") else ("B",))}
+            compat_keys = {
+                k for k in compat_keys
+                if camelot.key_to_camelot(k) in keep
+            }
+
+    sql_keys = set()
+    for k in compat_keys:
+        sql_keys.update(camelot.enharmonic_spellings(k))
+
+    where = ["s.path != ?"]
+    params = [resolved]
+
+    if target_bpm is not None:
+        lo = target_bpm * (1 - tol)
+        hi = target_bpm * (1 + tol)
+        where.append("s.bpm BETWEEN ? AND ?")
+        params.extend([lo, hi])
+
+    if sql_keys:
+        placeholders = ",".join("?" for _ in sql_keys)
+        where.append(f"LOWER(s.key) IN ({placeholders})")
+        params.extend(k.lower() for k in sql_keys)
+
+    if effective_kind == "loop":
+        where.append("(s.acid_beats > 0 OR s.duration >= 2.0)")
+    elif effective_kind == "one_shot":
+        where.append(
+            "((s.acid_beats IS NULL OR s.acid_beats = 0) AND "
+            "(s.duration IS NULL OR s.duration < 1.0))"
+        )
+
+    if min_duration is not None:
+        where.append("s.duration >= ?")
+        params.append(float(min_duration))
+
+    sql = (
+        "SELECT s.* FROM samples s WHERE "
+        + " AND ".join(where)
+        + " ORDER BY s.bpm IS NULL, ABS(s.bpm - ?) LIMIT ?"
+    )
+
+    # fan out across every library, applying the same WHERE
+    pairs = _open_all_libraries()
+    merged = []
+    try:
+        for cand_lib, cand_conn in pairs:
+            rows = cand_conn.execute(
+                sql, params + [target_bpm or 0, limit]
+            ).fetchall()
+            for r in rows:
+                d = dict(r)
+                d["library_label"] = cand_lib["label"]
+                merged.append(d)
+    finally:
+        _close_all(pairs)
+
+    merged = _dedup_by_path(merged)
+    merged.sort(
+        key=lambda r: (
+            0 if r.get("bpm") is not None else 1,
+            abs((r.get("bpm") or 0) - (target_bpm or 0)),
+            r.get("path") or "",
+        )
+    )
+    merged = merged[:limit]
+    return {
+        "target": {
+            "path": resolved,
+            "bpm": target_bpm,
+            "key": target_key,
+            "camelot": camelot.key_to_camelot(target_key) if target_key else None,
+            "kind": target_kind,
+            "library_label": lib["label"] if lib else None,
+        },
+        "compatible_keys": sorted(compat_keys),
+        "filter_kind": effective_kind,
+        "count": len(merged),
+        "samples": merged,
+    }
 
 
 # ── analysis tools (slow) ─────────────────────────────────────────
@@ -385,60 +632,72 @@ def find_similar(args):
     path = _require_path(args)
     n = int(args.get("n") or 5)
 
-    conn = _get_conn()
+    # try each library for the target's stored features first
+    target_feats = None
+    pairs = _open_all_libraries()
     try:
-        norm = idx.normalize_path(path)
-        target_feats = idx.get_features(conn, norm) or idx.get_features(conn, path)
-
-        if target_feats is None:
-            if not _librosa_available():
-                return _analysis_unavailable()
-            from acidcat.core.features import extract_audio_features
-            target_feats = extract_audio_features(path)
-            if target_feats is None:
-                raise ToolError(f"could not extract features from {path}")
-
-        feature_keys = sorted(
-            k for k, v in target_feats.items()
-            if isinstance(v, (int, float)) and not isinstance(v, bool)
-        )
-        if not feature_keys:
-            raise ToolError("no numeric features available")
-
-        tv = [float(target_feats[k]) for k in feature_keys]
-
-        rows = conn.execute(
-            "SELECT f.path, f.features_json, s.bpm, s.key, s.duration, s.format "
-            "FROM features f JOIN samples s ON s.path = f.path"
-        ).fetchall()
-
-        scored = []
-        for r in rows:
-            try:
-                feats = json.loads(r["features_json"])
-                v = [float(feats.get(k, 0.0) or 0.0) for k in feature_keys]
-            except Exception:
-                continue
-            sim = _cosine(tv, v)
-            scored.append({
-                "path": r["path"],
-                "bpm": r["bpm"],
-                "key": r["key"],
-                "duration": r["duration"],
-                "format": r["format"],
-                "similarity": round(sim, 6),
-            })
-        scored.sort(key=lambda x: x["similarity"], reverse=True)
-        # filter out the target itself
-        target_path = idx.normalize_path(path)
-        scored = [s for s in scored if s["path"] != target_path][:n]
-        return {
-            "target": path,
-            "population": len(rows),
-            "results": scored,
-        }
+        for _, conn in pairs:
+            target_feats = (idx.get_features(conn, acidpaths.normalize(path))
+                            or idx.get_features(conn, path))
+            if target_feats is not None:
+                break
     finally:
-        conn.close()
+        _close_all(pairs)
+
+    if target_feats is None:
+        if not _librosa_available():
+            return _analysis_unavailable()
+        from acidcat.core.features import extract_audio_features
+        target_feats = extract_audio_features(path)
+        if target_feats is None:
+            raise ToolError(f"could not extract features from {path}")
+
+    feature_keys = sorted(
+        k for k, v in target_feats.items()
+        if isinstance(v, (int, float)) and not isinstance(v, bool)
+    )
+    if not feature_keys:
+        raise ToolError("no numeric features available")
+    tv = [float(target_feats[k]) for k in feature_keys]
+
+    target_norm = acidpaths.normalize(path)
+    scored = []
+    pairs = _open_all_libraries()
+    population = 0
+    try:
+        for lib, conn in pairs:
+            rows = conn.execute(
+                "SELECT f.path, f.features_json, s.bpm, s.key, s.duration, s.format "
+                "FROM features f JOIN samples s ON s.path = f.path"
+            ).fetchall()
+            population += len(rows)
+            for r in rows:
+                try:
+                    feats = json.loads(r["features_json"])
+                    v = [float(feats.get(k, 0.0) or 0.0) for k in feature_keys]
+                except Exception:
+                    continue
+                sim = _cosine(tv, v)
+                scored.append({
+                    "path": r["path"],
+                    "bpm": r["bpm"],
+                    "key": r["key"],
+                    "duration": r["duration"],
+                    "format": r["format"],
+                    "library_label": lib["label"],
+                    "similarity": round(sim, 6),
+                })
+    finally:
+        _close_all(pairs)
+
+    scored = [s for s in scored if s["path"] != target_norm]
+    scored.sort(key=lambda x: x["similarity"], reverse=True)
+    scored = _dedup_by_path(scored)[:n]
+    return {
+        "target": path,
+        "population": population,
+        "results": scored,
+    }
 
 
 def _cosine(a, b):
@@ -481,64 +740,136 @@ def detect_bpm_key(args):
 
 
 def reindex(args):
-    path = _require_path(args)
+    """Rebuild a registered library by label or path.
+
+    Walks the library's root and refreshes its DB. Updates the registry.
+    """
+    target = args.get("path") or args.get("label")
+    if not target:
+        raise ToolError("path or label is required")
     with_features = bool(args.get("with_features", False))
-    if not os.path.isdir(path):
-        raise ToolError(f"not a directory: {path}")
+
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        lib = reg.get_library(rconn, target)
+    finally:
+        rconn.close()
+    if lib is None:
+        raise ToolError(
+            f"no registered library matches '{target}'. "
+            f"register it first via register_library."
+        )
 
     from acidcat.commands.index import _walk_and_upsert
 
-    conn = _get_conn()
+    if not os.path.isdir(lib["root_path"]):
+        raise ToolError(
+            f"library root {lib['root_path']} does not exist on disk"
+        )
+
+    conn = idx.open_db(lib["db_path"])
     try:
-        scan_root = idx.normalize_path(path)
         counts = _walk_and_upsert(
-            conn, scan_root,
+            conn, lib["root_path"],
             do_features=with_features,
             do_deep=False,
             quiet=True,
         )
         conn.commit()
-        return {"root": scan_root, "counts": counts}
+        sample_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM samples"
+        ).fetchone()["c"]
+        feature_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM features"
+        ).fetchone()["c"]
     finally:
         conn.close()
 
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        reg.update_stats(
+            rconn, lib["root_path"],
+            sample_count=sample_count,
+            feature_count=feature_count,
+            last_indexed_at=time.time(),
+            schema_version=idx.SCHEMA_VERSION,
+        )
+    finally:
+        rconn.close()
+
+    return {
+        "library_label": lib["label"],
+        "library_root": lib["root_path"],
+        "counts": counts,
+        "sample_count": sample_count,
+        "feature_count": feature_count,
+    }
+
 
 def reindex_features(args):
-    limit = args.get("limit")
+    """Extract librosa features for samples that lack them, across libraries."""
     if not _librosa_available():
         return _analysis_unavailable()
     from acidcat.core.features import extract_audio_features
 
-    conn = _get_conn()
-    try:
-        sql = (
-            "SELECT s.path FROM samples s "
-            "LEFT JOIN features f ON f.path = s.path "
-            "WHERE f.path IS NULL"
-        )
-        if limit:
-            sql += " LIMIT ?"
-            rows = conn.execute(sql, (int(limit),)).fetchall()
-        else:
-            rows = conn.execute(sql).fetchall()
+    limit = args.get("limit")
+    target_label = args.get("library")  # optional: scope to one library
 
-        processed = failed = 0
-        for r in rows:
-            path = r["path"]
-            if not os.path.isfile(path):
-                failed += 1
-                continue
-            feats = extract_audio_features(path)
-            if feats is None:
-                failed += 1
-                continue
-            idx.upsert_features(conn, path, feats, version=1)
-            processed += 1
-        conn.commit()
-        return {"processed": processed, "failed": failed,
-                "remaining_unprocessed": len(rows) - processed - failed}
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        if target_label:
+            lib = reg.get_library(rconn, target_label)
+            if lib is None:
+                raise ToolError(f"no library matches '{target_label}'")
+            libs = [lib] if os.path.isfile(lib["db_path"]) else []
+        else:
+            libs = reg.list_libraries(rconn, only_existing=True)
     finally:
-        conn.close()
+        rconn.close()
+
+    processed = failed = 0
+    remaining = 0
+    for lib in libs:
+        try:
+            conn = idx.open_db(lib["db_path"])
+        except Exception:
+            continue
+        try:
+            sql = (
+                "SELECT s.path FROM samples s "
+                "LEFT JOIN features f ON f.path = s.path "
+                "WHERE f.path IS NULL"
+            )
+            if limit:
+                sql += " LIMIT ?"
+                rows = conn.execute(sql, (int(limit),)).fetchall()
+            else:
+                rows = conn.execute(sql).fetchall()
+            for r in rows:
+                p = r["path"]
+                if not os.path.isfile(p):
+                    failed += 1
+                    continue
+                feats = extract_audio_features(p)
+                if feats is None:
+                    failed += 1
+                    continue
+                idx.upsert_features(conn, p, feats, version=1)
+                processed += 1
+            conn.commit()
+            remaining += conn.execute(
+                "SELECT COUNT(*) AS c FROM samples s "
+                "LEFT JOIN features f ON f.path = s.path "
+                "WHERE f.path IS NULL"
+            ).fetchone()["c"]
+        finally:
+            conn.close()
+
+    return {
+        "processed": processed,
+        "failed": failed,
+        "remaining_unprocessed": remaining,
+    }
 
 
 # ── write tools ───────────────────────────────────────────────────
@@ -551,7 +882,9 @@ def tag_sample(args):
     if not add and not remove:
         raise ToolError("provide add_tags and/or remove_tags")
 
-    conn = _get_conn()
+    lib, conn = _open_owning_library(path)
+    if conn is None:
+        raise ToolError(f"sample not indexed: {path}")
     try:
         resolved = _resolve_stored_path(conn, path)
         if resolved is None:
@@ -566,7 +899,11 @@ def tag_sample(args):
                 "SELECT tag FROM tags WHERE path = ? ORDER BY tag", (resolved,)
             ).fetchall()
         ]
-        return {"path": resolved, "tags": tags}
+        return {
+            "path": resolved,
+            "library_label": lib["label"] if lib else None,
+            "tags": tags,
+        }
     finally:
         conn.close()
 
@@ -574,27 +911,90 @@ def tag_sample(args):
 def describe_sample(args):
     path = _require_path(args)
     description = args.get("description")
-    conn = _get_conn()
+    lib, conn = _open_owning_library(path)
+    if conn is None:
+        raise ToolError(f"sample not indexed: {path}")
     try:
         resolved = _resolve_stored_path(conn, path)
         if resolved is None:
             raise ToolError(f"sample not indexed: {path}")
         idx.upsert_description(conn, resolved, description or "")
         conn.commit()
-        return {"path": resolved, "description": description or ""}
+        return {
+            "path": resolved,
+            "library_label": lib["label"] if lib else None,
+            "description": description or "",
+        }
     finally:
         conn.close()
+
+
+def register_library(args):
+    """Register a new library and create its DB. The user must run reindex
+    afterwards (or call this after `acidcat index DIR --label NAME` from
+    the CLI). This MCP tool is for letting an LLM expose the option."""
+    root = _require_path(args, field="root")
+    label = args.get("label") or os.path.basename(acidpaths.normalize(root)) \
+        or "library"
+    in_tree = bool(args.get("in_tree", False))
+
+    if not os.path.isdir(root):
+        raise ToolError(f"not a directory: {root}")
+
+    db_path = (acidpaths.in_tree_db_path_for(root) if in_tree
+               else acidpaths.central_db_path_for(root, label))
+
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        try:
+            reg.register_library(
+                rconn, root, label=label, db_path=db_path,
+                in_tree=in_tree, schema_version=idx.SCHEMA_VERSION,
+            )
+        except reg.OverlapError as e:
+            raise ToolError(str(e))
+    finally:
+        rconn.close()
+
+    # create the DB so the registry's only_existing filter sees it
+    conn = idx.open_db(db_path)
+    conn.close()
+
+    return {
+        "label": label,
+        "root": acidpaths.normalize(root),
+        "db_path": db_path,
+        "in_tree": in_tree,
+        "next_step": "call reindex with this library's label to populate it",
+    }
+
+
+def forget_library(args):
+    """Drop a library from the registry. Does NOT delete its DB file."""
+    target = args.get("label") or args.get("root")
+    if not target:
+        raise ToolError("label or root is required")
+    rconn = reg.open_registry(_REGISTRY_PATH)
+    try:
+        n = reg.forget_library(rconn, target)
+    finally:
+        rconn.close()
+    if n == 0:
+        raise ToolError(f"no library matches '{target}'")
+    return {"forgot": target, "count": n}
 
 
 # ── tool registration ─────────────────────────────────────────────
 
 
 def _register_all():
-    # fast
+    # fast (read-only)
     _tool(
         "search_samples",
-        "Fast. Filter the sample index by bpm/key/duration/tags/text/format/root. "
-        "Prefer this over analysis tools for any discovery query.",
+        "Fast. Filter samples across all registered libraries by "
+        "bpm/key/duration/tags/text/format. Use 'root' to scope to one or "
+        "more libraries by label or path. Prefer this over analysis tools "
+        "for any discovery query.",
         {
             "type": "object",
             "properties": {
@@ -612,7 +1012,8 @@ def _register_all():
                 "format": {"type": "string",
                            "description": "wav, mp3, flac, midi, serum, ..."},
                 "root": {"type": "string",
-                         "description": "Scope to samples under this scan root."},
+                         "description": "Library label or path. "
+                         "Comma-separated for multiple."},
                 "limit": {"type": "integer", "default": 50},
             },
         },
@@ -621,7 +1022,8 @@ def _register_all():
     )
     _tool(
         "get_sample",
-        "Fast. Full metadata for one sample path, including tags and description.",
+        "Fast. Full metadata for one sample path, including tags, "
+        "description, and which library it belongs to.",
         {
             "type": "object",
             "properties": {"path": {"type": "string"}},
@@ -632,8 +1034,8 @@ def _register_all():
     )
     _tool(
         "locate_sample",
-        "Fast. Find a sample by filename substring across all indexed roots. "
-        "Use this to answer 'where is X?' questions.",
+        "Fast. Find samples by filename substring across every registered "
+        "library. Use this to answer 'where is X?' questions.",
         {
             "type": "object",
             "properties": {
@@ -646,15 +1048,18 @@ def _register_all():
         {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )
     _tool(
-        "list_roots",
-        "Fast. Indexed scan roots with file counts and last-indexed times.",
+        "list_libraries",
+        "Fast. Every library registered with acidcat: label, root path, "
+        "sample/feature counts, in-tree vs central, last indexed at, "
+        "and whether the DB file is currently available on disk.",
         {"type": "object", "properties": {}},
-        list_roots,
+        list_libraries,
         {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )
     _tool(
         "list_tags",
-        "Fast. Distinct tags with counts. Use 'prefix' to narrow.",
+        "Fast. Distinct tags with counts, summed across all libraries. "
+        "Use 'prefix' to narrow.",
         {
             "type": "object",
             "properties": {"prefix": {"type": "string"}},
@@ -664,31 +1069,34 @@ def _register_all():
     )
     _tool(
         "list_keys",
-        "Fast. Distinct musical keys with counts.",
+        "Fast. Distinct musical keys with counts across all libraries.",
         {"type": "object", "properties": {}},
         list_keys,
         {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )
     _tool(
         "list_formats",
-        "Fast. Distinct file formats with counts.",
+        "Fast. Distinct file formats with counts across all libraries.",
         {"type": "object", "properties": {}},
         list_formats,
         {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )
     _tool(
         "index_stats",
-        "Fast. Totals, per-format counts, analysis availability, DB path.",
+        "Fast. Roll-up counts across every library: total samples, "
+        "feature coverage, format breakdown, available vs unavailable "
+        "library count, analysis-tool availability, registry path.",
         {"type": "object", "properties": {}},
         index_stats,
         {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )
     _tool(
         "find_compatible",
-        "Fast. Harmonically and rhythmically compatible samples via Camelot + "
-        "BPM tolerance. By default filters to the target's own kind (loops "
-        "match loops, one-shots match one-shots) so a kalimba loop query "
-        "does not return kalimba one-shots. No audio analysis; metadata-only.",
+        "Fast. Harmonically and rhythmically compatible samples via Camelot "
+        "+ BPM tolerance. Fans out across libraries. By default filters to "
+        "the target's own kind (loops match loops, one-shots match "
+        "one-shots) so a kalimba loop query does not return kalimba "
+        "one-shots. No audio analysis; metadata-only.",
         {
             "type": "object",
             "properties": {
@@ -700,13 +1108,13 @@ def _register_all():
                     "enum": ["loop", "one_shot", "any"],
                     "description":
                         "Filter by sample kind. Default: auto-infer from "
-                        "target (loop vs one-shot based on acid_beats+duration).",
+                        "target.",
                 },
                 "min_duration": {
                     "type": "number",
                     "description":
                         "Optional seconds floor. Overrides/augments kind "
-                        "filter when you want a specific minimum length.",
+                        "filter for length-specific queries.",
                 },
                 "limit": {"type": "integer", "default": 20},
             },
@@ -720,9 +1128,9 @@ def _register_all():
     _tool(
         "find_similar",
         "SLOW if features are not indexed, fast if they are. Requires "
-        "acidcat[analysis]. Nearest neighbors by librosa feature cosine. "
-        "Only use when metadata-based tools (search_samples, find_compatible) "
-        "cannot answer.",
+        "acidcat[analysis]. Nearest neighbors by librosa feature cosine, "
+        "fanned out across all libraries. Only use when metadata-based "
+        "tools (search_samples, find_compatible) cannot answer.",
         {
             "type": "object",
             "properties": {
@@ -736,8 +1144,9 @@ def _register_all():
     )
     _tool(
         "analyze_sample",
-        "SLOW (~1-10s). Requires acidcat[analysis]. On-the-fly librosa feature "
-        "extraction for an unindexed file. Prefer get_sample for indexed files.",
+        "SLOW (~1-10s). Requires acidcat[analysis]. On-the-fly librosa "
+        "feature extraction for an unindexed file. Prefer get_sample for "
+        "indexed files.",
         {
             "type": "object",
             "properties": {
@@ -751,8 +1160,9 @@ def _register_all():
     )
     _tool(
         "detect_bpm_key",
-        "SLOW (~0.5-2s). Requires acidcat[analysis]. BPM + key estimation only. "
-        "Cheaper than analyze_sample. Prefer get_sample when possible.",
+        "SLOW (~0.5-2s). Requires acidcat[analysis]. BPM + key estimation "
+        "only. Cheaper than analyze_sample. Prefer get_sample when the "
+        "file is already indexed.",
         {
             "type": "object",
             "properties": {"path": {"type": "string"}},
@@ -762,18 +1172,21 @@ def _register_all():
         {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
     )
 
-    # reindex (operational, slow)
+    # index management
     _tool(
         "reindex",
-        "SLOW. Only call when the user explicitly asks to refresh the index. "
-        "Walks a directory and upserts samples incrementally.",
+        "SLOW. Re-walk a registered library and refresh its DB. Identify "
+        "the library by label or root path. Only call when the user "
+        "explicitly asks to refresh.",
         {
             "type": "object",
             "properties": {
-                "path": {"type": "string"},
+                "label": {"type": "string",
+                          "description": "Library label (preferred)."},
+                "path": {"type": "string",
+                         "description": "Library root path (alternative)."},
                 "with_features": {"type": "boolean", "default": False},
             },
-            "required": ["path"],
         },
         reindex,
         {"readOnlyHint": False, "destructiveHint": False,
@@ -781,14 +1194,18 @@ def _register_all():
     )
     _tool(
         "reindex_features",
-        "VERY SLOW. Requires acidcat[analysis]. Extracts librosa features for "
-        "any indexed samples that do not have them yet. Only call when the "
-        "user explicitly asks.",
+        "VERY SLOW. Requires acidcat[analysis]. Extracts librosa features "
+        "for any indexed samples that lack them, across libraries (or one "
+        "library if 'library' arg provided). Only call when explicitly "
+        "asked.",
         {
             "type": "object",
             "properties": {
+                "library": {"type": "string",
+                            "description": "Optional: scope to one library "
+                                           "by label or root path."},
                 "limit": {"type": "integer",
-                          "description": "Max files to process this call."},
+                          "description": "Max files per library this call."},
             },
         },
         reindex_features,
@@ -796,11 +1213,52 @@ def _register_all():
          "idempotentHint": True, "openWorldHint": False},
     )
 
-    # write tools
+    # registry mutations
+    _tool(
+        "register_library",
+        "Modify the registry. Register a new library so it becomes part of "
+        "fan-out queries. Creates the DB but does NOT populate it (call "
+        "reindex afterwards). Default storage is central "
+        "(~/.acidcat/libraries/<label>_<hash>.db); pass in_tree=true to "
+        "store the DB inside the library's own directory.",
+        {
+            "type": "object",
+            "properties": {
+                "root": {"type": "string",
+                         "description": "Absolute path to the library root."},
+                "label": {"type": "string",
+                          "description":
+                              "Friendly label (default: basename of root)."},
+                "in_tree": {"type": "boolean", "default": False},
+            },
+            "required": ["root"],
+        },
+        register_library,
+        {"readOnlyHint": False, "destructiveHint": True,
+         "idempotentHint": True, "openWorldHint": False},
+    )
+    _tool(
+        "forget_library",
+        "Modify the registry. Remove a library from the registry. Does "
+        "NOT delete its DB file; rerunning register_library on the same "
+        "root re-attaches it. Confirm with the user before calling.",
+        {
+            "type": "object",
+            "properties": {
+                "label": {"type": "string"},
+                "root": {"type": "string"},
+            },
+        },
+        forget_library,
+        {"readOnlyHint": False, "destructiveHint": True,
+         "idempotentHint": False, "openWorldHint": False},
+    )
+
+    # write tools (sample-level)
     _tool(
         "tag_sample",
-        "Modify the index. Add/remove tags on a sample. Confirm with the user "
-        "before calling.",
+        "Modify the index. Add or remove tags on a sample. Confirm with "
+        "the user before calling.",
         {
             "type": "object",
             "properties": {
@@ -816,8 +1274,8 @@ def _register_all():
     )
     _tool(
         "describe_sample",
-        "Modify the index. Set or clear the free-text description for a sample. "
-        "Confirm with the user before calling.",
+        "Modify the index. Set or clear the free-text description on a "
+        "sample. Confirm with the user before calling.",
         {
             "type": "object",
             "properties": {
@@ -836,7 +1294,8 @@ _register_all()
 
 
 def dispatch(name, arguments):
-    """Call a tool by name with a dict of arguments. Raises ToolError or returns dict."""
+    """Call a tool by name with a dict of arguments. Raises ToolError or
+    returns dict."""
     for t in TOOLS:
         if t["name"] == name:
             return t["handler"](arguments or {})
@@ -896,18 +1355,29 @@ async def _run_stdio():
         await app.run(read, write, app.create_initialization_options())
 
 
+def _warn_legacy_db():
+    legacy = acidpaths.legacy_global_db_path()
+    if os.path.isfile(legacy):
+        print(f"acidcat-mcp: legacy v0.4 DB at {legacy} is ignored. "
+              f"Remove with: rm {legacy}*", file=sys.stderr)
+
+
 def main(argv=None):
-    global _DB_PATH
+    global _REGISTRY_PATH
     parser = argparse.ArgumentParser(
         prog="acidcat-mcp",
-        description="MCP server exposing the acidcat sample index over stdio.",
+        description="MCP server exposing the acidcat per-library index over stdio.",
     )
-    parser.add_argument("--db", help="Override DB path (default: "
-                                     "$ACIDCAT_DB or ~/.acidcat/index.db).")
+    parser.add_argument("--registry",
+                        help="Override registry DB path "
+                             "(default: $ACIDCAT_REGISTRY or "
+                             "~/.acidcat/registry.db).")
     parser.add_argument("--version", action="version",
                         version=f"acidcat-mcp {__version__}")
     args = parser.parse_args(argv)
-    _DB_PATH = idx.resolve_db_path(args.db)
+    _REGISTRY_PATH = args.registry  # None means: use defaults
+
+    _warn_legacy_db()
 
     import asyncio
     asyncio.run(_run_stdio())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,16 @@ import os
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolate_acidcat_env(monkeypatch):
+    """Strip acidcat env vars so a dev shell with ACIDCAT_REGISTRY/ACIDCAT_DB
+    set cannot leak into the test process and corrupt the user's real
+    registry or single-DB index. Applied to every test.
+    """
+    monkeypatch.delenv("ACIDCAT_DB", raising=False)
+    monkeypatch.delenv("ACIDCAT_REGISTRY", raising=False)
+
+
 def _make_riff_wav(sample_rate=44100, channels=1, bits=16, num_samples=4):
     """Build a minimal valid PCM WAV in memory."""
     block_align = channels * bits // 8

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,4 +1,4 @@
-"""Tests for the SQLite index and `acidcat index` command."""
+"""Tests for `acidcat index` (per-library + registry layout)."""
 
 import json
 import os
@@ -9,13 +9,12 @@ import pytest
 
 from acidcat.commands import index as index_cmd
 from acidcat.core import index as idx
+from acidcat.core import paths as acidpaths
+from acidcat.core import registry as reg
 
 
 def _make_riff_wav(sample_rate=44100, channels=1, bits=16, num_samples=4,
                    smpl_root_key=None):
-    """Build a minimal valid PCM WAV. If smpl_root_key is given, add a SMPL
-    chunk with that MIDI note as the unity note (no loops).
-    """
     block_align = channels * bits // 8
     byte_rate = sample_rate * block_align
     audio_data = b"\x00" * (num_samples * block_align)
@@ -24,52 +23,49 @@ def _make_riff_wav(sample_rate=44100, channels=1, bits=16, num_samples=4,
     )
     fmt_chunk = b"fmt " + struct.pack("<I", 16) + fmt
     data_chunk = b"data" + struct.pack("<I", len(audio_data)) + audio_data
-
     smpl_chunk = b""
     if smpl_root_key is not None:
-        # 36-byte smpl body: manufacturer, product, sample_period,
-        # midi_unity_note, midi_pitch_fraction, smpte_format, smpte_offset,
-        # sample_loops, sampler_data
         smpl_body = struct.pack(
             "<IIIIIIiiI",
             0, 0, 0, smpl_root_key, 0, 0, 0, 0, 0,
         )
         smpl_chunk = b"smpl" + struct.pack("<I", len(smpl_body)) + smpl_body
-
     riff_body = b"WAVE" + fmt_chunk + data_chunk + smpl_chunk
     return b"RIFF" + struct.pack("<I", len(riff_body)) + riff_body
 
 
 class _Args:
     def __init__(self, **kw):
-        for k, v in kw.items():
+        defaults = {
+            "target": None, "label": None, "in_tree": False,
+            "rebuild": False, "features": False, "deep": False,
+            "import_tags": None, "registry": None,
+            "list_libs": False, "orphans": False,
+            "stats_target": None, "forget": None, "remove": None,
+            "quiet": True, "verbose": False,
+        }
+        defaults.update(kw)
+        for k, v in defaults.items():
             setattr(self, k, v)
-        for name in ("target", "db", "features", "deep", "import_tags",
-                     "list_roots", "remove_root", "stats", "quiet"):
-            if not hasattr(self, name):
-                setattr(self, name, None)
-        if self.quiet is None:
-            self.quiet = True
-        if self.features is None:
-            self.features = False
-        if self.deep is None:
-            self.deep = False
-        if self.list_roots is None:
-            self.list_roots = False
-        if self.stats is None:
-            self.stats = False
 
 
-def _library(tmp_path, minimal_wav_bytes):
-    """Build a small library of WAVs in tmp_path/lib."""
-    lib = tmp_path / "lib"
-    lib.mkdir()
-    (lib / "kick.wav").write_bytes(minimal_wav_bytes)
-    (lib / "snare.wav").write_bytes(minimal_wav_bytes)
-    sub = lib / "sub"
-    sub.mkdir()
-    (sub / "hat.wav").write_bytes(minimal_wav_bytes)
-    return lib
+@pytest.fixture
+def registry_path(tmp_path, monkeypatch):
+    """Sandbox the registry path for every test in this module."""
+    p = str(tmp_path / "registry.db")
+    monkeypatch.setenv("ACIDCAT_REGISTRY", p)
+    return p
+
+
+@pytest.fixture
+def central_root(tmp_path, monkeypatch):
+    """Pin the central libraries dir under tmp_path so tests don't write
+    to the user's real ~/.acidcat/."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
 
 
 @pytest.fixture
@@ -77,249 +73,319 @@ def wav_bytes():
     return _make_riff_wav()
 
 
-def test_open_db_creates_schema(tmp_path):
-    db = tmp_path / "test.db"
-    conn = idx.open_db(str(db))
-    try:
-        row = conn.execute(
-            "SELECT v FROM meta WHERE k = 'schema_version'"
-        ).fetchone()
-        assert row["v"] == str(idx.SCHEMA_VERSION)
-        tables = {
-            r["name"] for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')"
-            ).fetchall()
-        }
-        for required in ("samples", "scan_roots", "tags", "descriptions",
-                         "features", "samples_fts"):
-            assert required in tables
-    finally:
-        conn.close()
-
-
-def test_index_populates_rows(tmp_path, wav_bytes):
-    lib = _library(tmp_path, wav_bytes)
-    db = tmp_path / "idx.db"
-    args = _Args(target=str(lib), db=str(db))
-    rc = index_cmd.run(args)
-    assert rc == 0
-
-    conn = idx.open_db(str(db))
-    try:
-        total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
-        assert total == 3
-        fmt_row = conn.execute(
-            "SELECT DISTINCT format FROM samples"
-        ).fetchone()
-        assert fmt_row["format"] == "wav"
-        roots = idx.list_roots(conn)
-        assert len(roots) == 1
-        assert roots[0]["file_count"] == 3
-    finally:
-        conn.close()
-
-
-def test_reindex_skips_unchanged(tmp_path, wav_bytes):
-    lib = _library(tmp_path, wav_bytes)
-    db = tmp_path / "idx.db"
-    args = _Args(target=str(lib), db=str(db))
-    index_cmd.run(args)
-
-    conn = idx.open_db(str(db))
-    try:
-        rows = conn.execute(
-            "SELECT path, indexed_at FROM samples"
-        ).fetchall()
-        first_indexed = {r["path"]: r["indexed_at"] for r in rows}
-    finally:
-        conn.close()
-
-    time.sleep(0.05)
-    index_cmd.run(args)
-
-    conn = idx.open_db(str(db))
-    try:
-        rows = conn.execute(
-            "SELECT path, indexed_at, last_seen_at FROM samples"
-        ).fetchall()
-        for r in rows:
-            assert r["indexed_at"] == first_indexed[r["path"]]
-            assert r["last_seen_at"] >= r["indexed_at"]
-    finally:
-        conn.close()
-
-
-def test_prune_missing_files(tmp_path, wav_bytes):
-    lib = _library(tmp_path, wav_bytes)
-    db = tmp_path / "idx.db"
-    args = _Args(target=str(lib), db=str(db))
-    index_cmd.run(args)
-
-    os.remove(lib / "kick.wav")
-
-    index_cmd.run(args)
-
-    conn = idx.open_db(str(db))
-    try:
-        paths = [
-            r["path"] for r in conn.execute(
-                "SELECT path FROM samples"
-            ).fetchall()
-        ]
-        assert not any(p.endswith("kick.wav") for p in paths)
-        assert len(paths) == 2
-    finally:
-        conn.close()
-
-
-def test_changed_file_updates_row(tmp_path, wav_bytes):
-    lib = tmp_path / "lib"
+def _library(tmp_path, wav_bytes, name="lib"):
+    lib = tmp_path / name
     lib.mkdir()
-    target = lib / "x.wav"
-    target.write_bytes(wav_bytes)
-    db = tmp_path / "idx.db"
-    args = _Args(target=str(lib), db=str(db))
-    index_cmd.run(args)
-
-    conn = idx.open_db(str(db))
-    orig_size = conn.execute("SELECT size FROM samples").fetchone()["size"]
-    conn.close()
-
-    # mutate the file: rewrite with longer audio
-    target.write_bytes(_make_riff_wav(num_samples=1024))
-    os.utime(target, (time.time() + 1, time.time() + 1))
-
-    index_cmd.run(args)
-
-    conn = idx.open_db(str(db))
-    new_size = conn.execute("SELECT size FROM samples").fetchone()["size"]
-    conn.close()
-    assert new_size != orig_size
+    (lib / "kick.wav").write_bytes(wav_bytes)
+    (lib / "snare.wav").write_bytes(wav_bytes)
+    sub = lib / "sub"
+    sub.mkdir()
+    (sub / "hat.wav").write_bytes(wav_bytes)
+    return lib
 
 
-def test_multiple_roots_share_db(tmp_path, wav_bytes):
-    db = tmp_path / "idx.db"
+class TestIndexCreatesLibrary:
+    def test_central_db_created_and_registered(self, tmp_path, central_root,
+                                                registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        rc = index_cmd.run(_Args(target=str(lib), label="testlib",
+                                 registry=registry_path))
+        assert rc == 0
 
-    lib_a = tmp_path / "a"
-    lib_a.mkdir()
-    (lib_a / "one.wav").write_bytes(wav_bytes)
+        # registry has the library
+        rconn = reg.open_registry(registry_path)
+        try:
+            rows = reg.list_libraries(rconn)
+            assert len(rows) == 1
+            assert rows[0]["label"] == "testlib"
+            assert rows[0]["sample_count"] == 3
+            assert rows[0]["in_tree"] == 0
+        finally:
+            rconn.close()
 
-    lib_b = tmp_path / "b"
-    lib_b.mkdir()
-    (lib_b / "two.wav").write_bytes(wav_bytes)
+        # the central DB file actually exists
+        assert os.path.isfile(rows[0]["db_path"])
 
-    index_cmd.run(_Args(target=str(lib_a), db=str(db)))
-    index_cmd.run(_Args(target=str(lib_b), db=str(db)))
+    def test_label_defaults_to_basename(self, tmp_path, central_root,
+                                         registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes, name="MyPack")
+        index_cmd.run(_Args(target=str(lib), registry=registry_path))
+        rconn = reg.open_registry(registry_path)
+        try:
+            rows = reg.list_libraries(rconn)
+            assert rows[0]["label"] == "MyPack"
+        finally:
+            rconn.close()
 
-    conn = idx.open_db(str(db))
-    try:
-        total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
-        assert total == 2
-        roots = idx.list_roots(conn)
-        assert len(roots) == 2
-    finally:
-        conn.close()
-
-
-def test_remove_root(tmp_path, wav_bytes):
-    lib = _library(tmp_path, wav_bytes)
-    db = tmp_path / "idx.db"
-    index_cmd.run(_Args(target=str(lib), db=str(db)))
-
-    scan_root = idx.normalize_path(str(lib))
-    args = _Args(remove_root=scan_root, db=str(db))
-    rc = index_cmd.run(args)
-    assert rc == 0
-
-    conn = idx.open_db(str(db))
-    try:
-        total = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
-        assert total == 0
-        assert idx.list_roots(conn) == []
-    finally:
-        conn.close()
-
-
-def test_junk_files_skipped(tmp_path, wav_bytes):
-    lib = tmp_path / "lib"
-    lib.mkdir()
-    (lib / "real.wav").write_bytes(wav_bytes)
-    # AppleDouble sidecars, plus other OS junk
-    (lib / "._real.wav").write_bytes(b"\x00" * 32)
-    (lib / ".DS_Store").write_bytes(b"\x00" * 32)
-    (lib / "Thumbs.db").write_bytes(b"\x00" * 32)
-    (lib / "desktop.ini").write_bytes(b"\x00" * 32)
-
-    db = tmp_path / "idx.db"
-    index_cmd.run(_Args(target=str(lib), db=str(db)))
-
-    conn = idx.open_db(str(db))
-    try:
-        paths = [
-            r["path"] for r in conn.execute("SELECT path FROM samples").fetchall()
-        ]
-        assert len(paths) == 1
-        assert paths[0].endswith("/real.wav")
-    finally:
-        conn.close()
+    def test_in_tree_mode(self, tmp_path, central_root, registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        rc = index_cmd.run(_Args(target=str(lib), label="intree",
+                                 in_tree=True, registry=registry_path))
+        assert rc == 0
+        expected_db = acidpaths.in_tree_db_path_for(str(lib))
+        assert os.path.isfile(expected_db)
 
 
-def test_smpl_root_key_stores_pitch_class_only(tmp_path):
-    # MIDI 60 = C4; key column should hold "C" (pitch class), not "C4".
-    bytes_c4 = _make_riff_wav(smpl_root_key=60)
-    bytes_fs3 = _make_riff_wav(smpl_root_key=54)  # F#3
-
-    lib = tmp_path / "lib"
-    lib.mkdir()
-    (lib / "c_sample.wav").write_bytes(bytes_c4)
-    (lib / "fsharp_sample.wav").write_bytes(bytes_fs3)
-
-    db = tmp_path / "idx.db"
-    index_cmd.run(_Args(target=str(lib), db=str(db)))
-
-    conn = idx.open_db(str(db))
-    try:
-        rows = {
-            os.path.basename(r["path"]): dict(r)
-            for r in conn.execute(
-                "SELECT path, key, root_note FROM samples"
-            ).fetchall()
-        }
-        assert rows["c_sample.wav"]["key"] == "C"
-        assert rows["c_sample.wav"]["root_note"] == 60
-        assert rows["fsharp_sample.wav"]["key"] == "F#"
-        assert rows["fsharp_sample.wav"]["root_note"] == 54
-    finally:
-        conn.close()
+class TestNoOverlap:
+    def test_child_of_existing_rejected(self, tmp_path, central_root,
+                                         registry_path, wav_bytes):
+        parent = _library(tmp_path, wav_bytes, name="parent")
+        index_cmd.run(_Args(target=str(parent), label="parent",
+                            registry=registry_path))
+        child = parent / "sub"
+        rc = index_cmd.run(_Args(target=str(child), label="child",
+                                 registry=registry_path))
+        assert rc == 1
 
 
-def test_import_tags(tmp_path, wav_bytes):
-    lib = tmp_path / "lib"
-    lib.mkdir()
-    (lib / "Drum_Loop.wav").write_bytes(wav_bytes)
-    db = tmp_path / "idx.db"
+class TestIncrementalReindex:
+    def test_skips_unchanged(self, tmp_path, central_root, registry_path,
+                              wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+        # second pass should not change indexed_at on existing rows
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
 
-    tags_file = tmp_path / "legacy_tags.json"
-    tags_file.write_text(json.dumps({
-        "data/samples\\Drum_Loop.wav": {
-            "description": "Energetic drum loop",
-            "tags": ["drums", "loop"],
-        }
-    }))
+        conn = idx.open_db(db_path)
+        try:
+            first_indexed = {
+                r["path"]: r["indexed_at"]
+                for r in conn.execute("SELECT path, indexed_at FROM samples")
+            }
+        finally:
+            conn.close()
 
-    args = _Args(target=str(lib), db=str(db), import_tags=str(tags_file))
-    rc = index_cmd.run(args)
-    assert rc == 0
+        time.sleep(0.05)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
 
-    conn = idx.open_db(str(db))
-    try:
-        tag_rows = conn.execute(
-            "SELECT tag FROM tags ORDER BY tag"
-        ).fetchall()
-        assert [r["tag"] for r in tag_rows] == ["drums", "loop"]
-        desc = conn.execute(
-            "SELECT description FROM descriptions"
-        ).fetchone()
+        conn = idx.open_db(db_path)
+        try:
+            second = {
+                r["path"]: r["indexed_at"]
+                for r in conn.execute("SELECT path, indexed_at FROM samples")
+            }
+        finally:
+            conn.close()
+        assert first_indexed == second
+
+
+class TestRebuild:
+    def test_rebuild_clears_db(self, tmp_path, central_root, registry_path,
+                                wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+        # remove a file from disk; --rebuild should produce a fresh DB
+        # without the row
+        (lib / "kick.wav").unlink()
+
+        rc = index_cmd.run(_Args(target=str(lib), label="x",
+                                 rebuild=True, registry=registry_path))
+        assert rc == 0
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+        conn = idx.open_db(db_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) AS c FROM samples").fetchone()["c"]
+        finally:
+            conn.close()
+        assert count == 2
+
+
+class TestPruneMissing:
+    def test_missing_files_pruned(self, tmp_path, central_root, registry_path,
+                                   wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+        (lib / "kick.wav").unlink()
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+        conn = idx.open_db(db_path)
+        try:
+            paths_in_db = [
+                r["path"] for r in conn.execute("SELECT path FROM samples")
+            ]
+        finally:
+            conn.close()
+        assert not any(p.endswith("kick.wav") for p in paths_in_db)
+        assert len(paths_in_db) == 2
+
+
+class TestForgetVsRemove:
+    def test_forget_keeps_db_file(self, tmp_path, central_root, registry_path,
+                                   wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+
+        rc = index_cmd.run(_Args(forget="x", registry=registry_path))
+        assert rc == 0
+        # registry no longer knows it
+        rconn = reg.open_registry(registry_path)
+        try:
+            assert reg.get_library(rconn, "x") is None
+        finally:
+            rconn.close()
+        # but DB file still exists
+        assert os.path.isfile(db_path)
+
+    def test_remove_deletes_db_file(self, tmp_path, central_root, registry_path,
+                                     wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+
+        rc = index_cmd.run(_Args(remove="x", registry=registry_path))
+        assert rc == 0
+        rconn = reg.open_registry(registry_path)
+        try:
+            assert reg.get_library(rconn, "x") is None
+        finally:
+            rconn.close()
+        assert not os.path.isfile(db_path)
+
+
+class TestOrphans:
+    def test_orphans_lists_missing_db(self, tmp_path, central_root,
+                                       registry_path, wav_bytes, capsys):
+        lib = _library(tmp_path, wav_bytes)
+        index_cmd.run(_Args(target=str(lib), label="x",
+                            registry=registry_path))
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+        # delete the DB file out from under the registry
+        for ext in ("", "-shm", "-wal"):
+            p = db_path + ext
+            if os.path.isfile(p):
+                os.remove(p)
+
+        rc = index_cmd.run(_Args(orphans=True, registry=registry_path))
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "x" in captured.out
+
+
+class TestImportTags:
+    def test_import_tags(self, tmp_path, central_root, registry_path):
+        lib = tmp_path / "lib"
+        lib.mkdir()
+        (lib / "Drum_Loop.wav").write_bytes(_make_riff_wav())
+        tags_file = tmp_path / "legacy_tags.json"
+        tags_file.write_text(json.dumps({
+            "data/samples\\Drum_Loop.wav": {
+                "description": "Energetic drum loop",
+                "tags": ["drums", "loop"],
+            }
+        }))
+        rc = index_cmd.run(_Args(target=str(lib), label="x",
+                                 import_tags=str(tags_file),
+                                 registry=registry_path))
+        assert rc == 0
+
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+        conn = idx.open_db(db_path)
+        try:
+            tags = sorted(
+                r["tag"] for r in conn.execute("SELECT tag FROM tags")
+            )
+            desc = conn.execute("SELECT description FROM descriptions").fetchone()
+        finally:
+            conn.close()
+        assert tags == ["drums", "loop"]
         assert desc["description"] == "Energetic drum loop"
-    finally:
-        conn.close()
+
+
+class TestSmplRootKey:
+    def test_zero_treated_as_unset(self, tmp_path, central_root, registry_path):
+        lib = tmp_path / "lib"
+        lib.mkdir()
+        (lib / "zero.wav").write_bytes(_make_riff_wav(smpl_root_key=0))
+        index_cmd.run(_Args(target=str(lib), label="x", registry=registry_path))
+
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+        conn = idx.open_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT key, root_note FROM samples"
+            ).fetchone()
+        finally:
+            conn.close()
+        # key may fall back to filename or be None; the regression is that
+        # it must NOT be "C-1"
+        assert row["key"] != "C-1"
+        assert row["root_note"] is None
+
+    def test_nonzero_yields_pitch_class(self, tmp_path, central_root,
+                                         registry_path):
+        lib = tmp_path / "lib"
+        lib.mkdir()
+        (lib / "c4.wav").write_bytes(_make_riff_wav(smpl_root_key=60))
+        index_cmd.run(_Args(target=str(lib), label="x", registry=registry_path))
+        rconn = reg.open_registry(registry_path)
+        try:
+            db_path = reg.get_library(rconn, "x")["db_path"]
+        finally:
+            rconn.close()
+        conn = idx.open_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT key, root_note FROM samples"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row["key"] == "C"
+        assert row["root_note"] == 60
+
+
+class TestJunkFilter:
+    def test_appledouble_skipped(self, tmp_path, central_root, registry_path,
+                                  wav_bytes):
+        lib = tmp_path / "lib"
+        lib.mkdir()
+        (lib / "real.wav").write_bytes(wav_bytes)
+        (lib / "._real.wav").write_bytes(b"\x00" * 32)
+        (lib / ".DS_Store").write_bytes(b"\x00" * 32)
+        index_cmd.run(_Args(target=str(lib), label="x", registry=registry_path))
+        rconn = reg.open_registry(registry_path)
+        try:
+            row = reg.get_library(rconn, "x")
+        finally:
+            rconn.close()
+        assert row["sample_count"] == 1

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,40 +1,68 @@
-"""Tests for the MCP tool surface (direct handler calls, bypass stdio)."""
+"""Tests for the MCP tool surface (per-library + registry layout)."""
 
 import json
+import os
 import time
 
 import pytest
 
 from acidcat import mcp_server
 from acidcat.core import index as idx
+from acidcat.core import paths as acidpaths
+from acidcat.core import registry as reg
 
 
-ROOT_A = idx.normalize_path("/tmp/mcp/a")
-ROOT_B = idx.normalize_path("/tmp/mcp/b")
-P_KICK = ROOT_A + "/kick_120.wav"
-P_HAT = ROOT_A + "/hat_128.wav"
-P_SYNTH = ROOT_B + "/synth_124.flac"
+@pytest.fixture
+def two_lib_setup(tmp_path, monkeypatch):
+    """Build two real registered libraries with seeded sample rows.
 
+    Sets _REGISTRY_PATH on mcp_server so handlers see this isolated
+    registry. Returns paths used by the assertions.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    registry_path = str(tmp_path / "registry.db")
+    monkeypatch.setattr(mcp_server, "_REGISTRY_PATH", registry_path)
 
-def _seed(db_path):
-    conn = idx.open_db(db_path)
+    lib_a_root_dir = tmp_path / "libA"
+    lib_a_root_dir.mkdir()
+    lib_b_root_dir = tmp_path / "libB"
+    lib_b_root_dir.mkdir()
+
+    a_root = acidpaths.normalize(str(lib_a_root_dir))
+    b_root = acidpaths.normalize(str(lib_b_root_dir))
+    p_kick = a_root + "/kick_120.wav"
+    p_hat = a_root + "/hat_128.wav"
+    p_synth = b_root + "/synth_124.flac"
+
+    rconn = reg.open_registry(registry_path)
+    try:
+        db_a = acidpaths.central_db_path_for(a_root, "A")
+        db_b = acidpaths.central_db_path_for(b_root, "B")
+        reg.register_library(rconn, a_root, label="A", db_path=db_a)
+        reg.register_library(rconn, b_root, label="B", db_path=db_b)
+    finally:
+        rconn.close()
+
     now = time.time()
-    rows = [
-        {"path": P_KICK, "scan_root": ROOT_A, "format": "wav",
+    a_rows = [
+        {"path": p_kick, "scan_root": a_root, "format": "wav",
          "duration": 1.2, "bpm": 120.0, "key": "C",
          "title": "kick one", "comment": "booming sub",
          "mtime": now, "size": 100, "indexed_at": now, "last_seen_at": now,
          "chunks": "acid,smpl", "acid_beats": 4, "root_note": 60,
          "sample_rate": 44100, "channels": 1, "bits_per_sample": 16,
          "artist": None, "album": None, "genre": None},
-        {"path": P_HAT, "scan_root": ROOT_A, "format": "wav",
+        {"path": p_hat, "scan_root": a_root, "format": "wav",
          "duration": 0.5, "bpm": 128.0, "key": "Am",
          "title": "closed hat", "mtime": now, "size": 100,
          "indexed_at": now, "last_seen_at": now,
          "artist": None, "album": None, "genre": None, "comment": None,
          "chunks": None, "acid_beats": None, "root_note": None,
          "sample_rate": None, "channels": None, "bits_per_sample": None},
-        {"path": P_SYNTH, "scan_root": ROOT_B, "format": "flac",
+    ]
+    b_rows = [
+        {"path": p_synth, "scan_root": b_root, "format": "flac",
          "duration": 8.0, "bpm": 124.0, "key": "Em",
          "title": "dusty synth", "artist": "someone",
          "album": "dust pack", "genre": "electronic",
@@ -43,275 +71,271 @@ def _seed(db_path):
          "chunks": None, "acid_beats": None, "root_note": None,
          "sample_rate": 44100, "channels": 2, "bits_per_sample": 16},
     ]
-    for r in rows:
-        idx.upsert_sample(conn, r)
-    idx.upsert_tags(conn, P_KICK, ["drums", "kick", "punchy"])
-    idx.upsert_tags(conn, P_HAT, ["drums", "hat"])
-    idx.upsert_tags(conn, P_SYNTH, ["synth", "pad"])
-    idx.upsert_description(conn, P_SYNTH, "moody analog pad")
-    idx.record_scan_root(conn, ROOT_A, 2, now)
-    idx.record_scan_root(conn, ROOT_B, 1, now)
-    conn.commit()
-    conn.close()
 
+    conn_a = idx.open_db(db_a)
+    try:
+        for r in a_rows:
+            idx.upsert_sample(conn_a, r)
+        idx.upsert_tags(conn_a, p_kick, ["drums", "kick", "punchy"])
+        idx.upsert_tags(conn_a, p_hat, ["drums", "hat"])
+        conn_a.commit()
+    finally:
+        conn_a.close()
 
-@pytest.fixture
-def seeded_db(tmp_path, monkeypatch):
-    db = tmp_path / "mcp.db"
-    _seed(str(db))
-    monkeypatch.setattr(mcp_server, "_DB_PATH", str(db))
-    return str(db)
+    conn_b = idx.open_db(db_b)
+    try:
+        for r in b_rows:
+            idx.upsert_sample(conn_b, r)
+        idx.upsert_tags(conn_b, p_synth, ["synth", "pad"])
+        idx.upsert_description(conn_b, p_synth, "moody analog pad")
+        conn_b.commit()
+    finally:
+        conn_b.close()
 
+    rconn = reg.open_registry(registry_path)
+    try:
+        reg.update_stats(rconn, a_root, sample_count=2)
+        reg.update_stats(rconn, b_root, sample_count=1)
+    finally:
+        rconn.close()
 
-def test_tools_registered():
-    names = {t["name"] for t in mcp_server.TOOLS}
-    expected = {
-        "search_samples", "get_sample", "locate_sample", "list_roots",
-        "list_tags", "list_keys", "list_formats", "index_stats",
-        "find_compatible",
-        "find_similar", "analyze_sample", "detect_bpm_key",
-        "reindex", "reindex_features",
-        "tag_sample", "describe_sample",
+    return {
+        "registry_path": registry_path,
+        "lib_a_root": a_root,
+        "lib_b_root": b_root,
+        "P_KICK": p_kick,
+        "P_HAT": p_hat,
+        "P_SYNTH": p_synth,
     }
-    assert expected.issubset(names)
 
 
-def test_fast_tools_have_fast_prefix():
-    fast_names = {"search_samples", "get_sample", "locate_sample",
-                  "list_roots", "list_tags", "list_keys", "list_formats",
-                  "index_stats", "find_compatible"}
-    for t in mcp_server.TOOLS:
-        if t["name"] in fast_names:
-            assert t["description"].startswith("Fast."), t["name"]
+class TestToolsRegistered:
+    def test_expected_tools(self):
+        names = {t["name"] for t in mcp_server.TOOLS}
+        expected = {
+            "search_samples", "get_sample", "locate_sample",
+            "list_libraries", "list_tags", "list_keys", "list_formats",
+            "index_stats", "find_compatible",
+            "find_similar", "analyze_sample", "detect_bpm_key",
+            "reindex", "reindex_features",
+            "register_library", "forget_library",
+            "tag_sample", "describe_sample",
+        }
+        assert expected.issubset(names)
+        assert "list_roots" not in names
+
+    def test_fast_tools_have_fast_prefix(self):
+        fast = {"search_samples", "get_sample", "locate_sample",
+                "list_libraries", "list_tags", "list_keys", "list_formats",
+                "index_stats", "find_compatible"}
+        for t in mcp_server.TOOLS:
+            if t["name"] in fast:
+                assert t["description"].startswith("Fast."), t["name"]
+
+    def test_destructive_tools_marked(self):
+        destructive = {"register_library", "forget_library",
+                       "tag_sample", "describe_sample"}
+        for t in mcp_server.TOOLS:
+            if t["name"] in destructive:
+                assert t["annotations"]["destructiveHint"] is True
 
 
-def test_slow_tools_have_slow_prefix():
-    slow_names = {"find_similar", "analyze_sample", "detect_bpm_key",
-                  "reindex", "reindex_features"}
-    for t in mcp_server.TOOLS:
-        if t["name"] in slow_names:
-            assert t["description"].startswith(("SLOW", "VERY SLOW")), t["name"]
+class TestSearchSamplesFanOut:
+    def test_no_filter_returns_all(self, two_lib_setup):
+        r = mcp_server.dispatch("search_samples", {})
+        paths = {s["path"] for s in r["samples"]}
+        assert two_lib_setup["P_KICK"] in paths
+        assert two_lib_setup["P_HAT"] in paths
+        assert two_lib_setup["P_SYNTH"] in paths
+        assert r["count"] == 3
+
+    def test_bpm_range_across_libs(self, two_lib_setup):
+        r = mcp_server.dispatch("search_samples",
+                                {"bpm_min": 120, "bpm_max": 125})
+        paths = {s["path"] for s in r["samples"]}
+        assert paths == {two_lib_setup["P_KICK"], two_lib_setup["P_SYNTH"]}
+
+    def test_text_fts_finds_in_one_lib(self, two_lib_setup):
+        r = mcp_server.dispatch("search_samples", {"text": "dusty"})
+        assert r["count"] == 1
+        assert r["samples"][0]["path"] == two_lib_setup["P_SYNTH"]
+        assert r["samples"][0]["library_label"] == "B"
+
+    def test_root_label_scope(self, two_lib_setup):
+        r = mcp_server.dispatch("search_samples", {"root": "A"})
+        paths = {s["path"] for s in r["samples"]}
+        assert two_lib_setup["P_SYNTH"] not in paths
+
+    def test_root_path_scope(self, two_lib_setup):
+        r = mcp_server.dispatch("search_samples",
+                                {"root": two_lib_setup["lib_b_root"]})
+        paths = {s["path"] for s in r["samples"]}
+        assert paths == {two_lib_setup["P_SYNTH"]}
 
 
-def test_write_tools_marked_destructive():
-    for t in mcp_server.TOOLS:
-        if t["name"] in ("tag_sample", "describe_sample"):
-            assert t["annotations"]["destructiveHint"] is True
-            assert t["annotations"]["readOnlyHint"] is False
+class TestGetSample:
+    def test_returns_full_record(self, two_lib_setup):
+        r = mcp_server.dispatch("get_sample",
+                                {"path": two_lib_setup["P_SYNTH"]})
+        assert r["path"] == two_lib_setup["P_SYNTH"]
+        assert r["tags"] == ["pad", "synth"]
+        assert r["description"] == "moody analog pad"
+        assert r["library_label"] == "B"
+
+    def test_unknown_raises(self, two_lib_setup):
+        with pytest.raises(mcp_server.ToolError):
+            mcp_server.dispatch("get_sample", {"path": "/nope.wav"})
 
 
-def test_fast_tools_read_only():
-    fast = {"search_samples", "get_sample", "locate_sample", "list_roots",
-            "list_tags", "list_keys", "list_formats", "index_stats",
-            "find_compatible"}
-    for t in mcp_server.TOOLS:
-        if t["name"] in fast:
-            assert t["annotations"]["readOnlyHint"] is True
-            assert t["annotations"]["destructiveHint"] is False
+class TestLocateSample:
+    def test_finds_by_substring(self, two_lib_setup):
+        r = mcp_server.dispatch("locate_sample", {"name": "synth"})
+        assert r["count"] == 1
+        assert r["samples"][0]["library_label"] == "B"
+
+    def test_substring_matches_mid_filename(self, two_lib_setup):
+        # Regression: "_120" sits mid-filename in kick_120.wav. The old
+        # "%/<name>%" pattern silently failed for this case because nothing
+        # in the path is `/120...`. Substring match must work anywhere.
+        r = mcp_server.dispatch("locate_sample", {"name": "_120"})
+        assert r["count"] == 1
+        assert r["samples"][0]["path"] == two_lib_setup["P_KICK"]
 
 
-def test_search_samples(seeded_db):
-    r = mcp_server.dispatch("search_samples", {"bpm_min": 120, "bpm_max": 125})
-    paths = {s["path"] for s in r["samples"]}
-    assert paths == {P_KICK, P_SYNTH}
+class TestListLibraries:
+    def test_returns_both(self, two_lib_setup):
+        r = mcp_server.dispatch("list_libraries", {})
+        labels = {lib["label"] for lib in r["libraries"]}
+        assert labels == {"A", "B"}
+        assert r["available"] == 2
+        assert r["unavailable"] == 0
 
 
-def test_search_samples_text(seeded_db):
-    r = mcp_server.dispatch("search_samples", {"text": "dusty"})
-    assert r["count"] == 1
-    assert r["samples"][0]["path"] == P_SYNTH
+class TestListTagsKeysFormats:
+    def test_list_tags_sums_across_libs(self, two_lib_setup):
+        r = mcp_server.dispatch("list_tags", {})
+        tag_map = {t["tag"]: t["count"] for t in r["tags"]}
+        assert tag_map["drums"] == 2
+        assert tag_map["synth"] == 1
+
+    def test_list_keys(self, two_lib_setup):
+        r = mcp_server.dispatch("list_keys", {})
+        keys = {k["key"] for k in r["keys"]}
+        assert keys == {"C", "Am", "Em"}
+
+    def test_list_formats(self, two_lib_setup):
+        r = mcp_server.dispatch("list_formats", {})
+        formats = {f["format"] for f in r["formats"]}
+        assert formats == {"wav", "flac"}
 
 
-def test_search_samples_tags_and(seeded_db):
-    r = mcp_server.dispatch("search_samples", {"tags": ["drums", "kick"]})
-    assert r["count"] == 1
-    assert r["samples"][0]["path"] == P_KICK
+class TestIndexStats:
+    def test_rolls_up(self, two_lib_setup):
+        r = mcp_server.dispatch("index_stats", {})
+        assert r["total_samples"] == 3
+        assert r["available_libraries"] == 2
+        assert r["unavailable_libraries"] == 0
 
 
-def test_get_sample(seeded_db):
-    r = mcp_server.dispatch("get_sample", {"path": P_SYNTH})
-    assert r["path"] == P_SYNTH
-    assert r["tags"] == ["pad", "synth"]
-    assert r["description"] == "moody analog pad"
-    assert r["has_features"] is False
+class TestFindCompatible:
+    def test_finds_compatible_across_libs(self, two_lib_setup):
+        # P_HAT is Am (8A) at 128 bpm, one_shot. With kind=any and a wider
+        # tolerance, P_SYNTH (Em loop at 124) should appear.
+        r = mcp_server.dispatch("find_compatible", {
+            "path": two_lib_setup["P_HAT"],
+            "kind": "any",
+            "bpm_tolerance_pct": 10,
+        })
+        paths = {s["path"] for s in r["samples"]}
+        assert two_lib_setup["P_SYNTH"] in paths
 
 
-def test_get_sample_not_indexed(seeded_db):
-    with pytest.raises(mcp_server.ToolError):
-        mcp_server.dispatch("get_sample", {"path": "/nope.wav"})
+class TestRegisterAndForget:
+    def test_register_creates_db_and_registry_row(self, two_lib_setup, tmp_path):
+        new_root = tmp_path / "newlib"
+        new_root.mkdir()
+        r = mcp_server.dispatch("register_library", {
+            "root": str(new_root), "label": "newlib",
+        })
+        assert r["label"] == "newlib"
+        assert os.path.isfile(r["db_path"])
+        listed = mcp_server.dispatch("list_libraries", {})
+        labels = {lib["label"] for lib in listed["libraries"]}
+        assert labels == {"A", "B", "newlib"}
+
+    def test_register_overlap_rejected(self, two_lib_setup, tmp_path):
+        sub = tmp_path / "libA" / "sub"
+        sub.mkdir()
+        with pytest.raises(mcp_server.ToolError) as excinfo:
+            mcp_server.dispatch("register_library", {
+                "root": str(sub), "label": "sub",
+            })
+        assert "'A'" in str(excinfo.value)
+
+    def test_forget_removes_from_registry(self, two_lib_setup):
+        r = mcp_server.dispatch("forget_library", {"label": "A"})
+        assert r["count"] == 1
+        listed = mcp_server.dispatch("list_libraries", {})
+        labels = {lib["label"] for lib in listed["libraries"]}
+        assert "A" not in labels
 
 
-def test_locate_sample(seeded_db):
-    r = mcp_server.dispatch("locate_sample", {"name": "synth"})
-    assert r["count"] == 1
-    assert r["samples"][0]["path"] == P_SYNTH
+class TestTagSample:
+    def test_add_remove_round_trip(self, two_lib_setup):
+        r = mcp_server.dispatch("tag_sample", {
+            "path": two_lib_setup["P_HAT"],
+            "add_tags": ["bright"],
+        })
+        assert "bright" in r["tags"]
+        assert r["library_label"] == "A"
+        r2 = mcp_server.dispatch("tag_sample", {
+            "path": two_lib_setup["P_HAT"],
+            "remove_tags": ["bright"],
+        })
+        assert "bright" not in r2["tags"]
 
 
-def test_list_roots(seeded_db):
-    r = mcp_server.dispatch("list_roots", {})
-    paths = {root["path"] for root in r["roots"]}
-    assert paths == {ROOT_A, ROOT_B}
+class TestDescribeSample:
+    def test_set_description(self, two_lib_setup):
+        r = mcp_server.dispatch("describe_sample", {
+            "path": two_lib_setup["P_HAT"],
+            "description": "crispy hat",
+        })
+        assert r["description"] == "crispy hat"
+        got = mcp_server.dispatch("get_sample", {
+            "path": two_lib_setup["P_HAT"],
+        })
+        assert got["description"] == "crispy hat"
 
 
-def test_list_tags(seeded_db):
-    r = mcp_server.dispatch("list_tags", {})
-    tag_names = [t["tag"] for t in r["tags"]]
-    assert "drums" in tag_names
-    # drums count is 2 (kick + hat)
-    tag_map = {t["tag"]: t["count"] for t in r["tags"]}
-    assert tag_map["drums"] == 2
+class TestAnalysisDegrades:
+    def test_analyze_sample_no_librosa(self, two_lib_setup, monkeypatch):
+        monkeypatch.setattr(mcp_server, "_librosa_available", lambda: False)
+        r = mcp_server.dispatch("analyze_sample",
+                                {"path": two_lib_setup["P_HAT"]})
+        assert "error" in r
+
+    def test_detect_bpm_key_no_librosa(self, two_lib_setup, monkeypatch):
+        monkeypatch.setattr(mcp_server, "_librosa_available", lambda: False)
+        r = mcp_server.dispatch("detect_bpm_key",
+                                {"path": two_lib_setup["P_HAT"]})
+        assert "error" in r
 
 
-def test_list_tags_prefix(seeded_db):
-    r = mcp_server.dispatch("list_tags", {"prefix": "dr"})
-    tag_names = [t["tag"] for t in r["tags"]]
-    assert tag_names == ["drums"]
+class TestUnknownTool:
+    def test_dispatch_raises(self):
+        with pytest.raises(mcp_server.ToolError):
+            mcp_server.dispatch("nope", {})
 
 
-def test_list_keys(seeded_db):
-    r = mcp_server.dispatch("list_keys", {})
-    keys = {k["key"] for k in r["keys"]}
-    assert keys == {"C", "Am", "Em"}
+class TestInferKindHelper:
+    def test_one_shot(self):
+        assert mcp_server.infer_kind(0.5, 0) == "one_shot"
+        assert mcp_server.infer_kind(0.5, None) == "one_shot"
 
+    def test_loop(self):
+        assert mcp_server.infer_kind(8.0, 0) == "loop"
+        assert mcp_server.infer_kind(1.2, 4) == "loop"
 
-def test_list_formats(seeded_db):
-    r = mcp_server.dispatch("list_formats", {})
-    formats = {f["format"] for f in r["formats"]}
-    assert formats == {"wav", "flac"}
-
-
-def test_index_stats(seeded_db):
-    r = mcp_server.dispatch("index_stats", {})
-    assert r["total_samples"] == 3
-    assert "analysis_available" in r
-    assert r["db_path"] == seeded_db
-
-
-def test_find_compatible_loops_match_loops(seeded_db):
-    # P_KICK: duration 1.2, acid_beats 4 -> loop (acid_beats > 0)
-    # P_SYNTH: duration 8.0, no acid_beats -> loop (duration >= 2.0)
-    # P_HAT:   duration 0.5, no acid_beats -> one_shot
-    # P_KICK is key C (8B); compatible with Am, Em, F, G. None of seeds match.
-    # Run with wider tolerance and check synth (Em) loop shows up.
-    r = mcp_server.dispatch("find_compatible", {
-        "path": P_SYNTH, "bpm_tolerance_pct": 20,
-    })
-    assert r["target"]["kind"] == "loop"
-    assert r["filter_kind"] == "loop"
-    # P_KICK and P_HAT are both compatible by key (Em -> compatible with C and G);
-    # only the loop (P_KICK) should come back.
-    paths = {s["path"] for s in r["samples"]}
-    # C is in compatible_keys for Em target (Em=9A -> 9B=G, 10A=Bm, 8A=Am)...
-    # so the exact membership depends on the Camelot wheel. What matters:
-    # the one_shot P_HAT MUST NOT appear.
-    assert P_HAT not in paths
-
-
-def test_find_compatible_default_excludes_cross_kind(seeded_db):
-    # Target is a one_shot (P_HAT). Default kind filter should exclude loops.
-    r = mcp_server.dispatch("find_compatible", {"path": P_HAT})
-    assert r["target"]["kind"] == "one_shot"
-    assert r["filter_kind"] == "one_shot"
-    paths = {s["path"] for s in r["samples"]}
-    # P_SYNTH is a loop, P_KICK is a loop (acid_beats=4); both excluded.
-    assert P_SYNTH not in paths
-    assert P_KICK not in paths
-
-
-def test_find_compatible_kind_any_overrides(seeded_db):
-    # With kind="any", the old behavior is back: a one_shot target finds loops.
-    r = mcp_server.dispatch("find_compatible", {
-        "path": P_HAT, "kind": "any",
-    })
-    assert r["filter_kind"] == "any"
-    paths = {s["path"] for s in r["samples"]}
-    assert P_SYNTH in paths
-
-
-def test_find_compatible_min_duration_override(seeded_db):
-    r = mcp_server.dispatch("find_compatible", {
-        "path": P_HAT, "kind": "any", "min_duration": 2.0,
-    })
-    paths = {s["path"] for s in r["samples"]}
-    # P_KICK (1.2s) excluded, P_SYNTH (8s) kept
-    assert P_KICK not in paths
-    assert P_SYNTH in paths
-
-
-def test_find_compatible_infer_kind_helper():
-    assert mcp_server.infer_kind(0.5, 0) == "one_shot"
-    assert mcp_server.infer_kind(0.5, None) == "one_shot"
-    assert mcp_server.infer_kind(8.0, 0) == "loop"
-    assert mcp_server.infer_kind(1.2, 4) == "loop"
-    # 1.0 to 2.0 with no beats is genuinely ambiguous
-    assert mcp_server.infer_kind(1.5, 0) == "any"
-
-
-@pytest.mark.parametrize("duration,acid_beats,expected", [
-    # Producer Loops Hypnotize pack: ACID chunk present but beats=0,
-    # durations are exact bar counts. Must classify as loops via duration.
-    (7.619, 0, "loop"),         # 2 bars at 126 BPM
-    (15.238, 0, "loop"),        # 4 bars at 126 BPM
-    # equivalence: None and 0 must behave identically for every duration band
-    (7.619, None, "loop"),
-    (15.238, None, "loop"),
-    (0.3, 0, "one_shot"),
-    (0.3, None, "one_shot"),
-    (1.5, 0, "any"),
-    (1.5, None, "any"),
-])
-def test_infer_kind_zero_beats_equivalent_to_null(duration, acid_beats, expected):
-    # regression guard: acid_beats == 0 must be treated as uninformative
-    # (equivalent to NULL), never as a one-shot signal on its own.
-    # some commercial packs (Producer Loops Hypnotize) write ACID chunks
-    # with beats=0 on legitimate loops, so inference must fall through to
-    # duration-based classification.
-    assert mcp_server.infer_kind(duration, acid_beats) == expected
-
-
-def test_tag_sample(seeded_db):
-    r = mcp_server.dispatch("tag_sample", {
-        "path": P_HAT, "add_tags": ["bright", "tight"],
-    })
-    assert "bright" in r["tags"]
-    assert "tight" in r["tags"]
-
-    r2 = mcp_server.dispatch("tag_sample", {
-        "path": P_HAT, "remove_tags": ["bright"],
-    })
-    assert "bright" not in r2["tags"]
-    assert "tight" in r2["tags"]
-
-
-def test_describe_sample(seeded_db):
-    r = mcp_server.dispatch("describe_sample", {
-        "path": P_HAT, "description": "crispy closed hat",
-    })
-    assert r["description"] == "crispy closed hat"
-    got = mcp_server.dispatch("get_sample", {"path": P_HAT})
-    assert got["description"] == "crispy closed hat"
-
-
-def test_analysis_tools_degrade_without_librosa(seeded_db, monkeypatch):
-    monkeypatch.setattr(mcp_server, "_librosa_available", lambda: False)
-
-    r = mcp_server.dispatch("analyze_sample", {"path": P_HAT})
-    assert "error" in r
-    assert "acidcat[analysis]" in r["fix"]
-
-    r = mcp_server.dispatch("detect_bpm_key", {"path": P_HAT})
-    assert "error" in r
-
-    r = mcp_server.dispatch("reindex_features", {})
-    assert "error" in r
-
-
-def test_find_similar_no_features_no_librosa(seeded_db, monkeypatch):
-    monkeypatch.setattr(mcp_server, "_librosa_available", lambda: False)
-    r = mcp_server.dispatch("find_similar", {"path": P_HAT})
-    assert "error" in r
-
-
-def test_unknown_tool(seeded_db):
-    with pytest.raises(mcp_server.ToolError):
-        mcp_server.dispatch("nope", {})
+    def test_ambiguous(self):
+        assert mcp_server.infer_kind(1.5, 0) == "any"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,137 @@
+"""Tests for core/paths.py path-layout helpers."""
+
+import os
+
+import pytest
+
+from acidcat.core import paths
+
+
+class TestNormalize:
+    def test_returns_absolute(self):
+        result = paths.normalize("rel/path")
+        assert os.path.isabs(result)
+
+    def test_forward_slashes(self):
+        result = paths.normalize("rel/path")
+        assert "\\" not in result
+
+    def test_idempotent(self):
+        once = paths.normalize("/tmp/x")
+        twice = paths.normalize(once)
+        assert once == twice
+
+
+class TestSafeLabel:
+    def test_keeps_alnum(self):
+        assert paths.safe_label("Hypnotize_03") == "Hypnotize_03"
+
+    def test_strips_unsafe_runs(self):
+        assert paths.safe_label("My / Pack #1") == "My_Pack_1"
+
+    def test_collapses_dashes(self):
+        # dashes are safe so they pass through, only "unsafe runs" collapse
+        assert paths.safe_label("a-b-c") == "a-b-c"
+
+    def test_dots_safe(self):
+        assert paths.safe_label("v1.2.3") == "v1.2.3"
+
+    def test_trims_leading_trailing_underscores(self):
+        assert paths.safe_label("___wat___") == "wat"
+
+    def test_empty_falls_back(self):
+        assert paths.safe_label("") == "library"
+        assert paths.safe_label(None) == "library"
+        assert paths.safe_label("///") == "library"
+
+
+class TestPathHash:
+    def test_eight_chars(self):
+        h = paths.path_hash("/foo/bar")
+        assert len(h) == 8
+        # all hex
+        int(h, 16)
+
+    def test_stable_across_calls(self):
+        a = paths.path_hash("/foo/bar")
+        b = paths.path_hash("/foo/bar")
+        assert a == b
+
+    def test_distinguishes_paths(self):
+        a = paths.path_hash("/foo/bar")
+        b = paths.path_hash("/foo/baz")
+        assert a != b
+
+    def test_normalizes_input(self):
+        # equal-after-normalization paths should produce equal hashes
+        a = paths.path_hash("/foo/bar")
+        b = paths.path_hash("/foo/bar/")  # trailing slash
+        assert a == b
+
+
+class TestCentralDbPathFor:
+    def test_lives_in_libraries_dir(self):
+        p = paths.central_db_path_for("/foo/Hypnotize", "hypnotize")
+        assert p.startswith(paths.central_libraries_dir() + "/")
+        assert p.endswith(".db")
+
+    def test_label_and_hash_in_filename(self):
+        p = paths.central_db_path_for("/foo/Hypnotize", "hypnotize")
+        name = os.path.basename(p)
+        assert name.startswith("hypnotize_")
+        assert len(name) == len("hypnotize_") + 8 + len(".db")
+
+    def test_unsafe_label_sanitized(self):
+        p = paths.central_db_path_for("/foo/x", "weird name / with junk")
+        name = os.path.basename(p)
+        assert "/" not in name
+        assert " " not in name
+
+
+class TestInTreeDbPathFor:
+    def test_inside_root(self):
+        p = paths.in_tree_db_path_for("/foo/Hypnotize")
+        assert p.startswith("/foo/Hypnotize/" if os.name != "nt"
+                            else paths.normalize("/foo/Hypnotize") + "/")
+        assert p.endswith("/.acidcat/index.db")
+
+
+class TestRegistryPathResolution:
+    def test_default_under_home(self, monkeypatch):
+        # cli/env both unset
+        p = paths.resolve_registry_path()
+        assert p.endswith("/.acidcat/registry.db")
+
+    def test_env_overrides_default(self, monkeypatch, tmp_path):
+        custom = str(tmp_path / "alt.db")
+        monkeypatch.setenv("ACIDCAT_REGISTRY", custom)
+        assert paths.resolve_registry_path() == custom
+
+    def test_cli_overrides_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ACIDCAT_REGISTRY", str(tmp_path / "from_env.db"))
+        cli = str(tmp_path / "from_cli.db")
+        assert paths.resolve_registry_path(cli) == cli
+
+
+class TestLegacyDetection:
+    def test_path_format(self):
+        # not asserting existence; this is a deterministic path
+        assert paths.legacy_global_db_path().endswith("/.acidcat/index.db")
+
+
+class TestFindLibraryRootAbove:
+    def test_returns_none_when_no_in_tree_db(self, tmp_path):
+        f = tmp_path / "x.wav"
+        f.write_bytes(b"")
+        assert paths.find_library_root_above(str(f)) is None
+
+    def test_finds_in_tree_db(self, tmp_path):
+        lib = tmp_path / "lib"
+        (lib / paths.ACIDCAT_DIR_NAME).mkdir(parents=True)
+        (lib / paths.ACIDCAT_DIR_NAME / paths.INDEX_DB_NAME).write_bytes(b"")
+        sub = lib / "drums"
+        sub.mkdir()
+        sample = sub / "kick.wav"
+        sample.write_bytes(b"")
+        result = paths.find_library_root_above(str(sample))
+        assert result == paths.normalize(str(lib))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,185 +1,204 @@
-"""Tests for `acidcat query` -- filtering over the SQLite index."""
+"""Tests for `acidcat query` over the per-library + registry layout."""
 
 import io
+import json
 import time
 
 import pytest
 
 from acidcat.commands import query as query_cmd
 from acidcat.core import index as idx
+from acidcat.core import paths as acidpaths
+from acidcat.core import registry as reg
 
 
 class _Args:
     def __init__(self, **kw):
         defaults = {
-            "db": None,
-            "bpm": None, "key": None, "duration": None, "tag": [],
-            "file_format": None, "text": None, "root": None,
-            "limit": 50,
-            "output_format": "json",
-            "output": None,
-            "paths_only": False,
+            "registry": None, "bpm": None, "key": None, "duration": None,
+            "tag": [], "file_format": None, "text": None, "root": None,
+            "limit": 50, "output_format": "json", "output": None,
+            "paths_only": False, "verbose": False,
         }
         defaults.update(kw)
         for k, v in defaults.items():
             setattr(self, k, v)
 
 
-ROOT_A = idx.normalize_path("/tmp/lib/a")
-ROOT_B = idx.normalize_path("/tmp/lib/b")
-P_KICK = ROOT_A + "/kick_120.wav"
-P_HAT = ROOT_A + "/hat_128.wav"
-P_SYNTH = ROOT_B + "/synth_124.flac"
+@pytest.fixture
+def two_library_setup(tmp_path, monkeypatch):
+    """Build two real libraries on disk with seeded sample rows.
 
+    Returns dict with: registry_path, lib_a_root, lib_b_root, paths.
+    """
+    monkeypatch.setenv("ACIDCAT_REGISTRY",
+                       str(tmp_path / "registry.db"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
 
-def _seed(db_path):
-    conn = idx.open_db(db_path)
+    lib_a_root = tmp_path / "libA"
+    lib_a_root.mkdir()
+    lib_b_root = tmp_path / "libB"
+    lib_b_root.mkdir()
+
+    a_root_str = acidpaths.normalize(str(lib_a_root))
+    b_root_str = acidpaths.normalize(str(lib_b_root))
+    p_kick = a_root_str + "/kick_120.wav"
+    p_hat = a_root_str + "/hat_128.wav"
+    p_synth = b_root_str + "/synth_124.flac"
+
+    # register both libraries
+    rconn = reg.open_registry()
+    try:
+        db_a = acidpaths.central_db_path_for(a_root_str, "A")
+        db_b = acidpaths.central_db_path_for(b_root_str, "B")
+        reg.register_library(rconn, a_root_str, label="A", db_path=db_a)
+        reg.register_library(rconn, b_root_str, label="B", db_path=db_b)
+    finally:
+        rconn.close()
+
+    # seed each library's DB
     now = time.time()
-    rows = [
-        {
-            "path": P_KICK, "scan_root": ROOT_A,
-            "format": "wav", "duration": 1.2, "bpm": 120.0, "key": "C",
-            "title": "kick one", "artist": None, "album": None,
-            "genre": None, "comment": "booming sub", "mtime": now,
-            "size": 100, "indexed_at": now, "last_seen_at": now,
-            "chunks": "acid,smpl",
-            "acid_beats": 4, "root_note": 60,
-            "sample_rate": 44100, "channels": 1, "bits_per_sample": 16,
-        },
-        {
-            "path": P_HAT, "scan_root": ROOT_A,
-            "format": "wav", "duration": 0.5, "bpm": 128.0, "key": "Am",
-            "title": "closed hat", "artist": None, "album": None,
-            "genre": None, "comment": None, "mtime": now,
-            "size": 100, "indexed_at": now, "last_seen_at": now,
-            "chunks": None, "acid_beats": None, "root_note": None,
-            "sample_rate": None, "channels": None, "bits_per_sample": None,
-        },
-        {
-            "path": P_SYNTH, "scan_root": ROOT_B,
-            "format": "flac", "duration": 8.0, "bpm": 124.0, "key": "Fm",
-            "title": "dusty synth", "artist": "someone",
-            "album": "dust pack", "genre": "electronic",
-            "comment": "warm and lofi", "mtime": now,
-            "size": 200, "indexed_at": now, "last_seen_at": now,
-            "chunks": None, "acid_beats": None, "root_note": None,
-            "sample_rate": 44100, "channels": 2, "bits_per_sample": 16,
-        },
+    a_rows = [
+        {"path": p_kick, "scan_root": a_root_str, "format": "wav",
+         "duration": 1.2, "bpm": 120.0, "key": "C",
+         "title": "kick one", "comment": "booming sub",
+         "mtime": now, "size": 100, "indexed_at": now, "last_seen_at": now,
+         "chunks": "acid,smpl", "acid_beats": 4, "root_note": 60,
+         "sample_rate": 44100, "channels": 1, "bits_per_sample": 16,
+         "artist": None, "album": None, "genre": None},
+        {"path": p_hat, "scan_root": a_root_str, "format": "wav",
+         "duration": 0.5, "bpm": 128.0, "key": "Am",
+         "title": "closed hat", "mtime": now, "size": 100,
+         "indexed_at": now, "last_seen_at": now,
+         "artist": None, "album": None, "genre": None, "comment": None,
+         "chunks": None, "acid_beats": None, "root_note": None,
+         "sample_rate": None, "channels": None, "bits_per_sample": None},
     ]
-    for r in rows:
-        idx.upsert_sample(conn, r)
+    b_rows = [
+        {"path": p_synth, "scan_root": b_root_str, "format": "flac",
+         "duration": 8.0, "bpm": 124.0, "key": "Fm",
+         "title": "dusty synth", "artist": "someone",
+         "album": "dust pack", "genre": "electronic",
+         "comment": "warm and lofi",
+         "mtime": now, "size": 200, "indexed_at": now, "last_seen_at": now,
+         "chunks": None, "acid_beats": None, "root_note": None,
+         "sample_rate": 44100, "channels": 2, "bits_per_sample": 16},
+    ]
 
-    idx.upsert_tags(conn, P_KICK, ["drums", "kick", "punchy"])
-    idx.upsert_tags(conn, P_HAT, ["drums", "hat"])
-    idx.upsert_tags(conn, P_SYNTH, ["synth", "pad"])
+    conn_a = idx.open_db(db_a)
+    try:
+        for r in a_rows:
+            idx.upsert_sample(conn_a, r)
+        idx.upsert_tags(conn_a, p_kick, ["drums", "kick", "punchy"])
+        idx.upsert_tags(conn_a, p_hat, ["drums", "hat"])
+        conn_a.commit()
+    finally:
+        conn_a.close()
 
-    idx.record_scan_root(conn, ROOT_A, 2, now)
-    idx.record_scan_root(conn, ROOT_B, 1, now)
+    conn_b = idx.open_db(db_b)
+    try:
+        for r in b_rows:
+            idx.upsert_sample(conn_b, r)
+        idx.upsert_tags(conn_b, p_synth, ["synth", "pad"])
+        conn_b.commit()
+    finally:
+        conn_b.close()
 
-    conn.commit()
-    conn.close()
-
-
-def test_bpm_range(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-
-    rows = _run(db, bpm="120:125")
-    paths = {r["path"] for r in rows}
-    assert paths == {P_KICK, P_SYNTH}
-
-
-def test_bpm_exact(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, bpm="128")
-    assert len(rows) == 1
-    assert rows[0]["bpm"] == 128.0
-
-
-def test_duration_range(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, duration=":1")
-    assert len(rows) == 1
-    assert rows[0]["path"] == P_HAT
-
-
-def test_key_filter(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, key="am")
-    assert len(rows) == 1
-    assert rows[0]["path"] == P_HAT
+    return {
+        "lib_a_root": a_root_str,
+        "lib_b_root": b_root_str,
+        "P_KICK": p_kick,
+        "P_HAT": p_hat,
+        "P_SYNTH": p_synth,
+    }
 
 
-def test_format_filter(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, file_format="flac")
-    assert len(rows) == 1
-
-
-def test_tag_filter_and(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, tag=["drums"])
-    paths = {r["path"] for r in rows}
-    assert paths == {P_KICK, P_HAT}
-
-    rows = _run(db, tag=["drums", "kick"])
-    assert len(rows) == 1
-    assert rows[0]["path"] == P_KICK
-
-
-def test_root_filter(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, root=ROOT_A)
-    assert len(rows) == 2
-    rows = _run(db, root=ROOT_B)
-    assert len(rows) == 1
-
-
-def test_text_fts(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-
-    rows = _run(db, text="dusty")
-    assert len(rows) == 1
-    assert rows[0]["path"] == P_SYNTH
-
-    rows = _run(db, text="punchy")
-    assert len(rows) == 1
-    assert rows[0]["path"] == P_KICK
-
-    rows = _run(db, text="synth")
-    paths = {r["path"] for r in rows}
-    assert paths == {P_SYNTH}
-
-
-def test_limit(tmp_path):
-    db = tmp_path / "q.db"
-    _seed(str(db))
-    rows = _run(db, limit=1)
-    assert len(rows) == 1
-
-
-def test_no_index_returns_error(tmp_path, capsys):
-    args = _Args(db=str(tmp_path / "nope.db"))
-    rc = query_cmd.run(args)
-    assert rc == 1
-
-
-def _run(db, **kwargs):
-    buf = io.StringIO()
-    args = _Args(db=str(db), output_format="json", **kwargs)
-    # capture to a buffer via the output arg path
-    out_file = str(db) + ".out.json"
-    args.output = out_file
+def _run(args):
+    """Run the query command capturing stdout to JSON."""
+    args.output_format = "json"
+    args.output = "/tmp/_acidcat_query_test.json"  # any tmp path
+    import os
+    if os.path.isfile(args.output):
+        os.remove(args.output)
     rc = query_cmd.run(args)
     assert rc == 0
-    import json
-    with open(out_file, "r", encoding="utf-8") as f:
+    with open(args.output, "r", encoding="utf-8") as f:
         data = json.load(f)
     return data if isinstance(data, list) else [data]
+
+
+class TestFanOut:
+    def test_no_filter_returns_all(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(output=out_file))
+        paths = {r["path"] for r in rows}
+        assert two_library_setup["P_KICK"] in paths
+        assert two_library_setup["P_HAT"] in paths
+        assert two_library_setup["P_SYNTH"] in paths
+
+    def test_bpm_range_across_libs(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(bpm="120:125", output=out_file))
+        paths = {r["path"] for r in rows}
+        assert paths == {two_library_setup["P_KICK"],
+                          two_library_setup["P_SYNTH"]}
+
+    def test_text_fts_finds_in_one_lib(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(text="dusty", output=out_file))
+        assert len(rows) == 1
+        assert rows[0]["path"] == two_library_setup["P_SYNTH"]
+
+
+class TestRootScoping:
+    def test_root_by_label(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(root="A", output=out_file))
+        paths = {r["path"] for r in rows}
+        assert two_library_setup["P_SYNTH"] not in paths
+        assert two_library_setup["P_KICK"] in paths
+
+    def test_root_by_path(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(root=two_library_setup["lib_b_root"],
+                          output=out_file))
+        paths = {r["path"] for r in rows}
+        assert paths == {two_library_setup["P_SYNTH"]}
+
+    def test_root_csv_multi(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(root="A,B", output=out_file))
+        assert len(rows) == 3
+
+    def test_root_unknown_label_returns_error(self, two_library_setup):
+        rc = query_cmd.run(_Args(root="ZZZZ"))
+        assert rc == 1
+
+
+class TestTagFilter:
+    def test_single_tag_in_one_lib(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(tag=["synth"], output=out_file))
+        paths = {r["path"] for r in rows}
+        assert paths == {two_library_setup["P_SYNTH"]}
+
+    def test_and_semantics(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(tag=["drums", "kick"], output=out_file))
+        assert len(rows) == 1
+        assert rows[0]["path"] == two_library_setup["P_KICK"]
+
+
+class TestNoLibraries:
+    def test_no_libs_registered_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ACIDCAT_REGISTRY", str(tmp_path / "empty.db"))
+        rc = query_cmd.run(_Args())
+        assert rc == 1
+
+
+class TestLimit:
+    def test_global_limit_applied(self, two_library_setup, tmp_path):
+        out_file = str(tmp_path / "out.json")
+        rows = _run(_Args(limit=2, output=out_file))
+        assert len(rows) == 2

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,260 @@
+"""Tests for core/registry.py."""
+
+import os
+import time
+
+import pytest
+
+from acidcat.core import paths, registry as reg
+
+
+@pytest.fixture
+def reg_conn(tmp_path, monkeypatch):
+    """Open a registry inside tmp_path so tests cannot collide with each other
+    or with the user's real registry."""
+    monkeypatch.setenv("ACIDCAT_REGISTRY", str(tmp_path / "registry.db"))
+    conn = reg.open_registry()
+    yield conn
+    conn.close()
+
+
+def _mkroot(tmp_path, name):
+    """Create a real directory under tmp_path so paths.normalize survives."""
+    d = tmp_path / name
+    d.mkdir()
+    return paths.normalize(str(d))
+
+
+def _mkdb(tmp_path, root, label):
+    """Pretend the per-lib DB file exists at the central path so list_libraries
+    only_existing=True returns the row."""
+    db = paths.central_db_path_for(root, label)
+    os.makedirs(os.path.dirname(db), exist_ok=True)
+    open(db, "wb").close()
+    return db
+
+
+class TestSchemaCreation:
+    def test_meta_table_seeded(self, reg_conn):
+        row = reg_conn.execute(
+            "SELECT v FROM meta WHERE k = 'schema_version'"
+        ).fetchone()
+        assert row["v"] == str(reg.REGISTRY_SCHEMA_VERSION)
+
+    def test_libraries_table_exists(self, reg_conn):
+        rows = reg_conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        names = {r["name"] for r in rows}
+        assert "libraries" in names
+
+
+class TestRegister:
+    def test_basic(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "lib_a")
+        db = paths.central_db_path_for(root, "lib_a")
+        reg.register_library(reg_conn, root, label="lib_a", db_path=db)
+        rows = reg.list_libraries(reg_conn)
+        assert len(rows) == 1
+        assert rows[0]["root_path"] == root
+        assert rows[0]["label"] == "lib_a"
+        assert rows[0]["in_tree"] == 0
+
+    def test_in_tree_flag(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "intree")
+        db = paths.in_tree_db_path_for(root)
+        reg.register_library(reg_conn, root, label="intree",
+                             db_path=db, in_tree=True)
+        row = reg.list_libraries(reg_conn)[0]
+        assert row["in_tree"] == 1
+
+    def test_label_is_required(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "x")
+        db = paths.central_db_path_for(root, "x")
+        with pytest.raises(ValueError):
+            reg.register_library(reg_conn, root, label=None, db_path=db)
+        with pytest.raises(ValueError):
+            reg.register_library(reg_conn, root, label="", db_path=db)
+
+    def test_idempotent_re_register_preserves_created_at(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "x")
+        db = paths.central_db_path_for(root, "x")
+        reg.register_library(reg_conn, root, label="x", db_path=db)
+        first = reg_conn.execute(
+            "SELECT created_at, last_seen_at FROM libraries WHERE root_path = ?",
+            (root,),
+        ).fetchone()
+        time.sleep(0.01)
+        reg.register_library(reg_conn, root, label="x", db_path=db)
+        second = reg_conn.execute(
+            "SELECT created_at, last_seen_at FROM libraries WHERE root_path = ?",
+            (root,),
+        ).fetchone()
+        assert first["created_at"] == second["created_at"]
+        assert second["last_seen_at"] >= first["last_seen_at"]
+
+
+class TestOverlapRejection:
+    def test_child_of_existing_rejected(self, reg_conn, tmp_path):
+        parent = _mkroot(tmp_path, "parent")
+        (tmp_path / "parent" / "child").mkdir()
+        child = paths.normalize(str(tmp_path / "parent" / "child"))
+        reg.register_library(
+            reg_conn, parent, label="parent",
+            db_path=paths.central_db_path_for(parent, "parent"),
+        )
+        with pytest.raises(reg.OverlapError) as excinfo:
+            reg.register_library(
+                reg_conn, child, label="child",
+                db_path=paths.central_db_path_for(child, "child"),
+            )
+        assert "parent" in str(excinfo.value)
+
+    def test_parent_of_existing_rejected(self, reg_conn, tmp_path):
+        (tmp_path / "p" / "child").mkdir(parents=True)
+        parent = paths.normalize(str(tmp_path / "p"))
+        child = paths.normalize(str(tmp_path / "p" / "child"))
+        reg.register_library(
+            reg_conn, child, label="child",
+            db_path=paths.central_db_path_for(child, "child"),
+        )
+        with pytest.raises(reg.OverlapError):
+            reg.register_library(
+                reg_conn, parent, label="parent",
+                db_path=paths.central_db_path_for(parent, "parent"),
+            )
+
+    def test_exact_match_is_allowed(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "x")
+        db = paths.central_db_path_for(root, "x")
+        reg.register_library(reg_conn, root, label="x", db_path=db)
+        # exact re-register of the same root: not an overlap
+        reg.register_library(reg_conn, root, label="x", db_path=db)
+        assert len(reg.list_libraries(reg_conn)) == 1
+
+    def test_sibling_paths_allowed(self, reg_conn, tmp_path):
+        a = _mkroot(tmp_path, "a")
+        b = _mkroot(tmp_path, "b")
+        reg.register_library(reg_conn, a, label="a",
+                             db_path=paths.central_db_path_for(a, "a"))
+        reg.register_library(reg_conn, b, label="b",
+                             db_path=paths.central_db_path_for(b, "b"))
+        assert len(reg.list_libraries(reg_conn)) == 2
+
+
+class TestUpdateStats:
+    def test_updates_counts(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "x")
+        reg.register_library(
+            reg_conn, root, label="x",
+            db_path=paths.central_db_path_for(root, "x"),
+        )
+        reg.update_stats(reg_conn, root, sample_count=42, feature_count=10,
+                         last_indexed_at=12345.0)
+        row = reg.list_libraries(reg_conn)[0]
+        assert row["sample_count"] == 42
+        assert row["feature_count"] == 10
+        assert row["last_indexed_at"] == 12345.0
+
+
+class TestForgetAndGet:
+    def test_forget_by_label(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "lab")
+        reg.register_library(
+            reg_conn, root, label="lab",
+            db_path=paths.central_db_path_for(root, "lab"),
+        )
+        n = reg.forget_library(reg_conn, "lab")
+        assert n == 1
+        assert reg.get_library(reg_conn, "lab") is None
+
+    def test_forget_by_root(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "byroot")
+        reg.register_library(
+            reg_conn, root, label="byroot",
+            db_path=paths.central_db_path_for(root, "byroot"),
+        )
+        n = reg.forget_library(reg_conn, root)
+        assert n == 1
+
+    def test_forget_unknown_returns_zero(self, reg_conn):
+        assert reg.forget_library(reg_conn, "nope") == 0
+
+    def test_get_by_label(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "g1")
+        reg.register_library(
+            reg_conn, root, label="g1",
+            db_path=paths.central_db_path_for(root, "g1"),
+        )
+        row = reg.get_library(reg_conn, "g1")
+        assert row is not None
+        assert row["root_path"] == root
+
+    def test_get_by_root(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "g2")
+        reg.register_library(
+            reg_conn, root, label="g2",
+            db_path=paths.central_db_path_for(root, "g2"),
+        )
+        assert reg.get_library(reg_conn, root) is not None
+
+
+class TestListAndOrphans:
+    def test_only_existing_filters_out_missing_db(self, reg_conn, tmp_path):
+        root_real = _mkroot(tmp_path, "real")
+        _mkdb(tmp_path, root_real, "real")
+        reg.register_library(
+            reg_conn, root_real, label="real",
+            db_path=paths.central_db_path_for(root_real, "real"),
+        )
+        # second library: register but do NOT create the DB file
+        root_orphan = _mkroot(tmp_path, "orphan")
+        reg.register_library(
+            reg_conn, root_orphan, label="orphan",
+            db_path=paths.central_db_path_for(root_orphan, "orphan"),
+        )
+        all_rows = reg.list_libraries(reg_conn, only_existing=False)
+        existing = reg.list_libraries(reg_conn, only_existing=True)
+        assert len(all_rows) == 2
+        assert len(existing) == 1
+        assert existing[0]["label"] == "real"
+
+    def test_find_orphans_returns_only_orphans(self, reg_conn, tmp_path):
+        root_real = _mkroot(tmp_path, "real")
+        _mkdb(tmp_path, root_real, "real")
+        reg.register_library(
+            reg_conn, root_real, label="real",
+            db_path=paths.central_db_path_for(root_real, "real"),
+        )
+        root_orphan = _mkroot(tmp_path, "orphan")
+        reg.register_library(
+            reg_conn, root_orphan, label="orphan",
+            db_path=paths.central_db_path_for(root_orphan, "orphan"),
+        )
+        orphans = reg.find_orphans(reg_conn)
+        assert len(orphans) == 1
+        assert orphans[0]["label"] == "orphan"
+
+
+class TestFindLibraryForPath:
+    def test_returns_none_when_path_outside_all_libs(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "lib1")
+        reg.register_library(
+            reg_conn, root, label="lib1",
+            db_path=paths.central_db_path_for(root, "lib1"),
+        )
+        outside = _mkroot(tmp_path, "outside")
+        assert reg.find_library_for_path(reg_conn, outside + "/x.wav") is None
+
+    def test_finds_containing_lib(self, reg_conn, tmp_path):
+        root = _mkroot(tmp_path, "lib1")
+        sub = tmp_path / "lib1" / "drums"
+        sub.mkdir()
+        reg.register_library(
+            reg_conn, root, label="lib1",
+            db_path=paths.central_db_path_for(root, "lib1"),
+        )
+        sample = paths.normalize(str(sub / "kick.wav"))
+        result = reg.find_library_for_path(reg_conn, sample)
+        assert result is not None
+        assert result["label"] == "lib1"


### PR DESCRIPTION
Replaces the single ~/.acidcat/index.db with per-library DBs at ~/.acidcat/libraries/<label>_<hash>.db (default), tracked in a small global registry at ~/.acidcat/registry.db. Reads fan out across every registered library; writes route to the innermost containing library.

Each library is registered once via `acidcat index DIR --label NAME` and gets its own SQLite. The registry stores root_path, label, in_tree mode, sample_count, last_indexed_at, and schema_version per library.

new modules
  core/paths.py        path layout helpers: central vs in-tree DB
                       location, label slug + 8-char path hash, registry
                       path resolution, find_library_root_above for
                       in-tree detection. Skips the user home dir so the
                       legacy ~/.acidcat/index.db is not mistaken for an
                       in-tree library root.
  core/registry.py     CRUD over the libraries table: register_library
                       with no-overlap guard (rejects ==/parent-of/
                       child-of an existing root), update_stats,
                       forget_library, get_library, list_libraries with
                       optional only_existing filter, find_orphans,
                       find_library_for_path with longest-prefix match.
                       Mandatory non-null label.

reworked
  commands/index.py    CLI: `acidcat index DIR [--label] [--in-tree]
                       [--rebuild] [--features] [--deep] [--import-tags]`,
                       plus registry subcommands `--list`, `--orphans`,
                       `--stats`, `--forget`, `--remove`. Resolves
                       central vs in-tree DB path, validates non-overlap
                       up front, walks via existing _walk_and_upsert
                       (unchanged), refreshes registry stats post-walk.
                       Drops legacy `--db`, `--list-roots`,
                       `--remove-root`. One-line stderr warning when the
                       v0.4 ~/.acidcat/index.db is detected.
  commands/query.py    Default fan-out across `list_libraries(only_existing=True)`.
                       --root accepts label, absolute path, or
                       comma-separated mix. Per-library LIMIT then final
                       cap on the merged result. Drops --db.
  mcp_server.py        Replaces _DB_PATH global with _REGISTRY_PATH.
                       New helpers: _open_all_libraries (sorted deepest-
                       root-first for dedup), _open_owning_library
                       (registry lookup with brute-force fallback),
                       _scope_libraries, _close_all, _dedup_by_path.
                       Every fast tool fans out and returns library_label
                       on each row. Every owning-library tool (get_sample,
                       find_compatible, tag_sample, describe_sample)
                       routes to the right per-lib DB. New tools:
                       list_libraries, register_library (destructive),
                       forget_library (destructive). Drops list_roots
                       and the --db arg from main(). 18 tools total.
  locate_sample fix    Substring match anywhere in the path. Old
                       "%/<name>%" pattern silently failed for searches
                       that landed mid-filename ("Kick_Wet" inside
                       "PL_Hypnotize_03_126_Kick_Wet.wav" never had a
                       /Kick_Wet substring to anchor against).
  conftest.py          Autouse fixture stripping ACIDCAT_DB and
                       ACIDCAT_REGISTRY from os.environ so a dev shell
                       cannot poison test isolation.

tests
  +43 new across test_paths.py (path helpers), test_registry.py (CRUD,
  overlap rejection, orphan filtering, longest-prefix path lookup),
  rewritten test_index.py (per-library layout, --rebuild, --forget vs
  --remove, --orphans, SMPL=0 still treated as unset), rewritten
  test_query.py (fan-out across two libs, --root by label/path/CSV),
  rewritten test_mcp_server.py (every fast tool fan-out, registry
  mutations, locate substring regression). 202 passed.

upgrade impact
  Breaking change: legacy ~/.acidcat/index.db is no longer used.
  Existing data was test-only per user, so no migration code is shipped.
  The startup warning surfaces the legacy file once; remove it manually
  with `rm ~/.acidcat/index.db*` when ready, then re-register libraries
  via `acidcat index DIR --label NAME`.