### PR TITLE
v0.5.7: acid chunk fix, inspect verb, byte-level riff docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to acidcat. Format loosely follows
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 once it leaves alpha.
 
+## [0.5.7] - 2026-06-10
+
+First slice of the format-internals work: a High-severity parser fix
+found by verifying the docs against primary sources, byte-level format
+documentation, and a new readelf-style inspect verb.
+
+### Fixed
+
+- **acid chunk misparse**: `acid_beats` was read from the unknown
+  float at offset 8 (0 in every spec-conformant file) instead of the
+  real `num_beats` at offset 12, and the meter fields were read as two
+  uint32s spanning the wrong bytes. Verified against libsndfile and
+  hex dumps of ACIDized packs from four vendors. The long-standing
+  "acid_beats is usually 0" behavior was this bug, and kind inference
+  never saw a real beat count. **Reindex libraries to refresh stored
+  `acid_beats` values.**
+
+### Added
+
+- `acidcat inspect FILE`: readelf-style structural dump. Chunk table
+  with offsets and summaries, decoded per-field breakdown for fmt
+  (incl. extensible), data, fact, acid, smpl, inst, cue, LIST and
+  bext, `--hex` for raw bytes next to each field, `-f json` for
+  machines, and lint warnings for spec violations (riff_size lies,
+  loop points past EOF, acid beat/duration drift, cue count lies,
+  fmt-after-data ordering).
+
+### Documentation
+
+- `docs/formats/riff_wav.md`: ELF/TCP-style byte-ruler diagrams for
+  the RIFF header, chunk envelope, fmt, acid, smpl header and loop
+  entries, cue entries, and inst, plus layout provenance notes for
+  the acid chunk.
+
 ## [0.5.6] - 2026-06-10
 
 Docs and repo hygiene release. No code changes; 263 tests unchanged.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ full-text.
 | `acidcat similar CSV cluster` | Cluster samples by audio characteristics |
 | `acidcat search CSV query TEXT` | Text-based sample search (legacy CSV) |
 | `acidcat dump FILE CHUNK [...]` | Hex-dump specific RIFF chunks |
+| `acidcat inspect FILE [--hex]` | readelf-style structural dump with lint warnings |
 | `acidcat index DIR` | Upsert DIR into the global SQLite index |
 | `acidcat query [flags]` | Filter the global index by bpm/key/tag/text |
 

--- a/docs/formats/riff_wav.md
+++ b/docs/formats/riff_wav.md
@@ -24,6 +24,21 @@ chunk-based binary format. Everything is little-endian.
 +----------------------------------------------+
 ```
 
+### Byte-Level Map: RIFF Header
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  | 'R'  | 'I'  | 'F'  | 'F'  |  magic
+       +------+------+------+------+
+ 0x04  |      riff_size (u32 LE)   |  file size - 8
+       +---------------------------+
+ 0x08  | 'W'  | 'A'  | 'V'  | 'E'  |  form type
+       +------+------+------+------+
+ 0x0C  |  first chunk begins here  |
+       :                           :
+```
+
 ### Chunk Layout
 
 Every chunk follows the same envelope:
@@ -35,6 +50,20 @@ struct chunk {
     byte     data[size];  // payload
     // if size is odd, one pad byte follows (not counted in size)
 };
+```
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ +0x00 |      chunk id (4cc)       |  "fmt ", "data", "acid", ...
+       +---------------------------+
+ +0x04 |    chunk_size (u32 LE)    |  payload only, pad excluded
+       +---------------------------+
+ +0x08 |          payload          |
+       :       chunk_size bytes    :
+       +---------------------------+
+       | pad byte iff size is odd  |  word alignment, uncounted
+       +---------------------------+
 ```
 
 ### Mental Model
@@ -78,6 +107,19 @@ struct fmt_chunk {
     uint16_t block_align;       // channels * bits_per_sample / 8
     uint16_t bits_per_sample;   // 8, 16, 24, 32
 };
+```
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  | format_tag  |  channels   |  u16 / u16
+       +------+------+------+------+
+ 0x04  |     sample_rate (u32)     |  44100, 48000, ...
+       +---------------------------+
+ 0x08  |  avg_bytes_per_sec (u32)  |  rate * block_align
+       +---------------------------+
+ 0x0C  | block_align | bits/sample |  u16 / u16
+       +------+------+------+------+
 ```
 
 ### Format Tags
@@ -203,6 +245,33 @@ struct acid_chunk {
 };
 ```
 
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  |     type_flags (u32)      |  bit0 one-shot, bit1 root set,
+       +---------------------------+  bit2 stretch, bit3 disk-based
+ 0x04  |  root_note  |  unknown1   |  u16 MIDI note / u16, often 0x8000
+       +------+------+------+------+
+ 0x08  |      unknown2 (f32)       |  observed 0.0 in the wild
+       +---------------------------+
+ 0x0C  |     num_beats (u32)       |  beat count of the loop
+       +---------------------------+
+ 0x10  | meter_denom | meter_numer |  u16 / u16, usually 4 / 4
+       +------+------+------+------+
+ 0x14  |       tempo (f32)         |  BPM
+       +---------------------------+
+```
+
+Layout provenance: there is no official spec (the chunk is Sonic
+Foundry reverse-engineering lore). This field order matches
+libsndfile's `wav_read_acid_chunk` and was hex-verified 2026-06-10
+against ACIDized WAVs from four different sample vendors: the
+`num_beats / duration * 60` cross-check lands on the expected tempo
+in every file. Note `num_beats` sits at offset `0x0C`, after the
+unknown float -- a parser that reads beats at `0x08` gets 0 on every
+conformant file (acidcat itself made exactly that mistake before
+v0.5.7).
+
 ### Type Flags
 
 ```
@@ -265,6 +334,31 @@ struct smpl_chunk {
 };
 ```
 
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  |    manufacturer (u32)     |  MIDI manufacturer id, 0 = none
+       +---------------------------+
+ 0x04  |      product (u32)        |
+       +---------------------------+
+ 0x08  |   sample_period (u32)     |  ns per sample = 1e9 / rate
+       +---------------------------+
+ 0x0C  |  midi_unity_note (u32)    |  root key; 0 = unset sentinel
+       +---------------------------+
+ 0x10  |  midi_pitch_frac (u32)    |  fine tune, fraction of semitone
+       +---------------------------+
+ 0x14  |    smpte_format (u32)     |  0, 24, 25, 29, 30
+       +---------------------------+
+ 0x18  |    smpte_offset (u32)     |
+       +---------------------------+
+ 0x1C  | num_sample_loops (u32)    |
+       +---------------------------+
+ 0x20  |    sampler_data (u32)     |  trailing vendor blob size
+       +---------------------------+
+ 0x24  |  loop entries follow ...  |  24 bytes each
+       :                           :
+```
+
 ### Loop Entry (24 bytes each, follows smpl header)
 
 ```
@@ -276,6 +370,23 @@ struct smpl_loop {
     uint32_t fraction;          // fractional sample position
     uint32_t play_count;        // 0 = infinite loop
 };
+```
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ +0x00 |   cue_point_id (u32)      |  links to cue chunk
+       +---------------------------+
+ +0x04 |       type (u32)          |  0 fwd, 1 ping-pong, 2 reverse
+       +---------------------------+
+ +0x08 |       start (u32)         |  sample frames, not bytes
+       +---------------------------+
+ +0x0C |        end (u32)          |
+       +---------------------------+
+ +0x10 |     fraction (u32)        |
+       +---------------------------+
+ +0x14 |    play_count (u32)       |  0 = loop forever
+       +---------------------------+
 ```
 
 ### Loop Types
@@ -316,6 +427,15 @@ struct inst_chunk {
 };
 ```
 
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  | base | detun| gain | low_n|  i8 / i8 cents / i8 dB / u8
+       +------+------+------+------+
+ 0x04  |high_n| lo_v | hi_v |       |  u8 / u8 / u8 (7 bytes total,
+       +------+------+------+       |  pad byte follows: odd size)
+```
+
 ### Notes
 
 - often duplicates `smpl.midi_unity_note` as `base_note`
@@ -349,6 +469,23 @@ struct cue_point {
     uint32_t block_start;       // byte offset within block (usually 0)
     uint32_t sample_offset;     // actual sample position in audio
 };
+```
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ +0x00 |        id (u32)           |  unique, referenced by LIST/adtl
+       +---------------------------+
+ +0x04 |     position (u32)        |  playlist ordering
+       +------+------+------+------+
+ +0x08 | 'd'  | 'a'  | 't'  | 'a'  |  fcc of the chunk referenced
+       +------+------+------+------+
+ +0x0C |    chunk_start (u32)      |  usually 0
+       +---------------------------+
+ +0x10 |    block_start (u32)      |  usually 0
+       +---------------------------+
+ +0x14 |   sample_offset (u32)     |  the actual marker position
+       +---------------------------+
 ```
 
 Cue labels are stored in a separate `LIST/adtl` chunk, linked by cue ID.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.5.6"
+version = "0.5.7"
 description = "Audio metadata explorer and analysis tool, like exiftool but for audio"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/src/acidcat/cli.py
+++ b/src/acidcat/cli.py
@@ -26,13 +26,13 @@ import sys
 from acidcat import __version__
 from acidcat.commands import (
     info, scan, chunks, survey, detect, features, similar, search, dump,
-    index, query,
+    index, query, inspect,
 )
 from acidcat.util.stdin import is_stdin_target
 
 SUBCOMMANDS = {
     "info", "scan", "chunks", "survey", "detect", "features", "similar",
-    "search", "dump", "index", "query",
+    "search", "dump", "index", "query", "inspect",
 }
 
 
@@ -56,6 +56,7 @@ def _build_parser():
     dump.register(subparsers)
     index.register(subparsers)
     query.register(subparsers)
+    inspect.register(subparsers)
 
     return parser
 

--- a/src/acidcat/commands/inspect.py
+++ b/src/acidcat/commands/inspect.py
@@ -1,0 +1,469 @@
+"""
+acidcat inspect -- readelf-style structural dump for audio files.
+
+Walks the container chunk by chunk and prints a structural table, a
+decoded field breakdown per known chunk (with byte offsets), and any
+spec violations it noticed along the way. `--hex` adds the raw bytes
+next to each decoded field. `-f json` emits the same structure for
+machines.
+
+WAV/RIFF only for now; AIFF and MIDI walkers follow the same shape.
+"""
+
+import json
+import os
+import struct
+import sys
+
+from acidcat.core.riff import iter_chunks
+from acidcat.util.midi import midi_note_to_name
+
+_PAYLOAD_CAP = 65536
+
+_FORMAT_TAGS = {
+    0x0001: "PCM",
+    0x0002: "MS ADPCM",
+    0x0003: "IEEE float",
+    0x0006: "A-law",
+    0x0007: "mu-law",
+    0x0011: "IMA ADPCM",
+    0x0055: "MPEG Layer III",
+    0xFFFE: "extensible",
+}
+
+_ACID_FLAGS = (
+    (0x01, "one-shot"),
+    (0x02, "root set"),
+    (0x04, "stretch"),
+    (0x08, "disk-based"),
+)
+
+_LOOP_TYPES = {0: "forward", 1: "ping-pong", 2: "reverse"}
+
+_INFO_TAGS = {
+    "INAM": "title", "IART": "artist", "ICMT": "comment", "ISFT": "software",
+    "ICRD": "date", "IGNR": "genre", "ICOP": "copyright", "IKEY": "keywords",
+    "ISBJ": "subject", "IENG": "engineer", "ITCH": "technician", "IPRD": "product",
+}
+
+
+def register(subparsers):
+    p = subparsers.add_parser(
+        "inspect",
+        help="readelf-style structural dump of a WAV file.",
+    )
+    p.add_argument("target", help="Path to a WAV file.")
+    p.add_argument("--hex", action="store_true", dest="show_hex",
+                   help="Show raw bytes next to each decoded field.")
+    p.add_argument("-f", "--format", default="table", choices=["table", "json"],
+                   help="Output format (default: table).")
+    p.add_argument("-q", "--quiet", action="store_true",
+                   help="Chunk table only, no per-chunk field detail.")
+    p.add_argument("-v", "--verbose", action="store_true")
+    p.set_defaults(func=run)
+
+
+# ── field helpers ──────────────────────────────────────────────────
+# a field is a dict: off (relative to payload), len, name, value, note
+
+
+def _f(off, length, name, value, note=""):
+    return {"off": off, "len": length, "name": name, "value": value, "note": note}
+
+
+def _u16(b, off):
+    return struct.unpack_from("<H", b, off)[0]
+
+
+def _u32(b, off):
+    return struct.unpack_from("<I", b, off)[0]
+
+
+def _f32(b, off):
+    return struct.unpack_from("<f", b, off)[0]
+
+
+def _cstr(b, off, length):
+    return b[off:off + length].split(b"\x00")[0].decode("ascii", errors="replace").strip()
+
+
+def _flag_names(value, table):
+    names = [name for bit, name in table if value & bit]
+    return ", ".join(names) if names else "none"
+
+
+# ── per-chunk parsers ──────────────────────────────────────────────
+# each returns (summary, fields, warnings) and may read/update ctx,
+# which accumulates cross-chunk facts (sample rate, frame count...)
+
+
+def _parse_fmt(b, ctx):
+    fields, warns = [], []
+    if len(b) < 16:
+        return "truncated", fields, [f"fmt payload is {len(b)} bytes, spec minimum is 16"]
+    tag, ch, rate, avg, align, bits = struct.unpack_from("<HHIIHH", b, 0)
+    tag_name = _FORMAT_TAGS.get(tag, f"unknown 0x{tag:04x}")
+    fields.append(_f(0x00, 2, "format_tag", f"0x{tag:04x}", tag_name))
+    fields.append(_f(0x02, 2, "channels", ch))
+    fields.append(_f(0x04, 4, "sample_rate", rate, "Hz"))
+    fields.append(_f(0x08, 4, "avg_bytes_per_sec", avg))
+    fields.append(_f(0x0C, 2, "block_align", align))
+    fields.append(_f(0x0E, 2, "bits_per_sample", bits))
+    ctx.update({"format_tag": tag, "channels": ch, "sample_rate": rate,
+                "block_align": align, "bits": bits})
+
+    if tag == 1 and ch and bits and align != ch * bits // 8:
+        warns.append(f"block_align {align} != channels*bits/8 = {ch * bits // 8}")
+    if rate and align and avg != rate * align:
+        warns.append(f"avg_bytes_per_sec {avg} != sample_rate*block_align = {rate * align}")
+
+    if tag == 0xFFFE and len(b) >= 40:
+        cb = _u16(b, 0x10)
+        valid_bits = _u16(b, 0x12)
+        mask = _u32(b, 0x14)
+        sub = b[0x18:0x28]
+        sub_tag = struct.unpack_from("<H", sub, 0)[0]
+        sub_name = _FORMAT_TAGS.get(sub_tag, f"guid 0x{sub_tag:04x}")
+        fields.append(_f(0x10, 2, "cb_size", cb))
+        fields.append(_f(0x12, 2, "valid_bits_per_sample", valid_bits))
+        fields.append(_f(0x14, 4, "channel_mask", f"0x{mask:03x}"))
+        fields.append(_f(0x18, 16, "sub_format", sub_name))
+        ctx["format_tag"] = sub_tag
+
+    summary = f"{tag_name} {bits}-bit {ch}ch {rate} Hz"
+    return summary, fields, warns
+
+
+def _parse_data(b, ctx, size):
+    fields, warns = [], []
+    frames = None
+    align = ctx.get("block_align")
+    rate = ctx.get("sample_rate")
+    if align:
+        frames = size // align
+        ctx["frames"] = frames
+    summary = f"audio payload, {size:,} bytes"
+    if frames is not None and rate:
+        dur = frames / rate
+        ctx["duration"] = dur
+        summary += f", {dur:.3f} s"
+        fields.append(_f(0x00, size, "frames", frames, f"{dur:.3f} s at {rate} Hz"))
+    if size == 0:
+        warns.append("data chunk is empty")
+    return summary, fields, warns
+
+
+def _parse_fact(b, ctx):
+    if len(b) < 4:
+        return "truncated", [], ["fact payload under 4 bytes"]
+    n = _u32(b, 0)
+    rate = ctx.get("sample_rate")
+    note = f"{n / rate:.3f} s" if rate and n else ""
+    ctx.setdefault("frames", n)
+    return f"{n:,} samples/channel", [_f(0x00, 4, "sample_length", n, note)], []
+
+
+def _parse_acid(b, ctx):
+    fields, warns = [], []
+    if len(b) < 24:
+        return "truncated", fields, [f"acid payload is {len(b)} bytes, expected 24"]
+    flags, root, q1, q2, beats, denom, numer, tempo = struct.unpack_from("<IHHfIHHf", b, 0)
+    fields.append(_f(0x00, 4, "type_flags", f"0x{flags:08x}", _flag_names(flags, _ACID_FLAGS)))
+    fields.append(_f(0x04, 2, "root_note", root, midi_note_to_name(root) if root else "unset"))
+    fields.append(_f(0x06, 2, "unknown1", f"0x{q1:04x}"))
+    fields.append(_f(0x08, 4, "unknown2", round(q2, 4)))
+    fields.append(_f(0x0C, 4, "num_beats", beats))
+    fields.append(_f(0x10, 2, "meter_denominator", denom))
+    fields.append(_f(0x12, 2, "meter_numerator", numer))
+    fields.append(_f(0x14, 4, "tempo", round(tempo, 2), "BPM"))
+
+    if tempo and not (40 <= tempo <= 300):
+        warns.append(f"acid tempo {tempo:.2f} outside sane range 40-300")
+    dur = ctx.get("duration")
+    if beats and tempo and dur:
+        expected = beats / tempo * 60
+        drift = abs(expected - dur) / dur if dur else 0
+        if drift > 0.05:
+            warns.append(
+                f"acid says {beats} beats at {tempo:.2f} bpm = {expected:.3f} s "
+                f"but data holds {dur:.3f} s ({drift * 100:.0f}% drift)"
+            )
+    kind = "one-shot" if flags & 0x01 else "loop"
+    summary = f"{kind}, {beats} beats, {numer}/{denom}, {tempo:.2f} bpm"
+    if root:
+        summary += f", root {midi_note_to_name(root)}"
+    return summary, fields, warns
+
+
+def _parse_smpl(b, ctx):
+    fields, warns = [], []
+    if len(b) < 36:
+        return "truncated", fields, [f"smpl payload is {len(b)} bytes, header needs 36"]
+    (manuf, product, period, unity, frac,
+     smpte_fmt, smpte_off, n_loops, vendor) = struct.unpack_from("<IIIIIiiII", b, 0)
+    fields.append(_f(0x00, 4, "manufacturer", manuf))
+    fields.append(_f(0x04, 4, "product", product))
+    fields.append(_f(0x08, 4, "sample_period", period, "ns/sample"))
+    fields.append(_f(0x0C, 4, "midi_unity_note", unity,
+                     midi_note_to_name(unity) if unity else "0 = unset sentinel"))
+    fields.append(_f(0x10, 4, "midi_pitch_frac", frac))
+    fields.append(_f(0x14, 4, "smpte_format", smpte_fmt))
+    fields.append(_f(0x18, 4, "smpte_offset", smpte_off))
+    fields.append(_f(0x1C, 4, "num_sample_loops", n_loops))
+    fields.append(_f(0x20, 4, "sampler_data", vendor, "trailing vendor bytes"))
+
+    rate = ctx.get("sample_rate")
+    if rate and period and abs(period - round(1e9 / rate)) > 1:
+        warns.append(f"sample_period {period} disagrees with fmt rate {rate}")
+
+    capacity = max(0, (len(b) - 36) // 24)
+    if n_loops > capacity:
+        warns.append(f"declares {n_loops} loops but payload holds {capacity}")
+    frames = ctx.get("frames")
+    for i in range(min(n_loops, capacity)):
+        base = 36 + i * 24
+        cue_id, ltype, start, end, lfrac, count = struct.unpack_from("<IIIIII", b, base)
+        type_name = _LOOP_TYPES.get(ltype, f"unknown {ltype}")
+        plays = "forever" if count == 0 else f"{count}x"
+        fields.append(_f(base, 24, f"loop[{i}]",
+                         f"{start}..{end}", f"{type_name}, {plays}"))
+        if end < start:
+            warns.append(f"loop[{i}] end {end} before start {start}")
+        elif frames and end > frames:
+            warns.append(f"loop[{i}] end {end} past last frame {frames}")
+
+    summary = f"root {midi_note_to_name(unity)}" if unity else "root unset"
+    summary += f", {n_loops} loop(s)"
+    return summary, fields, warns
+
+
+def _parse_inst(b, ctx):
+    if len(b) < 7:
+        return "truncated", [], [f"inst payload is {len(b)} bytes, expected 7"]
+    base, detune, gain = struct.unpack_from("<bbb", b, 0)
+    low_n, high_n, low_v, high_v = b[3], b[4], b[5], b[6]
+    fields = [
+        _f(0x00, 1, "base_note", base, midi_note_to_name(base) if base >= 0 else ""),
+        _f(0x01, 1, "detune", detune, "cents"),
+        _f(0x02, 1, "gain", gain, "dB"),
+        _f(0x03, 1, "low_note", low_n, midi_note_to_name(low_n)),
+        _f(0x04, 1, "high_note", high_n, midi_note_to_name(high_n)),
+        _f(0x05, 1, "low_velocity", low_v),
+        _f(0x06, 1, "high_velocity", high_v),
+    ]
+    summary = (f"base {midi_note_to_name(base)}, "
+               f"keys {midi_note_to_name(low_n)}-{midi_note_to_name(high_n)}")
+    return summary, fields, []
+
+
+def _parse_cue(b, ctx):
+    fields, warns = [], []
+    if len(b) < 4:
+        return "truncated", fields, ["cue payload under 4 bytes"]
+    declared = _u32(b, 0)
+    capacity = max(0, (len(b) - 4) // 24)
+    fields.append(_f(0x00, 4, "num_cue_points", declared))
+    if declared > capacity:
+        warns.append(f"declares {declared} cue points but payload holds {capacity}")
+    for i in range(min(declared, capacity)):
+        base = 4 + i * 24
+        cid, pos, fcc, cstart, bstart, sample = struct.unpack_from("<II4sIII", b, base)
+        fields.append(_f(base, 24, f"cue[{i}]", sample,
+                         f"id {cid}, in '{fcc.decode('ascii', errors='replace')}'"))
+    return f"{min(declared, capacity)} marker(s)", fields, warns
+
+
+def _parse_list(b, ctx):
+    fields, warns = [], []
+    if len(b) < 4:
+        return "truncated", fields, ["LIST payload under 4 bytes"]
+    list_type = b[:4].decode("ascii", errors="replace")
+    pos = 4
+    count = 0
+    while pos + 8 <= len(b):
+        sub_id = b[pos:pos + 4].decode("ascii", errors="replace")
+        sub_size = _u32(b, pos + 4)
+        start, end = pos + 8, pos + 8 + sub_size
+        if end > len(b):
+            warns.append(f"sub-chunk {sub_id!r} overruns LIST payload")
+            break
+        if list_type == "adtl" and sub_id in ("labl", "note") and sub_size >= 4:
+            cue_id = _u32(b, start)
+            text = _cstr(b, start + 4, sub_size - 4)
+            fields.append(_f(pos, 8 + sub_size, sub_id, text, f"cue id {cue_id}"))
+        else:
+            text = _cstr(b, start, sub_size)
+            note = _INFO_TAGS.get(sub_id, "")
+            fields.append(_f(pos, 8 + sub_size, sub_id, text, note))
+        count += 1
+        pos = end + (sub_size & 1)
+    return f"{list_type}, {count} entries", fields, warns
+
+
+def _parse_bext(b, ctx):
+    fields, warns = [], []
+    if len(b) < 348:
+        return "truncated", fields, [f"bext payload is {len(b)} bytes, v0 minimum is 348"]
+    fields.append(_f(0x000, 256, "description", _cstr(b, 0, 256)))
+    fields.append(_f(0x100, 32, "originator", _cstr(b, 256, 32)))
+    fields.append(_f(0x120, 32, "originator_reference", _cstr(b, 288, 32)))
+    fields.append(_f(0x140, 10, "origination_date", _cstr(b, 320, 10)))
+    fields.append(_f(0x14A, 8, "origination_time", _cstr(b, 330, 8)))
+    low, high = _u32(b, 338), _u32(b, 342)
+    timeref = low + (high << 32)
+    rate = ctx.get("sample_rate")
+    note = f"{timeref / rate:.3f} s since midnight" if rate and timeref else ""
+    fields.append(_f(0x152, 8, "time_reference", timeref, note))
+    version = _u16(b, 346)
+    fields.append(_f(0x15A, 2, "version", version))
+    return f"BWF v{version}, {_cstr(b, 256, 32) or 'no originator'}", fields, warns
+
+
+_PARSERS = {
+    "fmt ": _parse_fmt,
+    "fact": _parse_fact,
+    "acid": _parse_acid,
+    "smpl": _parse_smpl,
+    "inst": _parse_inst,
+    "cue ": _parse_cue,
+    "LIST": _parse_list,
+    "bext": _parse_bext,
+}
+
+
+# ── walk ───────────────────────────────────────────────────────────
+
+
+def inspect_wav(filepath):
+    """Walk a WAV file and return (chunks, file_warnings).
+
+    Each chunk is a dict: id, offset, size, summary, fields, warnings.
+    """
+    file_size = os.path.getsize(filepath)
+    ctx = {}
+    chunks = []
+    file_warns = []
+    seen = []
+
+    with open(filepath, "rb") as f:
+        hdr = f.read(12)
+        riff_size = struct.unpack("<I", hdr[4:8])[0]
+        if riff_size + 8 != file_size:
+            file_warns.append(
+                f"riff_size says {riff_size + 8:,} bytes, file is {file_size:,} "
+                f"({file_size - riff_size - 8:+,})"
+            )
+
+        for cid, offset, size in iter_chunks(filepath):
+            seen.append(cid)
+            if offset + 8 + size > file_size:
+                file_warns.append(
+                    f"chunk {cid!r} at 0x{offset:08x} claims {size:,} bytes "
+                    f"but only {file_size - offset - 8:,} remain"
+                )
+            f.seek(offset + 8)
+            payload = f.read(min(size, _PAYLOAD_CAP))
+
+            entry = {"id": cid, "offset": offset, "size": size,
+                     "summary": "", "fields": [], "warnings": []}
+            parser = _PARSERS.get(cid)
+            if cid == "data":
+                entry["summary"], entry["fields"], entry["warnings"] = \
+                    _parse_data(payload, ctx, size)
+            elif parser:
+                try:
+                    entry["summary"], entry["fields"], entry["warnings"] = \
+                        parser(payload, ctx)
+                except Exception as e:
+                    entry["warnings"] = [f"parse error: {e.__class__.__name__}: {e}"]
+            else:
+                preview = payload[:16].hex(" ")
+                entry["summary"] = f"unparsed, first bytes: {preview}"
+            chunks.append(entry)
+
+    if "fmt " not in seen:
+        file_warns.append("no fmt chunk: not decodable as audio")
+    if "data" not in seen:
+        file_warns.append("no data chunk: no audio payload")
+    if "fmt " in seen and "data" in seen and seen.index("fmt ") > seen.index("data"):
+        file_warns.append("fmt appears after data, violating the one RIFF ordering rule")
+
+    return chunks, file_warns
+
+
+# ── rendering ──────────────────────────────────────────────────────
+
+
+def _hex_bytes(filepath, offset, length, cap=8):
+    with open(filepath, "rb") as f:
+        f.seek(offset)
+        raw = f.read(min(length, cap))
+    s = raw.hex(" ")
+    return s + " .." if length > cap else s
+
+
+def _render_table(filepath, chunks, file_warns, args):
+    file_size = os.path.getsize(filepath)
+    print(f"{os.path.basename(filepath)}: RIFF/WAVE, {file_size:,} bytes, "
+          f"{len(chunks)} chunks")
+    print()
+    print(f"  {'idx':<5} {'id':<5} {'offset':<11} {'size':<11} summary")
+    for i, c in enumerate(chunks):
+        print(f"  [{i:>2}]  {c['id']:<5} 0x{c['offset']:08x}  "
+              f"{c['size']:<11,} {c['summary']}")
+
+    if not args.quiet:
+        for c in chunks:
+            if not c["fields"]:
+                continue
+            print()
+            print(f"{c['id'].strip()} @ 0x{c['offset']:08x} ({c['size']} bytes)")
+            for fl in c["fields"]:
+                note = f"  {fl['note']}" if fl["note"] else ""
+                if args.show_hex:
+                    hx = _hex_bytes(filepath, c["offset"] + 8 + fl["off"], fl["len"])
+                    print(f"  +0x{fl['off']:04x}  {hx:<26} "
+                          f"{fl['name']:<22} {fl['value']!s:<14}{note}")
+                else:
+                    print(f"  +0x{fl['off']:04x}  {fl['name']:<22} "
+                          f"{fl['value']!s:<14}{note}")
+
+    all_warns = list(file_warns)
+    all_warns += [f"{c['id'].strip()}: {w}" for c in chunks for w in c["warnings"]]
+    if all_warns:
+        print()
+        print("warnings:")
+        for w in all_warns:
+            print(f"  ! {w}")
+    return 0
+
+
+def run(args):
+    filepath = args.target
+    if not os.path.isfile(filepath):
+        print(f"acidcat inspect: {filepath}: No such file", file=sys.stderr)
+        return 1
+    with open(filepath, "rb") as f:
+        magic = f.read(12)
+    if len(magic) < 12 or magic[:4] != b"RIFF" or magic[8:12] != b"WAVE":
+        if magic[:4] == b"RF64":
+            print("acidcat inspect: RF64 not supported yet", file=sys.stderr)
+        else:
+            print("acidcat inspect: not a RIFF/WAVE file "
+                  "(AIFF and MIDI walkers are planned)", file=sys.stderr)
+        return 1
+
+    chunks, file_warns = inspect_wav(filepath)
+
+    if args.format == "json":
+        json.dump({
+            "file": filepath,
+            "format": "RIFF/WAVE",
+            "size": os.path.getsize(filepath),
+            "chunks": chunks,
+            "warnings": file_warns,
+        }, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    return _render_table(filepath, chunks, file_warns, args)

--- a/src/acidcat/core/riff.py
+++ b/src/acidcat/core/riff.py
@@ -73,9 +73,15 @@ def parse_riff(filepath, enumerate_all=False):
             # --- Known chunk parsing ---
             if chunk_id == b'acid':
                 try:
-                    version, root_note, _, beats, meter_den, meter_num, tempo = struct.unpack(
-                        "<IHHIII f", chunk_data
-                    )
+                    # layout per libsndfile, field-verified against real
+                    # ACIDized packs 2026-06-10: flags u32, root u16,
+                    # q1 u16, q2 f32 (unknown, observed 0.0), num_beats
+                    # u32, meter denom u16, meter numer u16, tempo f32.
+                    # a previous unpack ("<IHHIII f") read num_beats from
+                    # q2 and the meter from the real beats field, so every
+                    # spec-conformant file reported acid_beats=0.
+                    flags, root_note, _q1, _q2, beats, meter_den, meter_num, tempo = \
+                        struct.unpack("<IHHfIHHf", chunk_data)
                     meta["acid_root_note"] = root_note
                     meta["acid_beats"] = beats
                     meta["bpm"] = round(tempo, 2)
@@ -84,7 +90,8 @@ def parse_riff(filepath, enumerate_all=False):
                         results.append(("acid", "beats", beats))
                         results.append(("acid", "root_note", midi_note_to_name(root_note)))
                         results.append(("acid", "meter", f"{meter_num}/{meter_den}"))
-                        results.append(("acid", "version", version))
+                        results.append(("acid", "one_shot", bool(flags & 0x01)))
+                        results.append(("acid", "flags", flags))
                 except Exception as e:
                     if enumerate_all:
                         results.append(("acid", "error", str(e)))

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,124 @@
+"""tests for acidcat.commands.inspect."""
+
+import struct
+from types import SimpleNamespace
+
+import pytest
+from acidcat.commands.inspect import inspect_wav, run
+
+
+def _wav(tmp_path, *chunks, riff_size=None, name="t.wav"):
+    body = b"WAVE" + b"".join(chunks)
+    size = riff_size if riff_size is not None else len(body)
+    p = tmp_path / name
+    p.write_bytes(b"RIFF" + struct.pack("<I", size) + body)
+    return str(p)
+
+
+def _chunk(cid, payload):
+    raw = cid + struct.pack("<I", len(payload)) + payload
+    return raw + (b"\x00" if len(payload) % 2 else b"")
+
+
+def _fmt(channels=1, rate=44100, bits=16):
+    align = channels * bits // 8
+    return _chunk(b"fmt ", struct.pack(
+        "<HHIIHH", 1, channels, rate, rate * align, align, bits))
+
+
+def _data(n_frames=441, align=2):
+    return _chunk(b"data", b"\x00" * (n_frames * align))
+
+
+def _acid(beats=8, tempo=120.0, root=60, flags=0x02):
+    return _chunk(b"acid", struct.pack(
+        "<IHHfIHHf", flags, root, 0x8000, 0.0, beats, 4, 4, tempo))
+
+
+def _smpl(unity=60, loops=()):
+    payload = struct.pack("<IIIIIiiII", 0, 0, 22675, unity, 0, 0, 0, len(loops), 0)
+    for i, (start, end) in enumerate(loops):
+        payload += struct.pack("<IIIIII", i, 0, start, end, 0, 0)
+    return _chunk(b"smpl", payload)
+
+
+class TestInspectWav:
+    def test_chunk_table_and_summaries(self, tmp_path):
+        path = _wav(tmp_path, _fmt(), _data(), _acid())
+        chunks, warns = inspect_wav(path)
+        ids = [c["id"] for c in chunks]
+        assert ids == ["fmt ", "data", "acid"]
+        assert "PCM 16-bit 1ch 44100 Hz" in chunks[0]["summary"]
+        assert "8 beats" in chunks[2]["summary"]
+        assert warns == []
+
+    def test_acid_fields_decoded(self, tmp_path):
+        path = _wav(tmp_path, _fmt(), _data(), _acid(beats=15, tempo=122.0))
+        chunks, _ = inspect_wav(path)
+        acid = next(c for c in chunks if c["id"] == "acid")
+        by_name = {f["name"]: f["value"] for f in acid["fields"]}
+        assert by_name["num_beats"] == 15
+        assert by_name["tempo"] == 122.0
+        assert by_name["meter_denominator"] == 4
+
+    def test_riff_size_lie_is_flagged(self, tmp_path):
+        path = _wav(tmp_path, _fmt(), _data(), riff_size=9999)
+        _, warns = inspect_wav(path)
+        assert any("riff_size" in w for w in warns)
+
+    def test_smpl_loop_past_eof_is_flagged(self, tmp_path):
+        # 441 frames of audio, loop end claims frame 100000
+        path = _wav(tmp_path, _fmt(), _data(441), _smpl(loops=[(0, 100000)]))
+        chunks, _ = inspect_wav(path)
+        smpl = next(c for c in chunks if c["id"] == "smpl")
+        assert any("past last frame" in w for w in smpl["warnings"])
+
+    def test_acid_duration_drift_is_flagged(self, tmp_path):
+        # 441 frames = 0.01 s, but acid claims 16 beats at 120 bpm = 8 s
+        path = _wav(tmp_path, _fmt(), _data(441), _acid(beats=16, tempo=120.0))
+        chunks, _ = inspect_wav(path)
+        acid = next(c for c in chunks if c["id"] == "acid")
+        assert any("drift" in w for w in acid["warnings"])
+
+    def test_missing_fmt_is_flagged(self, tmp_path):
+        path = _wav(tmp_path, _data())
+        _, warns = inspect_wav(path)
+        assert any("no fmt chunk" in w for w in warns)
+
+
+class TestRunCli:
+    def _args(self, target, **kw):
+        base = dict(target=target, show_hex=False, format="table",
+                    quiet=False, verbose=False)
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    def test_table_output(self, tmp_path, capsys):
+        path = _wav(tmp_path, _fmt(), _data(), _acid())
+        assert run(self._args(path)) == 0
+        out = capsys.readouterr().out
+        assert "RIFF/WAVE" in out
+        assert "acid @" in out
+        assert "num_beats" in out
+
+    def test_hex_column(self, tmp_path, capsys):
+        path = _wav(tmp_path, _fmt(), _data())
+        assert run(self._args(path, show_hex=True)) == 0
+        out = capsys.readouterr().out
+        assert "44 ac 00 00" in out  # 44100 little-endian
+
+    def test_json_output(self, tmp_path, capsys):
+        import json
+        path = _wav(tmp_path, _fmt(), _data())
+        assert run(self._args(path, format="json")) == 0
+        doc = json.loads(capsys.readouterr().out)
+        assert doc["format"] == "RIFF/WAVE"
+        assert [c["id"] for c in doc["chunks"]] == ["fmt ", "data"]
+
+    def test_not_riff_exits_1(self, tmp_path, capsys):
+        p = tmp_path / "x.bin"
+        p.write_bytes(b"\x00" * 64)
+        assert run(self._args(str(p))) == 1
+
+    def test_missing_file_exits_1(self):
+        assert run(self._args("does/not/exist.wav")) == 1

--- a/tests/test_riff.py
+++ b/tests/test_riff.py
@@ -142,6 +142,45 @@ class TestParseRiff:
         assert len(cue_markers) == 0
 
 
+    def test_acid_chunk_spec_layout(self, tmp_path):
+        """the acid chunk layout is, per libsndfile and field-verified
+        against real ACIDized packs:
+
+            offset 0   uint32  type flags
+            offset 4   uint16  root note
+            offset 6   uint16  q1 (unknown, often 0x8000)
+            offset 8   float32 q2 (unknown, observed 0.0)
+            offset 12  uint32  num_beats
+            offset 16  uint16  meter denominator
+            offset 18  uint16  meter numerator
+            offset 20  float32 tempo
+
+        the old parser unpacked '<IHHIII f', which read num_beats from
+        the q2 float (always 0 in the wild) and the meter as two
+        uint32s spanning the real num_beats and the packed meter words.
+        every spec-conformant file reported acid_beats=0 and garbage
+        meter. real loops must surface their actual beat count.
+        """
+        fmt = struct.pack("<HHIIHH", 1, 1, 44100, 44100 * 2, 2, 16)
+        fmt_chunk = b"fmt " + struct.pack("<I", 16) + fmt
+        data_chunk = b"data" + struct.pack("<I", 4) + b"\x00" * 4
+        # 15-beat 4/4 loop at 122 bpm, root C4: mirrors a verified
+        # real-world acid payload byte for byte
+        acid_payload = struct.pack(
+            "<IHHfIHHf", 0x05, 60, 0x8000, 0.0, 15, 4, 4, 122.0,
+        )
+        acid_chunk = b"acid" + struct.pack("<I", 24) + acid_payload
+        body = b"WAVE" + fmt_chunk + data_chunk + acid_chunk
+        wav = tmp_path / "acid_loop.wav"
+        wav.write_bytes(b"RIFF" + struct.pack("<I", len(body)) + body)
+
+        results, meta, _ = parse_riff(str(wav), enumerate_all=True)
+        assert meta["acid_beats"] == 15
+        assert meta["acid_root_note"] == 60
+        assert meta["bpm"] == 122.0
+        meter = next((v for c, k, v in results if k == "meter"), None)
+        assert meter == "4/4"
+
     def test_drum_loop_if_present(self):
         import os
         from conftest import SAMPLE_WAV


### PR DESCRIPTION
first slice of the format-internals roadmap (P1 + the start of P2).

**fix: acid chunk misparse (High).** found by verifying docs/formats/riff_wav.md against libsndfile and hex dumps of real ACIDized packs from four vendors. acid_beats was read from the unknown float at offset 8 (always 0 in conformant files) instead of num_beats at offset 12; meter was read as two uint32s spanning the wrong bytes. the long-standing 'acid_beats is usually 0' behavior was this bug, and infer_kind's beats signal was dead. red->green pair. **reindex libraries after merging to refresh stored acid_beats.**

**feat: acidcat inspect.** readelf-style structural dump for WAV: chunk table with offsets, decoded per-field breakdown (fmt incl. extensible, data, fact, acid, smpl, inst, cue, LIST, bext), --hex for raw bytes per field, -f json, and lint warnings (riff_size lies, loop points past EOF, acid beat/duration drift, cue count lies, fmt-after-data). field-tested on real library files: beat/duration cross-checks land exactly.

**docs: riff_wav.md** gains ELF/TCP-style byte-ruler diagrams for every chunk plus acid layout provenance.

275 tests pass, up from 263. aiff/midi diagrams and walkers follow in the next P1 slice.