### PR TITLE
v0.7.1: re-register db_path reuse, rf64 + serum inspect walkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to acidcat. Format loosely follows
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 once it leaves alpha.
 
+## [0.7.1] - 2026-06-11
+
+### Fixed
+
+- **Re-registering a pre-0.5.4 library no longer crashes** (or worse).
+  The central db filename scheme changed in 0.5.4 (label hash 8 -> 12
+  chars), so re-registration computed a different db_path for the same
+  root, slipped past the db_path upsert, and hit the root_path UNIQUE
+  constraint; without the crash it would have attached a fresh DB and
+  orphaned the old one with its tags and descriptions. The registry
+  now treats the root as the library's identity and reuses the stored
+  db_path (explicit central/in-tree transitions still re-key), and the
+  CLI adopts the canonical path the registry returns. Found when a
+  `--force` reindex of a v0.5.0-era library crashed.
+
+### Added
+
+- `inspect` walks RF64 (ds64 64-bit size overrides per EBU Tech 3306,
+  with sentinel and ordering lints) and Xfer Serum presets (signature,
+  decoded JSON metadata, blob extent). Every format acidcat parses
+  natively is now inspectable.
+
 ## [0.7.0] - 2026-06-11
 
 Apple Loops support and the tagged-format tags gap.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acidcat"
-version = "0.7.0"
+version = "0.7.1"
 description = "Audio metadata explorer and analysis tool, like exiftool but for audio"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}

--- a/src/acidcat/__init__.py
+++ b/src/acidcat/__init__.py
@@ -1,3 +1,3 @@
 """acidcat -- audio metadata explorer and analysis tool."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/acidcat/commands/index.py
+++ b/src/acidcat/commands/index.py
@@ -226,7 +226,11 @@ def run(args):
     rconn = reg.open_registry(registry_path)
     try:
         try:
-            reg.register_library(
+            # the registry returns the canonical db_path: on re-register
+            # it reuses the stored one, which can differ from the path
+            # computed above if the filename scheme changed since the
+            # library was first registered.
+            db_path = reg.register_library(
                 rconn, scan_root, label=label, db_path=db_path,
                 in_tree=in_tree, schema_version=idx.SCHEMA_VERSION,
             )

--- a/src/acidcat/commands/inspect.py
+++ b/src/acidcat/commands/inspect.py
@@ -818,6 +818,153 @@ def inspect_midi(filepath):
     return chunks, file_warns
 
 
+# ── rf64 walk ──────────────────────────────────────────────────────
+
+
+def _parse_ds64(b, ctx):
+    """EBU Tech 3306: 64-bit size overrides for RF64."""
+    fields, warns = [], []
+    if len(b) < 28:
+        return "truncated", fields, [f"ds64 payload is {len(b)} bytes, spec minimum is 28"]
+    riff_size, data_size, sample_count = struct.unpack_from("<QQQ", b, 0)
+    table_len = _u32(b, 24)
+    fields.append(_f(0x00, 8, "riff_size", f"{riff_size:,}"))
+    fields.append(_f(0x08, 8, "data_size", f"{data_size:,}"))
+    fields.append(_f(0x10, 8, "sample_count", f"{sample_count:,}"))
+    fields.append(_f(0x18, 4, "table_length", table_len,
+                     "additional chunk-size overrides"))
+    ctx["ds64_riff_size"] = riff_size
+    ctx["ds64_data_size"] = data_size
+    ctx["ds64_samples"] = sample_count
+    return f"64-bit sizes: data {data_size:,} bytes", fields, warns
+
+
+def inspect_rf64(filepath):
+    """Walk an RF64 file. Same grammar as RIFF except the 32-bit size
+    fields are 0xFFFFFFFF sentinels resolved through the ds64 chunk,
+    which must be the first chunk.
+    """
+    file_size = os.path.getsize(filepath)
+    ctx = {}
+    chunks = []
+    file_warns = []
+    seen = []
+    sentinel = 0xFFFFFFFF
+
+    with open(filepath, "rb") as f:
+        hdr = f.read(12)
+        riff_size = struct.unpack("<I", hdr[4:8])[0]
+        if riff_size != sentinel:
+            file_warns.append(
+                f"RF64 header size is {riff_size:#x}, spec says the "
+                f"0xffffffff sentinel"
+            )
+
+        pos = 12
+        while pos + 8 <= file_size:
+            f.seek(pos)
+            ch = f.read(8)
+            if len(ch) < 8:
+                break
+            cid = ch[0:4].decode("ascii", errors="ignore")
+            size = struct.unpack("<I", ch[4:8])[0]
+            real_size = size
+            if size == sentinel:
+                if cid == "data" and "ds64_data_size" in ctx:
+                    real_size = ctx["ds64_data_size"]
+                else:
+                    file_warns.append(
+                        f"chunk {cid!r} carries the 64-bit sentinel but "
+                        f"ds64 provides no override"
+                    )
+                    break
+            seen.append(cid)
+            payload = f.read(min(real_size, _PAYLOAD_CAP))
+
+            entry = {"id": cid, "offset": pos, "size": real_size,
+                     "summary": "", "fields": [], "warnings": []}
+            try:
+                if cid == "ds64":
+                    entry["summary"], entry["fields"], entry["warnings"] = \
+                        _parse_ds64(payload, ctx)
+                elif cid == "data":
+                    entry["summary"], entry["fields"], entry["warnings"] = \
+                        _parse_data(payload, ctx, real_size)
+                elif cid in _PARSERS:
+                    entry["summary"], entry["fields"], entry["warnings"] = \
+                        _PARSERS[cid](payload, ctx)
+                else:
+                    entry["summary"] = f"unparsed, first bytes: {payload[:16].hex(' ')}"
+            except Exception as e:
+                entry["warnings"] = [f"parse error: {e.__class__.__name__}: {e}"]
+            chunks.append(entry)
+
+            pos += 8 + real_size
+            if real_size % 2 == 1:
+                pos += 1
+
+    if seen and seen[0] != "ds64":
+        file_warns.append("first chunk is not ds64, violating EBU Tech 3306")
+    riff64 = ctx.get("ds64_riff_size")
+    if riff64 and riff64 + 8 != file_size:
+        file_warns.append(
+            f"ds64 riff_size says {riff64 + 8:,} bytes, file is {file_size:,}"
+        )
+    return chunks, file_warns
+
+
+# ── serum walk ─────────────────────────────────────────────────────
+
+
+def inspect_serum(filepath):
+    """Structural view of an Xfer Serum preset: XferJson magic, the
+    JSON metadata block, then opaque wavetable/modulation data."""
+    file_size = os.path.getsize(filepath)
+    with open(filepath, "rb") as f:
+        raw = f.read(min(file_size, 4 * 1024 * 1024))
+    chunks = []
+    file_warns = []
+
+    chunks.append({"id": "magc", "offset": 0, "size": 8,
+                   "summary": "XferJson signature",
+                   "fields": [_f(0x00, 8, "magic", "XferJson")],
+                   "warnings": []})
+
+    json_start = raw.find(b"{")
+    if json_start < 0:
+        file_warns.append("no JSON block after the magic")
+        return chunks, file_warns
+
+    text = raw[json_start:].decode("utf-8", errors="replace")
+    try:
+        parsed, end = json.JSONDecoder().raw_decode(text)
+    except ValueError as e:
+        file_warns.append(f"JSON block does not parse: {e}")
+        return chunks, file_warns
+
+    fields = []
+    for key in ("fileType", "presetName", "presetAuthor",
+                "presetDescription", "product", "productVersion",
+                "tags", "vendor", "version"):
+        if key in parsed:
+            val = parsed[key]
+            if isinstance(val, list):
+                val = ", ".join(str(v) for v in val)
+            fields.append(_f(None, 0, key, str(val)[:80]))
+    name = parsed.get("presetName") or "unnamed"
+    chunks.append({"id": "json", "offset": json_start, "size": end,
+                   "summary": f"'{name}' metadata, {len(parsed)} keys",
+                   "fields": fields, "warnings": []})
+
+    blob_off = json_start + end
+    chunks.append({"id": "blob", "offset": blob_off,
+                   "size": file_size - blob_off,
+                   "summary": f"wavetable/modulation data, "
+                              f"{file_size - blob_off:,} bytes (opaque)",
+                   "fields": [], "warnings": []})
+    return chunks, file_warns
+
+
 # ── rendering ──────────────────────────────────────────────────────
 
 
@@ -885,12 +1032,15 @@ def run(args):
     elif len(magic) >= 14 and magic[:4] == b"MThd":
         fmt_label = "Standard MIDI File"
         chunks, file_warns = inspect_midi(filepath)
-    elif magic[:4] == b"RF64":
-        print("acidcat inspect: RF64 not supported yet", file=sys.stderr)
-        return 1
+    elif len(magic) >= 12 and magic[:4] == b"RF64" and magic[8:12] == b"WAVE":
+        fmt_label = "RF64/WAVE"
+        chunks, file_warns = inspect_rf64(filepath)
+    elif magic[:8] == b"XferJson":
+        fmt_label = "Xfer Serum preset"
+        chunks, file_warns = inspect_serum(filepath)
     else:
-        print("acidcat inspect: not a WAV, AIFF, or MIDI file",
-              file=sys.stderr)
+        print("acidcat inspect: not a WAV, RF64, AIFF, MIDI, or Serum "
+              "preset", file=sys.stderr)
         return 1
 
     if args.format == "json":

--- a/src/acidcat/core/registry.py
+++ b/src/acidcat/core/registry.py
@@ -195,10 +195,27 @@ def register_library(conn, root, label, db_path, in_tree=False,
         _assert_no_overlap(conn, norm_root)
 
         existing = conn.execute(
-            "SELECT created_at FROM libraries WHERE root_path = ?",
+            "SELECT created_at, db_path, in_tree FROM libraries "
+            "WHERE root_path = ?",
             (norm_root,),
         ).fetchone()
         created_at = existing["created_at"] if existing else now
+        if existing:
+            if bool(existing["in_tree"]) == bool(in_tree):
+                # the library's identity is its root. a re-register may
+                # compute a different central filename (the label-hash
+                # scheme has changed across versions); reuse the stored
+                # db_path so the existing DB and its annotations stay
+                # attached instead of crashing on the root_path UNIQUE
+                # or orphaning the old file.
+                norm_db = existing["db_path"]
+            else:
+                # explicit layout transition (central <-> in-tree):
+                # replace the row so the upsert below can re-key it.
+                conn.execute(
+                    "DELETE FROM libraries WHERE root_path = ?",
+                    (norm_root,),
+                )
 
         conn.execute(
             """

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -218,6 +218,65 @@ class TestInspectMidi:
         assert any("120 bpm" in w for w in warns)
 
 
+class TestInspectRf64:
+    def _rf64(self, tmp_path, data_bytes=8, sentinel_ok=True):
+        from acidcat.commands.inspect import inspect_rf64  # noqa: F401
+        fmt = struct.pack("<HHIIHH", 1, 1, 44100, 88200, 2, 16)
+        fmt_chunk = b"fmt " + struct.pack("<I", 16) + fmt
+        data_chunk = b"data" + struct.pack("<I", 0xFFFFFFFF) + b"\x00" * data_bytes
+        body_after_hdr = b"WAVE"
+        # ds64 sizes: riff_size = file - 8, computed after assembly
+        ds64_payload = struct.pack("<QQQI", 0, data_bytes, data_bytes // 2, 0)
+        ds64_chunk = b"ds64" + struct.pack("<I", len(ds64_payload)) + ds64_payload
+        body = body_after_hdr + ds64_chunk + fmt_chunk + data_chunk
+        riff_size = len(body)
+        ds64_payload = struct.pack("<QQQI", riff_size, data_bytes,
+                                   data_bytes // 2, 0)
+        ds64_chunk = b"ds64" + struct.pack("<I", len(ds64_payload)) + ds64_payload
+        body = body_after_hdr + ds64_chunk + fmt_chunk + data_chunk
+        hdr_size = 0xFFFFFFFF if sentinel_ok else 123
+        p = tmp_path / "t.rf64"
+        p.write_bytes(b"RF64" + struct.pack("<I", hdr_size) + body)
+        return str(p)
+
+    def test_ds64_resolves_data_size(self, tmp_path):
+        from acidcat.commands.inspect import inspect_rf64
+        path = self._rf64(tmp_path)
+        chunks, warns = inspect_rf64(path)
+        ids = [c["id"] for c in chunks]
+        assert ids == ["ds64", "fmt ", "data"]
+        data = chunks[-1]
+        assert data["size"] == 8
+        assert warns == []
+
+    def test_header_sentinel_violation_flagged(self, tmp_path):
+        from acidcat.commands.inspect import inspect_rf64
+        path = self._rf64(tmp_path, sentinel_ok=False)
+        _, warns = inspect_rf64(path)
+        assert any("sentinel" in w for w in warns)
+
+
+class TestInspectSerum:
+    def test_json_and_blob(self, tmp_path):
+        from acidcat.commands.inspect import inspect_serum
+        meta = b'{"presetName": "Growl X", "presetAuthor": "u", "tags": "bass, growl"}'
+        p = tmp_path / "g.serumpreset"
+        p.write_bytes(b"XferJson" + meta + b"\x01\x02" * 64)
+        chunks, warns = inspect_serum(str(p))
+        ids = [c["id"] for c in chunks]
+        assert ids == ["magc", "json", "blob"]
+        assert "Growl X" in chunks[1]["summary"]
+        assert chunks[2]["size"] == 128
+        assert warns == []
+
+    def test_missing_json_flagged(self, tmp_path):
+        from acidcat.commands.inspect import inspect_serum
+        p = tmp_path / "bad.serumpreset"
+        p.write_bytes(b"XferJson" + b"\x00" * 32)
+        _, warns = inspect_serum(str(p))
+        assert any("JSON" in w for w in warns)
+
+
 class TestRunCli:
     def _args(self, target, **kw):
         base = dict(target=target, show_hex=False, format="table",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -49,6 +49,30 @@ class TestSchemaCreation:
         assert "libraries" in names
 
 
+class TestReRegisterReusesDbPath:
+    def test_changed_central_filename_reuses_stored_db(self, reg_conn,
+                                                       tmp_path):
+        """the central db filename scheme has changed across versions
+        (label hash 8 -> 12 chars in v0.5.4), so a re-register can
+        compute a different db_path for the same root. the library's
+        identity is its root: re-registering must reuse the stored
+        db_path instead of crashing on the root_path UNIQUE constraint
+        or, worse, pointing a fresh DB at the root and orphaning the
+        old one with its tags and descriptions.
+        """
+        root = _mkroot(tmp_path, "lib_a")
+        old_db = paths.normalize(str(tmp_path / "lib_a_oldhash8.db"))
+        reg.register_library(reg_conn, root, label="lib_a", db_path=old_db)
+
+        new_db = paths.normalize(str(tmp_path / "lib_a_newhash12chars.db"))
+        returned = reg.register_library(reg_conn, root, label="lib_a",
+                                        db_path=new_db)
+        assert returned == old_db
+        rows = reg_conn.execute("SELECT db_path FROM libraries").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["db_path"] == old_db
+
+
 class TestRegister:
     def test_basic(self, reg_conn, tmp_path):
         root = _mkroot(tmp_path, "lib_a")


### PR DESCRIPTION
**fix**: re-registering a pre-0.5.4 library crashed on the root_path UNIQUE constraint because the central filename scheme changed (label hash 8 -> 12 chars in 0.5.4) and the upsert keyed on db_path. without the crash it would have attached a fresh DB to the root and orphaned the old one with its annotations. the registry now treats the root as the library identity, reuses the stored db_path on re-register, and the CLI adopts the canonical returned path. red->green at the registry level. found in the field when a --force reindex of big_pack (registered at v0.5.0) crashed.

**feat**: inspect walks RF64 (ds64 sentinel resolution per EBU Tech 3306 + lints) and Serum presets (decoded JSON metadata, blob extent; field-tested on a real Serum 2 preset). every natively-parsed format is now inspectable.

313 tests, up from 308.