### PR TITLE
v0.5.8: aiff + midi spec verification, byte diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to acidcat. Format loosely follows
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 once it leaves alpha.
 
+## [0.5.8] - 2026-06-11
+
+P1 slice 2: AIFF and MIDI deep-verified against their specs, three
+spec-conformance fixes, byte-level diagrams for both formats.
+
+### Fixed
+
+- **MIDI SMPTE division**: files with bit 15 of the division field
+  set use SMPTE timing (negative frame rate in the high byte, ticks
+  per frame in the low byte). Duration is now computed as
+  ticks/(fps*tpf) per SMF 1.0 instead of feeding the raw division
+  into the ppqn formula; -29 maps to 29.97 drop-frame.
+- **MIDI running status**: meta and sysex events now cancel running
+  status per SMF 1.0, so malformed data bytes after a meta event no
+  longer decode as phantom notes through the stale status.
+- **AIFC `raw ` compression**: the compression 4cc is now matched
+  with its trailing space intact, so raw-PCM AIFC reports `raw`
+  instead of `unknown:raw`.
+
+### Documentation
+
+- `docs/formats/aiff.md`: byte-ruler maps for COMM, SSND, MARK
+  entries and INST, a bit-level diagram of the 80-bit extended
+  float, and a corrected sample-rate hex table (the previous
+  44100/48000/22050 encodings were one exponent too low).
+- `docs/formats/midi.md`: MThd map, division bit diagram for both
+  timing forms, status-byte bit split, a worked VLQ example, and
+  the running-status cancellation rules.
+
 ## [0.5.7] - 2026-06-10
 
 First slice of the format-internals work: a High-severity parser fix

--- a/docs/formats/aiff.md
+++ b/docs/formats/aiff.md
@@ -77,6 +77,19 @@ struct comm_chunk {
 };
 ```
 
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  | num_channels|  num_sample |  i16 / u32 spans the
+       +------+------+   _frames   |  2-byte boundary
+ 0x04  |  (frames)   | bits/sample |  ...u32 / i16
+       +------+------+------+------+
+ 0x08  |  sample_rate (80-bit ext  |
+       |   float, 10 bytes)        |
+ 0x10  |             |  AIFC ext.. |
+       +------+------+------+------+
+```
+
 ### AIFC Extension
 
 When form type is "AIFC", COMM has additional fields:
@@ -123,14 +136,31 @@ if exponent == 0x7FFF:               value = infinity
 else: value = sign * (mantissa / 2^63) * 2^(exponent - 16383)
 ```
 
-Common values:
+```
+bit-level map (10 bytes):
 
-| Sample Rate | Hex (10 bytes)                         |
-|-------------|----------------------------------------|
-| 44100       | `40 0D AC 44 00 00 00 00 00 00`        |
-| 48000       | `40 0D BB 80 00 00 00 00 00 00`        |
-| 96000       | `40 0F BB 80 00 00 00 00 00 00`        |
-| 22050       | `40 0C AC 44 00 00 00 00 00 00`        |
+  byte 0           byte 1          bytes 2..9
+ +-+-------------+----------------+--------------------------------+
+ |S| E E E E E E E E E E E E E E E| M M M M ... M M M M  (64 bits) |
+ +-+-------------+----------------+--------------------------------+
+  ^ sign          15-bit exponent   explicit-1 mantissa, BE
+                  bias 16383        (no hidden bit, unlike f32/f64)
+
+value = sign * (mantissa / 2^63) * 2^(exponent - 16383)
+```
+
+Common values (hand-verified; note the top mantissa word of 44100
+and 48000 is the rate itself, a handy eyeball check):
+
+| Sample Rate | Hex (10 bytes)                         | exponent |
+|-------------|----------------------------------------|----------|
+| 44100       | `40 0E AC 44 00 00 00 00 00 00`        | 2^15     |
+| 48000       | `40 0E BB 80 00 00 00 00 00 00`        | 2^15     |
+| 96000       | `40 0F BB 80 00 00 00 00 00 00`        | 2^16     |
+| 22050       | `40 0D AC 44 00 00 00 00 00 00`        | 2^14     |
+
+(A previous revision of this table had the 44100/48000/22050
+exponents one too low; `40 0D AC 44...` is 22050, not 44100.)
 
 ---
 
@@ -147,6 +177,17 @@ struct ssnd_chunk {
     uint32_t block_size;    // block alignment (usually 0)
     byte     data[];        // interleaved samples, big-endian
 };
+```
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  |      offset (u32 BE)      |  usually 0
+       +---------------------------+
+ 0x04  |    block_size (u32 BE)    |  usually 0
+       +---------------------------+
+ 0x08  |  sample frames, BE,       |
+       :  interleaved by channel   :
 ```
 
 ### Sample Encoding
@@ -189,6 +230,17 @@ struct marker {
 };
 ```
 
+```
+         0      1      2      3
+       +------+------+------+------+
+ +0x00 |  id (i16)   |  position   |  u32 spans the boundary
+       +------+------+   (frames)  |
+ +0x04 |  (pos cont) | len  | 'n'  |  pascal string: length byte
+       +------+------+------+------+  then chars, padded so the
+ +0x08 | 'a'  | 'm'  | 'e'  | pad  |  total 1+len lands even
+       +------+------+------+------+
+```
+
 Markers are referenced by ID from the INST chunk's loop definitions.
 
 ---
@@ -221,6 +273,27 @@ struct inst_chunk {
     int16_t  release_loop_end;
 };
 ```
+
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  | base | detun| low_n| hi_n |  i8 / i8 cents / u8 / u8
+       +------+------+------+------+
+ 0x04  | lo_v | hi_v |  gain (i16) |  u8 / u8 / dB
+       +------+------+------+------+
+ 0x08  | sus_mode    | sus_begin   |  i16 each; begin/end are
+       +------+------+------+------+  MARK ids, not positions
+ 0x0C  | sus_end     | rel_mode    |
+       +------+------+------+------+
+ 0x10  | rel_begin   | rel_end     |
+       +------+------+------+------+
+```
+
+Note the field-order trap relative to WAV's 7-byte `inst` chunk: AIFF
+puts the key range before the velocity range and carries gain as a
+16-bit value, and the loops live here (by marker reference) rather
+than in a separate smpl chunk. acidcat parses the scalar fields but
+does not yet resolve sustain/release loops through MARK.
 
 ### Loop Modes
 

--- a/docs/formats/midi.md
+++ b/docs/formats/midi.md
@@ -45,6 +45,19 @@ struct mthd {
 };
 ```
 
+```
+         0      1      2      3
+       +------+------+------+------+
+ 0x00  | 'M'  | 'T'  | 'h'  | 'd'  |  magic
+       +------+------+------+------+
+ 0x04  |    length (u32 BE) = 6    |  trust this, not the constant:
+       +---------------------------+  a longer header is legal and
+ 0x08  |  format     |  ntrks      |  the extra bytes are skipped
+       +------+------+------+------+
+ 0x0C  |  division   |
+       +------+------+
+```
+
 ### Format Types
 
 | Value | Meaning          | Track layout                            |
@@ -69,6 +82,24 @@ if bit 15 == 1:
     // SMPTE-based timing (rare in music production)
     smpte_format = -(division >> 8)   // -24, -25, -29, -30
     ticks_per_frame = division & 0xFF
+```
+
+```
+division bit-level, both forms:
+
+  metrical (bit 15 = 0):
+  +-+---------------------------+
+  |0|  ticks per quarter note   |   e.g. 0x01E0 = 480 ppqn
+  +-+---------------------------+
+
+  smpte (bit 15 = 1):
+  +-+--------------+------------+
+  |1| -fps (2's c) | ticks/frame|   e.g. 0xE728 = -25 fps, 40 tpf
+  +-+--------------+------------+        = 1000 ticks per second
+   15            8 7           0
+
+  smpte wall time = ticks / (fps * tpf). tempo events do not apply.
+  -29 means 29.97 drop-frame, not 29.
 ```
 
 Higher division = higher timing precision. 96 ticks/beat is common
@@ -111,6 +142,16 @@ decoding:
         byte = read()
         value = (value << 7) | (byte & 0x7F)
         if not (byte & 0x80): break
+
+bit-level, value 2000 (0x8F 0x50):
+
+  +-+--------------+   +-+--------------+
+  |1| 0 0 0 1 1 1 1|   |0| 1 0 1 0 0 0 0|
+  +-+--------------+   +-+--------------+
+   ^  high 7 bits       ^  low 7 bits
+   continue             last byte
+
+  (0x0F << 7) | 0x50  =  1920 + 80  =  2000
 ```
 
 Maximum VLQ is 4 bytes (28 bits), encoding values up to 0x0FFFFFFF.
@@ -130,6 +171,11 @@ Three categories: channel messages, system exclusive, and meta events.
 status byte format: SSSS CCCC
     SSSS = message type (8-E)
     CCCC = channel (0-15)
+
+  +-+-------------+-------------+
+  |1| S  S  S     | C  C  C  C  |   bit 7 set marks a status byte;
+  +-+-------------+-------------+   any byte < 0x80 is data
+   7  6  5  4      3  2  1  0
 ```
 
 | Status  | Type           | Data bytes | Format              |
@@ -162,6 +208,15 @@ the parser must track `running_status`.
 
 A non-status byte (< 0x80) triggers running status. The data byte
 is consumed as the first parameter of the running status message.
+
+Two rules every parser must honor:
+
+- running status applies to **channel messages only**, never to
+  sysex or meta events
+- **sysex and meta events cancel running status.** A data byte that
+  follows one of them with no fresh status byte is malformed input,
+  not a continuation of the pre-meta status. A parser that keeps the
+  stale status decodes phantom notes from garbage.
 
 ### System Exclusive (0xF0, 0xF7)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.5.7"
+version = "0.5.8"
 description = "Audio metadata explorer and analysis tool, like exiftool but for audio"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.5.7"
+__version__ = "0.5.8"

--- a/src/acidcat/core/aiff.py
+++ b/src/acidcat/core/aiff.py
@@ -153,15 +153,18 @@ def parse_aiff(filepath, enumerate_all=False):
                     # surfaced as 'unknown:<raw>' so callers can spot
                     # them rather than treating them as plain AIFF.
                     if form_type == "AIFC" and len(chunk_data) >= 22:
-                        comp_type = chunk_data[18:22].decode(
+                        comp_raw = chunk_data[18:22].decode(
                             "ascii", errors="ignore"
                         )
-                        comp_type = comp_type.strip()
-                        if comp_type in _AIFC_KNOWN_COMPRESSION:
-                            meta["compression"] = comp_type
+                        # membership tests the raw 4cc: codes like
+                        # "raw " carry a meaningful trailing space.
+                        # strip only for display.
+                        if comp_raw in _AIFC_KNOWN_COMPRESSION:
+                            meta["compression"] = comp_raw.strip()
                         else:
+                            stripped = comp_raw.strip()
                             meta["compression"] = (
-                                f"unknown:{comp_type}" if comp_type
+                                f"unknown:{stripped}" if stripped
                                 else "none"
                             )
 

--- a/src/acidcat/core/midi.py
+++ b/src/acidcat/core/midi.py
@@ -93,7 +93,11 @@ def parse_midi(filepath):
             status = trk_data[pos]
 
             if status == 0xFF:
-                # meta event
+                # meta event. per SMF 1.0, meta and sysex events cancel
+                # any running status in effect; a data byte after this
+                # point with no fresh status byte is malformed and must
+                # not decode through the stale status.
+                running_status = 0
                 if pos + 2 >= len(trk_data):
                     break
                 event_type = trk_data[pos + 1]
@@ -141,9 +145,11 @@ def parse_midi(filepath):
                     meta["copyright"] = event_data.decode("ascii", errors="replace").strip()
 
             elif status == 0xF0 or status == 0xF7:
-                # sysex. bound the VLQ length against remaining track
-                # bytes so a malformed file cannot push pos past the
-                # MTrk boundary into the next track's data.
+                # sysex cancels running status, same as meta events.
+                # bound the VLQ length against remaining track bytes so
+                # a malformed file cannot push pos past the MTrk
+                # boundary into the next track's data.
+                running_status = 0
                 sysex_len, pos = _read_vlq(trk_data, pos + 1)
                 if pos + sysex_len > len(trk_data):
                     break
@@ -224,9 +230,22 @@ def parse_midi(filepath):
     # convert channels_used set to sorted list for output
     meta["channels_used"] = sorted(meta["channels_used"])
 
-    # estimate duration in seconds if we have tempo and division
-    if meta["tempo_bpm"] and meta["division"] and meta["division"] > 0:
-        beats = total_ticks / meta["division"]
-        meta["duration_sec"] = round(beats * 60.0 / meta["tempo_bpm"], 2)
+    # estimate duration in seconds
+    division = meta["division"]
+    if division:
+        if division & 0x8000:
+            # smpte division: high byte is a negative two's-complement
+            # frame rate, low byte is ticks per frame. wall time is
+            # ticks / (fps * tpf); tempo does not apply. -29 means
+            # 29.97 drop-frame.
+            fps = -struct.unpack(">b", bytes([(division >> 8) & 0xFF]))[0]
+            tpf = division & 0xFF
+            if fps == 29:
+                fps = 29.97
+            if fps > 0 and tpf > 0:
+                meta["duration_sec"] = round(total_ticks / (fps * tpf), 2)
+        elif meta["tempo_bpm"]:
+            beats = total_ticks / division
+            meta["duration_sec"] = round(beats * 60.0 / meta["tempo_bpm"], 2)
 
     return meta

--- a/tests/test_aiff.py
+++ b/tests/test_aiff.py
@@ -1,0 +1,96 @@
+"""tests for acidcat.core.aiff."""
+
+import struct
+
+from acidcat.core.aiff import parse_aiff, _parse_ieee_extended
+
+
+# 80-bit extended floats, verified by hand: exponent 0x400E means
+# 2^15, and the top mantissa word of 44100/48000 is the rate itself
+RATE_44100 = bytes.fromhex("400eac440000000000000000")[:10]
+RATE_48000 = bytes.fromhex("400ebb800000000000000000")[:10]
+
+
+def _chunk(cid, payload):
+    raw = cid + struct.pack(">I", len(payload)) + payload
+    if len(payload) % 2:
+        raw += b"\x00"
+    return raw
+
+
+def _form(form_type, *chunks):
+    body = form_type + b"".join(chunks)
+    return b"FORM" + struct.pack(">I", len(body)) + body
+
+
+def _comm_aiff(channels=1, frames=441, bits=16, rate=RATE_44100):
+    return _chunk(b"COMM", struct.pack(">hIh", channels, frames, bits) + rate)
+
+
+def _comm_aifc(comp, name=b"", channels=1, frames=441, bits=16):
+    pstr = bytes([len(name)]) + name
+    if (1 + len(name)) % 2:
+        pstr += b"\x00"
+    payload = struct.pack(">hIh", channels, frames, bits) + RATE_44100 + comp + pstr
+    return _chunk(b"COMM", payload)
+
+
+def _ssnd(n_bytes=8):
+    return _chunk(b"SSND", struct.pack(">II", 0, 0) + b"\x00" * n_bytes)
+
+
+class TestIeeeExtended:
+    def test_44100(self):
+        assert _parse_ieee_extended(RATE_44100) == 44100.0
+
+    def test_48000(self):
+        assert _parse_ieee_extended(RATE_48000) == 48000.0
+
+    def test_zero(self):
+        assert _parse_ieee_extended(b"\x00" * 10) == 0.0
+
+    def test_short_input(self):
+        assert _parse_ieee_extended(b"\x40") == 0.0
+
+
+class TestParseAiff:
+    def test_minimal_aiff(self, tmp_path):
+        f = tmp_path / "a.aiff"
+        f.write_bytes(_form(b"AIFF", _comm_aiff(), _ssnd()))
+        _, meta, seen = parse_aiff(str(f))
+        assert meta["channels"] == 1
+        assert meta["num_frames"] == 441
+        assert meta["sample_rate"] == 44100
+        assert meta["duration_sec"] == 0.01
+        assert meta["compression"] == "none"
+        assert "COMM" in seen
+
+    def test_aifc_none_compression(self, tmp_path):
+        f = tmp_path / "a.aifc"
+        f.write_bytes(_form(b"AIFC", _comm_aifc(b"NONE", b"not compressed"), _ssnd()))
+        _, meta, _ = parse_aiff(str(f))
+        assert meta["compression"] == "NONE"
+
+    def test_aifc_raw_compression_with_trailing_space(self, tmp_path):
+        """the 'raw ' 4cc carries a meaningful trailing space. the old
+        code stripped the value before checking it against a known-set
+        that stores the spaced form, so spec-conformant raw-PCM AIFC
+        reported unknown:raw instead of raw.
+        """
+        f = tmp_path / "raw.aifc"
+        f.write_bytes(_form(b"AIFC", _comm_aifc(b"raw "), _ssnd()))
+        _, meta, _ = parse_aiff(str(f))
+        assert meta["compression"] == "raw"
+
+    def test_aifc_unknown_compression_is_surfaced(self, tmp_path):
+        f = tmp_path / "x.aifc"
+        f.write_bytes(_form(b"AIFC", _comm_aifc(b"XXyy"), _ssnd()))
+        _, meta, _ = parse_aiff(str(f))
+        assert meta["compression"] == "unknown:XXyy"
+
+    def test_not_aiff(self, tmp_path):
+        f = tmp_path / "n.bin"
+        f.write_bytes(b"\x00" * 64)
+        _, meta, seen = parse_aiff(str(f))
+        assert meta["channels"] is None
+        assert seen == []

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -5,9 +5,9 @@ import struct
 from acidcat.core.midi import parse_midi
 
 
-def _build_smf(tracks):
+def _build_smf(tracks, division=480):
     """Build a Standard MIDI File (format 1) with the given track bodies."""
-    hdr = b"MThd" + struct.pack(">IHHH", 6, 1, len(tracks), 480)
+    hdr = b"MThd" + struct.pack(">IHHH", 6, 1, len(tracks), division)
     out = hdr
     for body in tracks:
         out += b"MTrk" + struct.pack(">I", len(body)) + body
@@ -90,3 +90,41 @@ def test_sysex_overlong_vlq_does_not_run_past_track(tmp_path):
     assert meta["format"] == 1
     assert meta["tracks"] == 2
     assert meta["tempo_bpm"] is not None
+
+def test_smpte_division_duration(tmp_path):
+    """division with bit 15 set is SMPTE timing: the high byte is a
+    negative two's-complement frame rate, the low byte is ticks per
+    frame. wall time is ticks / (fps * tpf) and tempo does not enter
+    into it. 0xE728 is -25 fps at 40 ticks/frame = 1000 ticks/second,
+    so 2000 ticks must report 2.0 seconds. the ppqn formula fed the
+    raw division (59176) in and produced near-zero durations.
+    """
+    track = (
+        b"\x00\xFF\x51\x03\x07\xA1\x20"  # tempo 120 bpm, must not matter
+        b"\x8F\x50\xFF\x2F\x00"          # delta 2000 ticks, end of track
+    )
+    f = tmp_path / "smpte.mid"
+    f.write_bytes(_build_smf([track], division=0xE728))
+
+    meta = parse_midi(str(f))
+    assert meta["duration_sec"] == 2.0
+
+
+def test_meta_event_cancels_running_status(tmp_path):
+    """SMF 1.0: sysex and meta events cancel running status. a data
+    byte that follows a meta event without a fresh status byte is
+    malformed input and must not be decoded as a phantom note through
+    the stale status.
+    """
+    track = (
+        b"\x00\x90\x3C\x64"    # note on C4, establishes status 0x90
+        b"\x00\xFF\x01\x01A"   # meta text event cancels running status
+        b"\x00\x3E\x64"        # malformed: data bytes with no status
+        b"\x00\xFF\x2F\x00"    # end of track
+    )
+    f = tmp_path / "rs_cancel.mid"
+    f.write_bytes(_build_smf([track]))
+
+    meta = parse_midi(str(f))
+    assert meta["note_count"] == 1
+    assert meta["note_max"] == 60


### PR DESCRIPTION
P1 slice 2, stacked on #10 (merge that first; this PR's base will follow).

same recipe as the acid fix: verify the docs against the spec, then verify the parser against both. three findings, all red->green:

- **midi smpte division**: bit 15 set means smpte timing (negative fps high byte, ticks/frame low byte). duration is now ticks/(fps*tpf) per SMF 1.0; the ppqn formula was being fed the raw division and produced near-zero durations. -29 maps to 29.97 drop-frame.
- **midi running status**: meta and sysex events cancel running status per SMF 1.0. the parser carried it across, so malformed bytes after a meta event decoded as phantom notes.
- **aifc 'raw ' compression**: the 4cc was stripped before set membership against a set storing the spaced form, so raw-PCM AIFC reported unknown:raw.

docs: byte-ruler diagrams for COMM/SSND/MARK/INST and MThd/division/VLQ/status-byte, a bit-level map of the 80-bit extended float, and a corrected sample-rate hex table (the old 44100 encoding actually decoded to 22050).

first dedicated aiff test module. 286 tests pass, up from 275.