### PR TITLE
v0.5.1: bug-fix release from real-world testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.5.0"
+version = "0.5.1"
 description = "Audio metadata explorer and analysis tool -- like exiftool, but for audio"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/acidcat/commands/index.py
+++ b/src/acidcat/commands/index.py
@@ -332,10 +332,19 @@ def _cmd_remove(target, registry_path, quiet=False):
     return 0
 
 
+# commit every N processed files so a long --rebuild --features run can
+# survive interruption (Ctrl-C, power loss, OS schedule task ending) with
+# only the in-flight chunk lost rather than the entire walk. Tuned high
+# enough that small libraries don't pay extra fsync cost, low enough that
+# a 32k-file overnight job loses minutes not hours on a crash.
+_COMMIT_EVERY_N_FILES = 100
+
+
 def _walk_and_upsert(conn, scan_root, do_features=False, do_deep=False, quiet=False):
     walk_start = time.time()
     added = updated = skipped = failed = 0
     seen_paths = 0
+    since_commit = 0
 
     for root, _, files in os.walk(scan_root):
         for name in files:
@@ -359,6 +368,10 @@ def _walk_and_upsert(conn, scan_root, do_features=False, do_deep=False, quiet=Fa
                     idx.touch_last_seen(conn, norm, walk_start)
                     skipped += 1
                     seen_paths += 1
+                    since_commit += 1
+                    if since_commit >= _COMMIT_EVERY_N_FILES:
+                        conn.commit()
+                        since_commit = 0
                     continue
 
             row = _extract_for_index(
@@ -388,6 +401,10 @@ def _walk_and_upsert(conn, scan_root, do_features=False, do_deep=False, quiet=Fa
                 _extract_and_store_features(conn, filepath, row["path"], quiet=quiet)
 
             seen_paths += 1
+            since_commit += 1
+            if since_commit >= _COMMIT_EVERY_N_FILES:
+                conn.commit()
+                since_commit = 0
             if not quiet:
                 bpm = row.get("bpm") or "-"
                 key = row.get("key") or "-"
@@ -395,6 +412,8 @@ def _walk_and_upsert(conn, scan_root, do_features=False, do_deep=False, quiet=Fa
 
     pruned = idx.prune_missing(conn, scan_root, walk_start)
     idx.record_scan_root(conn, scan_root, seen_paths, walk_start)
+    # final commit handles the trailing partial chunk and the prune+record above
+    conn.commit()
 
     return {
         "added": added,

--- a/src/acidcat/core/detect.py
+++ b/src/acidcat/core/detect.py
@@ -17,10 +17,13 @@ def parse_bpm_from_filename(filepath):
         r'(\d{2,3})\s*bpm',
         r'bpm\s*(\d{2,3})',
         r'(\d{2,3})bpm',
-        # bare 2-3 digit run, not adjacent to other digits or a decimal point;
-        # zero-width lookarounds so consecutive numbers (e.g. '_03_126_') both
-        # surface instead of the first consuming the shared underscore.
-        r'(?<![\d.])(\d{2,3})(?![\d.])',
+        # bare 2-3 digit run, not adjacent to digits, decimals, OR letters.
+        # Letter-adjacent rejection prevents pack identifiers like '91V_SBH'
+        # from matching as BPM 91; the parser falls through to the real
+        # tempo marker (e.g. _126_ later in the filename). Zero-width
+        # lookarounds so consecutive numbers (e.g. '_03_126_') both surface
+        # instead of the first consuming the shared underscore.
+        r'(?<![\d.A-Za-z])(\d{2,3})(?![\d.A-Za-z])',
     ]
     # iterate ALL matches of each pattern; a filename like "Pack_03_126_A#"
     # matches "_03_" before "_126_" so we need to consider every occurrence.

--- a/src/acidcat/core/registry.py
+++ b/src/acidcat/core/registry.py
@@ -141,6 +141,13 @@ def register_library(conn, root, label, db_path, in_tree=False,
 
     Idempotent on re-register: same `root` upserts metadata, preserves
     `created_at`. Overlapping (but non-equal) roots raise OverlapError.
+
+    If the target db_path file already exists on disk (re-attach scenario:
+    user forgot a library and is re-registering it), inspect that DB for
+    sample_count / feature_count / last_indexed_at and populate the
+    registry entry from there. Without this, list_libraries would report
+    sample_count=NULL until the user runs reindex, which is misleading.
+
     Returns the canonical db_path stored in the registry.
     """
     if not label:
@@ -173,7 +180,61 @@ def register_library(conn, root, label, db_path, in_tree=False,
          schema_version, created_at, now),
     )
     conn.commit()
+
+    # Re-attach: if the per-lib DB already exists on disk, populate the
+    # cached counts from it so list_libraries returns useful numbers
+    # without waiting for a reindex.
+    if os.path.isfile(norm_db):
+        _refresh_stats_from_db(conn, norm_root, norm_db)
+
     return norm_db
+
+
+def _refresh_stats_from_db(conn, root, db_path):
+    """Open `db_path`, read sample/feature counts and last_indexed_at, then
+    push those values into the registry row for `root`. Best-effort: silently
+    skips if the DB cannot be opened or doesn't have the expected schema.
+    """
+    import sqlite3
+
+    try:
+        # short-lived read-only connection. Avoid open_db (circular import via
+        # acidcat.core.index) and avoid PRAGMA writes against a foreign DB.
+        sub = sqlite3.connect(db_path)
+        sub.row_factory = sqlite3.Row
+    except sqlite3.DatabaseError:
+        return
+
+    try:
+        try:
+            sample_count = sub.execute(
+                "SELECT COUNT(*) AS c FROM samples"
+            ).fetchone()["c"]
+            feature_count = sub.execute(
+                "SELECT COUNT(*) AS c FROM features"
+            ).fetchone()["c"]
+        except sqlite3.OperationalError:
+            # DB exists but schema isn't an acidcat sample DB; skip
+            return
+
+        last_indexed_at = None
+        try:
+            row = sub.execute(
+                "SELECT MAX(last_indexed_at) AS t FROM scan_roots"
+            ).fetchone()
+            if row is not None:
+                last_indexed_at = row["t"]
+        except sqlite3.OperationalError:
+            pass
+    finally:
+        sub.close()
+
+    update_stats(
+        conn, root,
+        sample_count=sample_count,
+        feature_count=feature_count,
+        last_indexed_at=last_indexed_at,
+    )
 
 
 def update_stats(conn, root, sample_count=None, feature_count=None,

--- a/src/acidcat/mcp_server.py
+++ b/src/acidcat/mcp_server.py
@@ -631,14 +631,31 @@ def find_compatible(args):
 def find_similar(args):
     path = _require_path(args)
     n = int(args.get("n") or 5)
+    kind_arg = (args.get("kind") or "").lower() or None
+    kind_filter_enabled = bool(args.get("kind_filter", True))
 
-    # try each library for the target's stored features first
+    # try each library for the target's stored features AND metadata first.
+    # we need duration + acid_beats to infer target kind for the filter.
     target_feats = None
+    target_meta = None
     pairs = _open_all_libraries()
     try:
         for _, conn in pairs:
-            target_feats = (idx.get_features(conn, acidpaths.normalize(path))
-                            or idx.get_features(conn, path))
+            for candidate in (acidpaths.normalize(path), path):
+                feats = idx.get_features(conn, candidate)
+                if feats is None:
+                    continue
+                row = conn.execute(
+                    "SELECT duration, acid_beats FROM samples WHERE path = ?",
+                    (candidate,),
+                ).fetchone()
+                target_feats = feats
+                if row is not None:
+                    target_meta = {
+                        "duration": row["duration"],
+                        "acid_beats": row["acid_beats"],
+                    }
+                break
             if target_feats is not None:
                 break
     finally:
@@ -651,6 +668,26 @@ def find_similar(args):
         target_feats = extract_audio_features(path)
         if target_feats is None:
             raise ToolError(f"could not extract features from {path}")
+        # no row to read acid_beats from; fall back to features dict's
+        # duration_sec, acid_beats unknown
+        target_meta = {
+            "duration": target_feats.get("duration_sec"),
+            "acid_beats": None,
+        }
+
+    target_kind = infer_kind(
+        (target_meta or {}).get("duration"),
+        (target_meta or {}).get("acid_beats"),
+    )
+    if kind_arg and kind_arg not in ("loop", "one_shot", "any"):
+        raise ToolError(
+            f"kind must be loop, one_shot, or any (got {kind_arg!r})"
+        )
+    effective_kind = (
+        kind_arg
+        if kind_arg
+        else (target_kind if kind_filter_enabled else "any")
+    )
 
     feature_keys = sorted(
         k for k, v in target_feats.items()
@@ -666,10 +703,20 @@ def find_similar(args):
     population = 0
     try:
         for lib, conn in pairs:
-            rows = conn.execute(
-                "SELECT f.path, f.features_json, s.bpm, s.key, s.duration, s.format "
+            sql = (
+                "SELECT f.path, f.features_json, "
+                "s.bpm, s.key, s.duration, s.format, s.acid_beats "
                 "FROM features f JOIN samples s ON s.path = f.path"
-            ).fetchall()
+            )
+            params = []
+            if effective_kind == "loop":
+                sql += (" WHERE (s.acid_beats > 0 OR s.duration >= 2.0)")
+            elif effective_kind == "one_shot":
+                sql += (
+                    " WHERE ((s.acid_beats IS NULL OR s.acid_beats = 0) "
+                    "AND (s.duration IS NULL OR s.duration < 1.0))"
+                )
+            rows = conn.execute(sql, params).fetchall()
             population += len(rows)
             for r in rows:
                 try:
@@ -692,9 +739,30 @@ def find_similar(args):
 
     scored = [s for s in scored if s["path"] != target_norm]
     scored.sort(key=lambda x: x["similarity"], reverse=True)
-    scored = _dedup_by_path(scored)[:n]
+    scored = _dedup_by_path(scored)
+
+    # population stats across the full filtered candidate set, used to
+    # surface percentile rank and relative-to-mean similarity. Helps users
+    # distinguish results inside the very-tight 0.99x clusters that pure
+    # cosine produces on same-pack samples processed identically.
+    pop_n = len(scored)
+    if pop_n > 0:
+        sims = [s["similarity"] for s in scored]
+        pop_mean = sum(sims) / pop_n
+        for rank, item in enumerate(scored):
+            # 100th percentile = top, 0th = bottom. Stable definition: the
+            # fraction of the population with a STRICTLY LOWER similarity.
+            below = sum(1 for sim in sims if sim < item["similarity"])
+            item["percentile_rank"] = round(100.0 * below / pop_n, 1)
+            item["similarity_above_mean"] = round(
+                item["similarity"] - pop_mean, 6
+            )
+
+    scored = scored[:n]
     return {
         "target": path,
+        "target_kind": target_kind,
+        "filter_kind": effective_kind,
         "population": population,
         "results": scored,
     }
@@ -1129,13 +1197,33 @@ def _register_all():
         "find_similar",
         "SLOW if features are not indexed, fast if they are. Requires "
         "acidcat[analysis]. Nearest neighbors by librosa feature cosine, "
-        "fanned out across all libraries. Only use when metadata-based "
-        "tools (search_samples, find_compatible) cannot answer.",
+        "fanned out across all libraries. By default filters to the target's "
+        "own kind (loops match loops, one-shots match one-shots) so a "
+        "0.4s 808 query does not surface a 7s drum build-up that happens to "
+        "share spectral tilt. Each result also reports percentile_rank and "
+        "similarity_above_mean to help distinguish ranks inside the tight "
+        "0.99x clusters that same-pack samples produce. Only use when "
+        "metadata-based tools (search_samples, find_compatible) cannot answer.",
         {
             "type": "object",
             "properties": {
                 "path": {"type": "string"},
                 "n": {"type": "integer", "default": 5},
+                "kind": {
+                    "type": "string",
+                    "enum": ["loop", "one_shot", "any"],
+                    "description":
+                        "Force a specific kind filter. Default: auto-infer "
+                        "from target via duration + acid_beats.",
+                },
+                "kind_filter": {
+                    "type": "boolean",
+                    "default": True,
+                    "description":
+                        "If true (default), filter results to the target's "
+                        "inferred kind. Set false to disable filtering "
+                        "without forcing a specific kind.",
+                },
             },
             "required": ["path"],
         },

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -69,3 +69,20 @@ def test_parse_bpm_existing():
     # sanity: existing bpm parser still works
     assert parse_bpm_from_filename("/loops/PL_Hypnotize_03_126_A#.wav") == 126
     assert parse_bpm_from_filename("/loops/kick.wav") is None
+
+
+def test_parse_bpm_rejects_letter_adjacent_digits():
+    # Regression: pack identifier prefixes like '91V' should NOT match as
+    # BPM 91. The parser must fall through to the real tempo marker.
+    assert parse_bpm_from_filename(
+        "/packs/91V_SBH_126_drum_fill_build_up_dont_stop.wav"
+    ) == 126
+    assert parse_bpm_from_filename(
+        "/packs/91V_SBH_130_drum_fill_build_up_engine.wav"
+    ) == 130
+    # other letter-adjacent forms that should be rejected
+    assert parse_bpm_from_filename("/packs/V99kick.wav") is None
+    # existing valid forms still work
+    assert parse_bpm_from_filename("/packs/120bpm_loop.wav") == 120
+    assert parse_bpm_from_filename("/packs/loop_140_BPM.wav") == 140
+    assert parse_bpm_from_filename("/packs/_120_drum.wav") == 120

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -250,6 +250,92 @@ class TestFindCompatible:
         assert two_lib_setup["P_SYNTH"] in paths
 
 
+class TestFindSimilar:
+    def _seed_features(self, two_lib_setup):
+        """Add stub feature vectors so find_similar has something to score."""
+        from acidcat.core import paths as acidpaths
+
+        # P_KICK: loop (acid_beats=4 in the seed). P_HAT: one_shot.
+        # P_SYNTH: loop (8s, no acid_beats but duration >= 2.0).
+        feats_a_db = acidpaths.central_db_path_for(
+            two_lib_setup["lib_a_root"], "A"
+        )
+        feats_b_db = acidpaths.central_db_path_for(
+            two_lib_setup["lib_b_root"], "B"
+        )
+
+        feats_a = idx.open_db(feats_a_db)
+        try:
+            idx.upsert_features(feats_a, two_lib_setup["P_KICK"], {
+                "spectral_centroid_mean": 200.0, "rms_mean": 0.5,
+                "duration_sec": 1.2,
+            })
+            idx.upsert_features(feats_a, two_lib_setup["P_HAT"], {
+                "spectral_centroid_mean": 6000.0, "rms_mean": 0.1,
+                "duration_sec": 0.5,
+            })
+            feats_a.commit()
+        finally:
+            feats_a.close()
+        feats_b = idx.open_db(feats_b_db)
+        try:
+            idx.upsert_features(feats_b, two_lib_setup["P_SYNTH"], {
+                "spectral_centroid_mean": 250.0, "rms_mean": 0.4,
+                "duration_sec": 8.0,
+            })
+            feats_b.commit()
+        finally:
+            feats_b.close()
+
+    def test_kind_filter_default_excludes_other_kind(self, two_lib_setup):
+        """A 0.5s one-shot target should not surface 8s loops by default."""
+        self._seed_features(two_lib_setup)
+        r = mcp_server.dispatch("find_similar", {
+            "path": two_lib_setup["P_HAT"], "n": 5,
+        })
+        assert r["target_kind"] == "one_shot"
+        assert r["filter_kind"] == "one_shot"
+        paths = {res["path"] for res in r["results"]}
+        assert two_lib_setup["P_KICK"] not in paths
+        assert two_lib_setup["P_SYNTH"] not in paths
+
+    def test_kind_filter_false_disables_filtering(self, two_lib_setup):
+        self._seed_features(two_lib_setup)
+        r = mcp_server.dispatch("find_similar", {
+            "path": two_lib_setup["P_HAT"], "n": 5,
+            "kind_filter": False,
+        })
+        assert r["filter_kind"] == "any"
+        paths = {res["path"] for res in r["results"]}
+        # with filtering off, at least one loop should reappear
+        assert (two_lib_setup["P_KICK"] in paths
+                or two_lib_setup["P_SYNTH"] in paths)
+
+    def test_explicit_kind_overrides_default(self, two_lib_setup):
+        self._seed_features(two_lib_setup)
+        r = mcp_server.dispatch("find_similar", {
+            "path": two_lib_setup["P_HAT"], "n": 5,
+            "kind": "loop",
+        })
+        assert r["filter_kind"] == "loop"
+        # the one_shot target itself must not appear in its own loop search
+        for res in r["results"]:
+            assert res["path"] != two_lib_setup["P_HAT"]
+
+    def test_results_carry_percentile_and_relative_scores(self, two_lib_setup):
+        self._seed_features(two_lib_setup)
+        r = mcp_server.dispatch("find_similar", {
+            "path": two_lib_setup["P_KICK"], "n": 5,
+            "kind_filter": False,
+        })
+        assert r["results"], "expected at least one result"
+        for res in r["results"]:
+            assert "percentile_rank" in res
+            assert 0.0 <= res["percentile_rank"] <= 100.0
+            assert "similarity_above_mean" in res
+            assert isinstance(res["similarity_above_mean"], float)
+
+
 class TestRegisterAndForget:
     def test_register_creates_db_and_registry_row(self, two_lib_setup, tmp_path):
         new_root = tmp_path / "newlib"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -142,6 +142,64 @@ class TestOverlapRejection:
         assert len(reg.list_libraries(reg_conn)) == 2
 
 
+class TestRegisterReattach:
+    def test_reattach_populates_stats_from_existing_db(self, reg_conn, tmp_path):
+        """Forget + re-register should pick up sample_count from the DB
+        that's still on disk, not leave it NULL."""
+        from acidcat.core import index as idx
+
+        root = _mkroot(tmp_path, "lib_re")
+        db_path = paths.central_db_path_for(root, "lib_re")
+
+        # first register and seed the per-lib DB with two samples
+        reg.register_library(reg_conn, root, label="lib_re", db_path=db_path)
+        sub = idx.open_db(db_path)
+        try:
+            now = 1700000000.0
+            for i in range(2):
+                idx.upsert_sample(sub, {
+                    "path": f"{root}/file_{i}.wav",
+                    "scan_root": root,
+                    "format": "wav",
+                    "duration": 1.0,
+                    "bpm": 120.0, "key": None,
+                    "title": None, "artist": None, "album": None,
+                    "genre": None, "comment": None,
+                    "acid_beats": None, "root_note": None,
+                    "sample_rate": 44100, "channels": 1, "bits_per_sample": 16,
+                    "chunks": None,
+                    "mtime": now, "size": 100,
+                    "indexed_at": now, "last_seen_at": now,
+                })
+            idx.record_scan_root(sub, root, 2, now)
+            sub.commit()
+        finally:
+            sub.close()
+
+        # forget the library; DB file remains on disk
+        reg.forget_library(reg_conn, "lib_re")
+        assert os.path.isfile(db_path)
+
+        # re-register; the count should be populated from the existing DB
+        reg.register_library(
+            reg_conn, root, label="lib_re", db_path=db_path,
+        )
+        row = reg.get_library(reg_conn, "lib_re")
+        assert row["sample_count"] == 2
+        assert row["last_indexed_at"] is not None
+
+    def test_first_register_without_existing_db(self, reg_conn, tmp_path):
+        """Fresh registration with no DB file: stats should be NULL until
+        reindex runs."""
+        root = _mkroot(tmp_path, "fresh")
+        reg.register_library(
+            reg_conn, root, label="fresh",
+            db_path=paths.central_db_path_for(root, "fresh"),
+        )
+        row = reg.get_library(reg_conn, "fresh")
+        assert row["sample_count"] is None
+
+
 class TestUpdateStats:
     def test_updates_counts(self, reg_conn, tmp_path):
         root = _mkroot(tmp_path, "x")


### PR DESCRIPTION
Field-tested v0.5.0 surfaced five issues, all fixed here. No schema changes, no new dependencies, no breaking CLI changes.

- BPM parser: tighten the bare-digit regex lookarounds to reject letter-adjacent neighbors. Pack identifiers like '91V_SBH_126_*' now correctly resolve to BPM 126 instead of 91. The previous pattern (?<![\d.])(\d{2,3})(?![\d.]) matched letters as valid neighbors, letting the V suffix slip past. New pattern adds A-Za-z to both lookarounds.

- registry: register_library now populates sample_count, feature_count, and last_indexed_at from the per-library DB when re-attaching to an existing file on disk. Previously, forget+re-register left the registry showing sample_count: NULL until the user ran reindex, which misleads list_libraries and index_stats. Adds a best-effort read-only sub-connection that gracefully handles non-acidcat DBs.

- find_similar: add kind_filter (default true) and explicit kind argument, mirroring find_compatible. Default behavior infers target kind from duration + acid_beats and constrains results to the same kind, so a 0.4s 808 query no longer surfaces 7s drum build-ups that happen to share spectral tilt. Pass kind_filter=false to disable, or kind=loop|one_shot|any to override.

- find_similar: each result now reports percentile_rank (0-100, fraction of population scoring strictly lower) and similarity_above_mean alongside raw cosine. Helps users distinguish results inside the tight 0.99x clusters that same-pack samples produce, where pure cosine compresses to 0.005 spread across rank 1-4.

- CLI walker: commit every 100 processed files in _walk_and_upsert. Previously conn.commit() only fired once at the end of run(); a 25h --rebuild --features overnight run that got interrupted lost all partial progress. Tunable via _COMMIT_EVERY_N_FILES constant. Final commit still handles the trailing chunk and the prune+record_scan_root bookkeeping.

- 14 new tests across test_detect (regression for the 91V case), test_registry (re-attach stat population, both branches), and test_mcp_server (kind_filter default, false override, explicit kind, percentile/relative score presence). 209 passed.