### PR TITLE
v0.5.3: CLI safety + post-discover stats + migration helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.5.2"
+version = "0.5.3"
 description = "Audio metadata explorer and analysis tool -- like exiftool, but for audio"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/src/acidcat/commands/index.py
+++ b/src/acidcat/commands/index.py
@@ -85,6 +85,16 @@ def register(subparsers):
                         "its DB file.")
     p.add_argument("--remove", dest="remove",
                    help="Forget a library AND delete its DB file.")
+    p.add_argument("--refresh-stats", dest="refresh_stats",
+                   action="store_true",
+                   help="Read every registered library's DB and refresh the "
+                        "registry's cached sample_count, feature_count, and "
+                        "last_indexed_at. Useful migration step after upgrading "
+                        "from an older version that did not auto-populate "
+                        "these fields.")
+    p.add_argument("--refresh-stats-target", dest="refresh_stats_target",
+                   help="With --refresh-stats: scope to one library by label "
+                        "or path. Default: refresh every registered library.")
     # discovery (walk a tree, register qualifying directories as libraries)
     p.add_argument("--discover", dest="discover_root",
                    help="Walk this directory and register every qualifying "
@@ -126,6 +136,34 @@ def run(args):
     quiet = getattr(args, "quiet", False)
     registry_path = getattr(args, "registry", None)
 
+    # collision check: registry-management flags don't take a positional
+    # target. Silently ignoring the target hides what the user actually
+    # asked for. Surface it instead.
+    mgmt_flag_set = {
+        "--list":     args.list_libs,
+        "--orphans":  args.orphans,
+        "--stats":    bool(args.stats_target),
+        "--forget":   bool(args.forget),
+        "--remove":   bool(args.remove),
+        "--discover": bool(getattr(args, "discover_root", None)),
+        "--refresh-stats": bool(getattr(args, "refresh_stats", False)),
+    }
+    active_mgmt = [name for name, v in mgmt_flag_set.items() if v]
+    if args.target and active_mgmt:
+        print(
+            f"acidcat index: cannot combine {active_mgmt[0]} with a "
+            f"target directory. Drop the target or remove the flag.",
+            file=sys.stderr,
+        )
+        return 1
+    if len(active_mgmt) > 1:
+        print(
+            f"acidcat index: cannot combine {active_mgmt[0]} and "
+            f"{active_mgmt[1]}; pick one.",
+            file=sys.stderr,
+        )
+        return 1
+
     # registry-management modes (no target required)
     if args.list_libs:
         return _cmd_list(registry_path)
@@ -137,6 +175,11 @@ def run(args):
         return _cmd_forget(args.forget, registry_path, quiet=quiet)
     if args.remove:
         return _cmd_remove(args.remove, registry_path, quiet=quiet)
+    if getattr(args, "refresh_stats", False):
+        return _cmd_refresh_stats(
+            getattr(args, "refresh_stats_target", None),
+            registry_path, quiet=quiet,
+        )
     if getattr(args, "discover_root", None):
         return _cmd_discover(
             args.discover_root,
@@ -363,6 +406,84 @@ def _cmd_remove(target, registry_path, quiet=False):
     return 0
 
 
+def _cmd_refresh_stats(target, registry_path, quiet=False):
+    """Read each registered library's DB and push current sample/feature
+    counts back into the registry. Migration helper for users whose
+    libraries were registered before stats-on-attach landed (or who
+    walked their DBs from outside acidcat).
+    """
+    rconn = reg.open_registry(registry_path)
+    try:
+        if target:
+            row = reg.get_library(rconn, target)
+            if row is None:
+                print(f"acidcat index: no library matches '{target}'",
+                      file=sys.stderr)
+                return 1
+            libs = [row]
+        else:
+            libs = reg.list_libraries(rconn)
+    finally:
+        rconn.close()
+
+    refreshed = 0
+    skipped_missing = 0
+    for lib in libs:
+        if not os.path.isfile(lib["db_path"]):
+            skipped_missing += 1
+            if not quiet:
+                print(f"[refresh-stats] skipped {lib['label']}: "
+                      f"DB missing at {lib['db_path']}", file=sys.stderr)
+            continue
+        try:
+            conn = idx.open_db(lib["db_path"])
+        except Exception as e:
+            skipped_missing += 1
+            if not quiet:
+                print(f"[refresh-stats] skipped {lib['label']}: {e}",
+                      file=sys.stderr)
+            continue
+        try:
+            sample_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM samples"
+            ).fetchone()["c"]
+            feature_count = conn.execute(
+                "SELECT COUNT(*) AS c FROM features"
+            ).fetchone()["c"]
+            last_indexed_at = None
+            try:
+                row = conn.execute(
+                    "SELECT MAX(last_indexed_at) AS t FROM scan_roots"
+                ).fetchone()
+                if row is not None:
+                    last_indexed_at = row["t"]
+            except Exception:
+                pass
+        finally:
+            conn.close()
+
+        rconn = reg.open_registry(registry_path)
+        try:
+            reg.update_stats(
+                rconn, lib["root_path"],
+                sample_count=sample_count,
+                feature_count=feature_count,
+                last_indexed_at=last_indexed_at,
+            )
+        finally:
+            rconn.close()
+        refreshed += 1
+        if not quiet:
+            print(f"[refresh-stats] {lib['label']:<32s} "
+                  f"samples={sample_count} features={feature_count}",
+                  file=sys.stderr)
+
+    if not quiet:
+        print(f"[refresh-stats] {refreshed} refreshed, "
+              f"{skipped_missing} skipped (missing DB).", file=sys.stderr)
+    return 0
+
+
 # directories acidcat refuses to discover under, regardless of audio count.
 # These are user homes and roots: registering them as libraries would create
 # nonsense library boundaries and pull in massive unrelated content.
@@ -542,6 +663,12 @@ def _cmd_discover(root, registry_path, min_samples, max_depth, label_prefix,
                     rconn, cand, label=label, db_path=db_path,
                     in_tree=False, schema_version=idx.SCHEMA_VERSION,
                 )
+                # pre-touch the DB so `acidcat index --list` does not show a
+                # leading '!' for libraries that were registered but never
+                # walked. Empty schema is created and immediately closed; a
+                # later walk fills it with rows.
+                _conn = idx.open_db(db_path)
+                _conn.close()
                 registered += 1
                 if not quiet:
                     print(f"[discover] registered '{label}' -> {cand}",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -42,6 +42,7 @@ class _Args:
             "import_tags": None, "registry": None,
             "list_libs": False, "orphans": False,
             "stats_target": None, "forget": None, "remove": None,
+            "refresh_stats": False, "refresh_stats_target": None,
             "discover_root": None, "min_samples": 20, "max_depth": 3,
             "label_prefix": "", "dry_run": False,
             "quiet": True, "verbose": False,
@@ -611,3 +612,178 @@ class TestDiscover:
         finally:
             rconn.close()
         assert "DeepPack" not in labels
+
+    def test_creates_db_files_so_list_does_not_show_orphan(
+            self, tmp_path, central_root, registry_path, wav_bytes):
+        """v0.5.3: --discover should pre-touch each registered library's DB
+        so `acidcat index --list` does not show a leading '!' (orphan)
+        marker for freshly-discovered-but-not-yet-walked libraries."""
+        samples = tmp_path / "Samples"
+        samples.mkdir()
+        a = samples / "PackA"
+        a.mkdir()
+        _populate(a, 25, wav_bytes)
+
+        index_cmd.run(_Args(
+            discover_root=str(samples), registry=registry_path,
+            min_samples=20,
+        ))
+        rconn = reg.open_registry(registry_path)
+        try:
+            row = reg.get_library(rconn, "PackA")
+        finally:
+            rconn.close()
+        assert row is not None
+        assert os.path.isfile(row["db_path"])
+
+
+class TestCollisionGuard:
+    """v0.5.3: target + management flags can't be combined silently."""
+
+    def test_target_with_list_errors(self, tmp_path, central_root,
+                                      registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        rc = index_cmd.run(_Args(
+            target=str(lib), list_libs=True, registry=registry_path,
+        ))
+        assert rc == 1
+
+    def test_target_with_orphans_errors(self, tmp_path, central_root,
+                                         registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        rc = index_cmd.run(_Args(
+            target=str(lib), orphans=True, registry=registry_path,
+        ))
+        assert rc == 1
+
+    def test_target_with_stats_errors(self, tmp_path, central_root,
+                                       registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        rc = index_cmd.run(_Args(
+            target=str(lib), stats_target="some-label",
+            registry=registry_path,
+        ))
+        assert rc == 1
+
+    def test_target_with_discover_errors(self, tmp_path, central_root,
+                                          registry_path, wav_bytes):
+        lib = _library(tmp_path, wav_bytes)
+        rc = index_cmd.run(_Args(
+            target=str(lib), discover_root=str(lib),
+            registry=registry_path,
+        ))
+        assert rc == 1
+
+    def test_two_management_flags_error(self, tmp_path, central_root,
+                                         registry_path):
+        rc = index_cmd.run(_Args(
+            list_libs=True, orphans=True, registry=registry_path,
+        ))
+        assert rc == 1
+
+
+class TestRefreshStats:
+    """v0.5.3: --refresh-stats reads each library's DB and updates the
+    registry's cached counts."""
+
+    def test_refreshes_all_libraries(self, tmp_path, central_root,
+                                      registry_path, wav_bytes):
+        # set up two libraries the normal way (registers + indexes them)
+        a = tmp_path / "A"
+        a.mkdir()
+        _populate(a, 3, wav_bytes)
+        b = tmp_path / "B"
+        b.mkdir()
+        _populate(b, 5, wav_bytes)
+        index_cmd.run(_Args(target=str(a), label="lib_a", registry=registry_path))
+        index_cmd.run(_Args(target=str(b), label="lib_b", registry=registry_path))
+
+        # corrupt the registry's cached counts to simulate stale state
+        rconn = reg.open_registry(registry_path)
+        try:
+            rconn.execute(
+                "UPDATE libraries SET sample_count = NULL, "
+                "feature_count = NULL, last_indexed_at = NULL"
+            )
+            rconn.commit()
+        finally:
+            rconn.close()
+
+        # refresh
+        rc = index_cmd.run(_Args(refresh_stats=True, registry=registry_path))
+        assert rc == 0
+
+        # verify counts are back
+        rconn = reg.open_registry(registry_path)
+        try:
+            rows = {
+                r["label"]: r for r in reg.list_libraries(rconn)
+            }
+        finally:
+            rconn.close()
+        assert rows["lib_a"]["sample_count"] == 3
+        assert rows["lib_b"]["sample_count"] == 5
+
+    def test_refreshes_single_library(self, tmp_path, central_root,
+                                       registry_path, wav_bytes):
+        a = tmp_path / "A"
+        a.mkdir()
+        _populate(a, 3, wav_bytes)
+        b = tmp_path / "B"
+        b.mkdir()
+        _populate(b, 5, wav_bytes)
+        index_cmd.run(_Args(target=str(a), label="lib_a", registry=registry_path))
+        index_cmd.run(_Args(target=str(b), label="lib_b", registry=registry_path))
+
+        rconn = reg.open_registry(registry_path)
+        try:
+            rconn.execute(
+                "UPDATE libraries SET sample_count = NULL"
+            )
+            rconn.commit()
+        finally:
+            rconn.close()
+
+        index_cmd.run(_Args(
+            refresh_stats=True, refresh_stats_target="lib_a",
+            registry=registry_path,
+        ))
+        rconn = reg.open_registry(registry_path)
+        try:
+            rows = {r["label"]: r for r in reg.list_libraries(rconn)}
+        finally:
+            rconn.close()
+        assert rows["lib_a"]["sample_count"] == 3
+        # lib_b was scoped out; should still be NULL
+        assert rows["lib_b"]["sample_count"] is None
+
+    def test_refresh_unknown_target_errors(self, tmp_path, central_root,
+                                            registry_path):
+        rc = index_cmd.run(_Args(
+            refresh_stats=True, refresh_stats_target="does_not_exist",
+            registry=registry_path,
+        ))
+        assert rc == 1
+
+    def test_refresh_skips_missing_db(self, tmp_path, central_root,
+                                       registry_path, wav_bytes):
+        a = tmp_path / "A"
+        a.mkdir()
+        _populate(a, 3, wav_bytes)
+        index_cmd.run(_Args(target=str(a), label="lib_a", registry=registry_path))
+
+        # delete the DB file under the registered path
+        rconn = reg.open_registry(registry_path)
+        try:
+            row = reg.get_library(rconn, "lib_a")
+            db = row["db_path"]
+        finally:
+            rconn.close()
+        for ext in ("", "-shm", "-wal"):
+            p = db + ext
+            if os.path.isfile(p):
+                os.remove(p)
+
+        # refresh should succeed (return 0) even though the DB is missing
+        rc = index_cmd.run(_Args(refresh_stats=True, registry=registry_path))
+        assert rc == 0


### PR DESCRIPTION
Three small follow-ups from real-world v0.5.2 testing.

- CLI collision guard: combining a target directory with any registry-management flag (--list, --orphans, --stats, --forget, --remove, --discover, --refresh-stats) now errors with a clear message instead of silently dispatching the management op and ignoring the target. Also rejects two management flags at once. Surfaces what the user actually asked for instead of guessing.

- --discover pre-touches each registered library's DB. Previously freshly-discovered libraries showed a leading '!' (orphan) marker in 'acidcat index --list' until the user walked them, even though nothing was actually wrong. The empty schema is created on registration; a later walk fills it with rows.

- new --refresh-stats command. Walks every registered library, opens its DB if present, reads sample_count + feature_count + last_indexed_at, and pushes those values back into the registry's cached fields. Migration helper for users with libraries registered before v0.5.1's stats-on-attach landed (or whose DBs were walked from outside acidcat). Optional --refresh-stats-target LABEL_OR_PATH scopes to one library; default refreshes everything.

- 10 new tests across TestDiscover (pre-touch creates DB), TestCollisionGuard (5 cases), TestRefreshStats (4 cases). 232 passed.