### PR TITLE
docs: amp-orange theme for the codebase explorer

### DIFF
--- a/docs/codebase_explorer.html
+++ b/docs/codebase_explorer.html
@@ -8,30 +8,31 @@
 <meta property="og:title" content="acidcat codebase explorer / v0.5.6" />
 <meta property="og:type" content="article" />
 <style>
+/* theme: amp-orange (see skill themes/ for presets) */
 :root{
-  --paper:#fcfcfa;
-  --ink:#151515;
-  --muted:#64625c;
-  --line:#d8d5ce;
+  --paper:#f6f4ee;
+  --ink:#1c1a17;
+  --muted:#746c5f;
+  --line:#d6d1c4;
   --soft:rgba(0,0,0,0.012);
-  --accent-deep:#1A2F3F;
-  --accent-hot:#EC503A;
-  --accent-warm:#F78F82;
-  --accent-warm-soft:rgba(247,143,130,0.10);
-  --accent-hot-soft:rgba(236,80,58,0.08);
-  --accent-deep-soft:rgba(26,47,63,0.05);
-  --code-bg:#1A2F3F;
-  --code-fg:#cbd2da;
-  --ex-bg:#faf8f3;
-  --pin-bg:rgba(236,80,58,0.14);
-  --ink-soft:#262626;
-  --line-soft:rgba(216,213,206,0.7);
-  --code-inline-bg:rgba(217,215,209,0.30);
-  --code-kw:#f5b06b;
-  --code-hdr:#5cc0b0;
-  --code-cm:#7d8a99;
-  --code-num:#e0b060;
-  --code-str:#a8d39a;
+  --accent-deep:#33302a;
+  --accent-hot:#bc3a10;
+  --accent-warm:#F05138;
+  --accent-warm-soft:rgba(240,81,56,0.10);
+  --accent-hot-soft:rgba(188,58,16,0.08);
+  --accent-deep-soft:rgba(51,48,42,0.05);
+  --code-bg:#211d18;
+  --code-fg:#d8d2c4;
+  --ex-bg:#efece2;
+  --pin-bg:rgba(240,81,56,0.14);
+  --ink-soft:#272420;
+  --line-soft:rgba(214,209,196,0.7);
+  --code-inline-bg:rgba(214,209,196,0.35);
+  --code-kw:#f0824c;
+  --code-hdr:#d2c5a8;
+  --code-cm:#7d766a;
+  --code-num:#d8a868;
+  --code-str:#b0a880;
 }
 *{box-sizing:border-box}
 html{scroll-behavior:smooth}


### PR DESCRIPTION
swaps the explorer's :root block to amp-orange: near-monochrome warm grounds with one y2k orange accent. the vivid #F05138 is decoration-only (db box outlines, dashed flows, tints); link and eyebrow text uses a darkened cut of the same hue at 5:1 contrast. validated against the color contract.