### PR TITLE
v0.5.9: vet acid_beats against the one-shot flag and duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to acidcat. Format loosely follows
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 once it leaves alpha.
 
+## [0.5.9] - 2026-06-11
+
+### Fixed
+
+- **acid_beats vetting**: the 0.5.7 layout fix surfaced real beat
+  counts, which exposed a second-order problem: batch taggers leave
+  boilerplate beats/tempo (8 / 120) in files whose one-shot flag is
+  set, and surfacing those made kind inference read 0.1s one-shots
+  as loops. New shared helper `effective_acid_beats` vets the field:
+  trust beats when the one-shot bit is clear (field-measured ~93%
+  reliable), otherwise keep them only when they reconcile with the
+  actual duration within 15% (vendors sometimes set the bit on real
+  loops with accurate counts). `parse_riff` now also surfaces
+  `acid_one_shot`. Wired into info, scan, and the indexer.
+
 ## [0.5.8] - 2026-06-11
 
 P1 slice 2: AIFF and MIDI deep-verified against their specs, three

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.5.8"
+version = "0.5.9"
 description = "Audio metadata explorer and analysis tool, like exiftool but for audio"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"

--- a/src/acidcat/commands/index.py
+++ b/src/acidcat/commands/index.py
@@ -27,7 +27,7 @@ from acidcat.core import paths as acidpaths
 from acidcat.core import registry as reg
 from acidcat.core.riff import (
     parse_riff, get_duration, get_fmt_info,
-    smpl_root_or_none, acid_root_or_none,
+    smpl_root_or_none, acid_root_or_none, effective_acid_beats,
 )
 from acidcat.core.aiff import is_aiff, parse_aiff
 from acidcat.core.midi import is_midi, parse_midi
@@ -931,7 +931,7 @@ def _from_wav(filepath, row, do_deep=False):
 
     # key stores pitch class only (no octave); full MIDI int lives in root_note.
     row["key"] = midi_note_to_pitch_class(smpl) or midi_note_to_pitch_class(acid)
-    row["acid_beats"] = meta.get("acid_beats")
+    row["acid_beats"] = effective_acid_beats(meta, duration)
     row["root_note"] = smpl or acid
     row["chunks"] = ",".join(
         c for c in seen if c not in ("RIFF", "WAVE", "fmt ", "data")

--- a/src/acidcat/commands/info.py
+++ b/src/acidcat/commands/info.py
@@ -10,7 +10,7 @@ import sys
 
 from acidcat.core.riff import (
     parse_riff, get_duration, get_fmt_info,
-    smpl_root_or_none, acid_root_or_none,
+    smpl_root_or_none, acid_root_or_none, effective_acid_beats,
 )
 from acidcat.core.aiff import is_aiff, parse_aiff
 from acidcat.core.midi import is_midi, parse_midi
@@ -92,12 +92,13 @@ def _info_wav(filepath, args):
 
     if meta["bpm"] is not None:
         rec["BPM"] = meta["bpm"]
-        if meta["acid_beats"]:
-            rec["Beats"] = meta["acid_beats"]
+        beats = effective_acid_beats(meta, duration)
+        if beats:
+            rec["Beats"] = beats
         if acid_root is not None:
             rec["ACID Root"] = midi_note_to_name(acid_root)
-        if meta["acid_beats"] and meta["bpm"]:
-            expected = round((meta["acid_beats"] / meta["bpm"]) * 60, 4)
+        if beats and meta["bpm"]:
+            expected = round((beats / meta["bpm"]) * 60, 4)
             rec["Expected Duration"] = f"{expected}s"
             if duration:
                 diff = round(duration - expected, 4)

--- a/src/acidcat/commands/scan.py
+++ b/src/acidcat/commands/scan.py
@@ -8,6 +8,7 @@ import sys
 
 from acidcat.core.riff import (
     parse_riff, get_duration, smpl_root_or_none, acid_root_or_none,
+    effective_acid_beats,
 )
 from acidcat.core.aiff import is_aiff, parse_aiff
 from acidcat.core.tagged import is_tagged_format
@@ -47,9 +48,10 @@ def _scan_wav(filepath):
     _, meta, seen = parse_riff(filepath, enumerate_all=False)
     duration = get_duration(filepath)
 
+    beats = effective_acid_beats(meta, duration)
     expected = diff = None
-    if meta["bpm"] and meta["acid_beats"] and meta["acid_beats"] > 0:
-        expected = round((meta["acid_beats"] / meta["bpm"]) * 60, 4)
+    if meta["bpm"] and beats:
+        expected = round((beats / meta["bpm"]) * 60, 4)
         diff = round(duration - expected, 4) if duration else None
 
     # SMPL/ACID root_key = 0 is the documented "unset" sentinel
@@ -68,7 +70,7 @@ def _scan_wav(filepath):
         "duration_sec": duration,
         "title": None,
         "artist": None,
-        "acid_beats": meta["acid_beats"],
+        "acid_beats": beats,
         "expected_duration": expected,
         "duration_diff": diff,
         "chunks": ",".join(c for c in seen if c not in ("RIFF", "WAVE", "fmt ", "data")),

--- a/src/acidcat/core/riff.py
+++ b/src/acidcat/core/riff.py
@@ -32,6 +32,7 @@ def parse_riff(filepath, enumerate_all=False):
     meta = {
         "bpm": None,
         "acid_beats": None,
+        "acid_one_shot": None,
         "acid_root_note": None,
         "smpl_root_key": None,
         "smpl_loop_start": None,
@@ -84,6 +85,7 @@ def parse_riff(filepath, enumerate_all=False):
                         struct.unpack("<IHHfIHHf", chunk_data)
                     meta["acid_root_note"] = root_note
                     meta["acid_beats"] = beats
+                    meta["acid_one_shot"] = bool(flags & 0x01)
                     meta["bpm"] = round(tempo, 2)
                     if enumerate_all:
                         results.append(("acid", "bpm", meta["bpm"]))
@@ -285,6 +287,32 @@ def acid_root_or_none(meta):
     """
     val = meta.get("acid_root_note") if hasattr(meta, "get") else meta
     return val if val else None
+
+
+def effective_acid_beats(meta, duration):
+    """Vet the acid num_beats field against the one-shot flag and the
+    file's actual duration.
+
+    Field measurement (2026-06-11, 400 ACIDized files): with the
+    one-shot bit clear, num_beats reconciles with duration*tempo/60
+    in ~93% of files. With the bit set it is a coin flip: batch
+    taggers leave boilerplate 8-beat/120-bpm values in true
+    one-shots, while some vendors set the bit on real loops that
+    carry accurate beat counts. So: trust beats when the flag is
+    clear; when it is set, keep beats only if they reconcile with
+    the actual duration within 15%.
+    """
+    beats = meta.get("acid_beats")
+    if not beats:
+        return None
+    if not meta.get("acid_one_shot"):
+        return beats
+    bpm = meta.get("bpm")
+    if bpm and duration:
+        expected = beats / bpm * 60
+        if abs(expected - duration) / duration < 0.15:
+            return beats
+    return None
 
 
 def get_riff_info(filepath):

--- a/tests/test_riff.py
+++ b/tests/test_riff.py
@@ -4,7 +4,10 @@ import struct
 import time
 
 import pytest
-from acidcat.core.riff import iter_chunks, get_riff_info, get_duration, parse_riff
+from acidcat.core.riff import (
+    iter_chunks, get_riff_info, get_duration, parse_riff,
+    effective_acid_beats,
+)
 
 
 class TestGetRiffInfo:
@@ -189,3 +192,55 @@ class TestParseRiff:
         results, meta, seen = parse_riff(SAMPLE_WAV)
         assert "fmt " in seen
         assert "data" in seen
+
+    def test_acid_one_shot_flag_surfaces(self, tmp_path):
+        """parse_riff reports facts: raw beats plus the one-shot flag.
+        vetting is the consumer's job via effective_acid_beats.
+        """
+        fmt = struct.pack("<HHIIHH", 1, 1, 44100, 44100 * 2, 2, 16)
+        fmt_chunk = b"fmt " + struct.pack("<I", 16) + fmt
+        data_chunk = b"data" + struct.pack("<I", 4) + b"\x00" * 4
+        # flags 0x03 = one-shot + root set, boilerplate beats/tempo
+        acid_payload = struct.pack(
+            "<IHHfIHHf", 0x03, 47, 0x8000, 0.0, 8, 4, 4, 120.0,
+        )
+        acid_chunk = b"acid" + struct.pack("<I", 24) + acid_payload
+        body = b"WAVE" + fmt_chunk + data_chunk + acid_chunk
+        wav = tmp_path / "oneshot.wav"
+        wav.write_bytes(b"RIFF" + struct.pack("<I", len(body)) + body)
+
+        _, meta, _ = parse_riff(str(wav))
+        assert meta["acid_beats"] == 8
+        assert meta["acid_one_shot"] is True
+        assert meta["acid_root_note"] == 47
+
+
+class TestEffectiveAcidBeats:
+    """vetting policy, calibrated on 400 real ACIDized files
+    (2026-06-11): flag clear means beats are ~93% trustworthy; flag
+    set is a coin flip between accurate loops and batch-tagger
+    boilerplate, so the duration cross-check decides.
+    """
+
+    def test_flag_clear_trusts_beats(self):
+        meta = {"acid_beats": 16, "acid_one_shot": False, "bpm": 120.0}
+        assert effective_acid_beats(meta, 0.5) == 16
+
+    def test_one_shot_boilerplate_is_dropped(self):
+        # 0.12s hat claiming 8 beats at 120 bpm (4s): bogus
+        meta = {"acid_beats": 8, "acid_one_shot": True, "bpm": 120.0}
+        assert effective_acid_beats(meta, 0.12) is None
+
+    def test_one_shot_with_reconciling_beats_is_kept(self):
+        # 8.0s file claiming 16 beats at 120 bpm (8s): vendor set the
+        # one-shot bit on a real loop, the beat count is accurate
+        meta = {"acid_beats": 16, "acid_one_shot": True, "bpm": 120.0}
+        assert effective_acid_beats(meta, 8.0) == 16
+
+    def test_one_shot_without_duration_is_dropped(self):
+        meta = {"acid_beats": 8, "acid_one_shot": True, "bpm": 120.0}
+        assert effective_acid_beats(meta, None) is None
+
+    def test_no_beats_is_none(self):
+        meta = {"acid_beats": 0, "acid_one_shot": False, "bpm": 120.0}
+        assert effective_acid_beats(meta, 4.0) is None


### PR DESCRIPTION
follow-up the 0.5.7 acid fix made necessary: surfacing real beat counts also surfaced batch-tagger boilerplate (8 beats / 120 bpm left in 0.1s one-shots), which made infer_kind read those files as loops.

field measurement on 400 ACIDized files from the indexed libraries: one-shot bit clear means beats reconcile with duration in ~93% of files; bit set is a coin flip (62 accurate loops vs 75 boilerplate in the sample), so neither trusting nor nulling on the flag alone works.

the fix is layered: parse_riff reports facts (raw beats + new acid_one_shot), and a shared effective_acid_beats helper applies policy at the consumer layer where duration is known: trust beats when the flag is clear, otherwise keep them only if they reconcile with actual duration within 15%. wired into info, scan, and the indexer.

292 tests pass, up from 286. index migration runs separately (local script vets stored rows the same way).